### PR TITLE
feat: add EagerToolOutputClearShaper for cache-ready early context sh…

### DIFF
--- a/opencollab/opencollab/application/shaping/__init__.py
+++ b/opencollab/opencollab/application/shaping/__init__.py
@@ -9,7 +9,11 @@ view.
 
 The pipeline is an ordered, **lazy-degradation** chain (Liu et al. 2026,
 §3.1/4.3): cheaper, lower-loss layers run before costlier ones, and each layer
-only acts under the pressure it is responsible for. Two orthogonal pressures:
+only acts under the pressure it is responsible for. The single exception is the
+front rung — ``EagerToolOutputClearShaper`` (``eager``) — which runs
+*unconditionally* on every call (no trigger), clearing old compactable tool
+content age-based and deterministically so the deep prefix stays cacheable and
+the reactive layers below rarely have to fire. Two orthogonal pressures:
 
 * **Per-message explosion** — ``PerToolResultBudgetShaper`` (``tool_budget``)
   caps *any one* tool result. It is unconditional: every oversize result is
@@ -42,6 +46,11 @@ Package layout: ``pipeline`` (chain + trigger math + span helpers),
 ``tool_budget`` (per-result cap), ``reactive`` (the history layers).
 """
 
+from opencollab.application.shaping.eager import (
+    DEFAULT_EAGER_KEEP_RECENT,
+    EAGER_STUB_PREFIX,
+    EagerToolOutputClearShaper,
+)
 from opencollab.application.shaping.pipeline import (
     DEFAULT_COMPACT_BUFFER_TOKENS,
     DEFAULT_HISTORY_KEEP_RECENT_GROUPS,
@@ -80,6 +89,8 @@ __all__ = [
     "DEFAULT_CLEARED_TOOL_CONTENT",
     "DEFAULT_TOOL_CLEAR_KEEP_RECENT",
     "DEFAULT_COMPACTABLE_TOOLS",
+    "DEFAULT_EAGER_KEEP_RECENT",
+    "EAGER_STUB_PREFIX",
     "DEFAULT_OUTPUT_RESERVE_TOKENS",
     "DEFAULT_COMPACT_BUFFER_TOKENS",
     "HISTORY_TARGET_RATIO",
@@ -91,6 +102,7 @@ __all__ = [
     "history_trigger_target",
     "ShaperPipeline",
     "PerToolResultBudgetShaper",
+    "EagerToolOutputClearShaper",
     "ToolOutputClearShaper",
     "LowPriorityContextShedShaper",
     "OldHistorySnipShaper",

--- a/opencollab/opencollab/application/shaping/eager.py
+++ b/opencollab/opencollab/application/shaping/eager.py
@@ -136,7 +136,11 @@ class EagerToolOutputClearShaper:
         Pinned issuing turns are skipped. The last ``keep_recent`` ids are
         excluded so they stay verbatim.
         """
-        compactable: list[tuple[str, str]] = []  # (tool_call_id, stub)
+        # Collect raw (id, name, arguments) for every compactable call first, then
+        # parse arguments + build stubs ONLY for the older calls that get cleared —
+        # the last ``keep_recent`` are kept verbatim, so parsing their JSON every
+        # turn would be pure waste on this always-on rung.
+        compactable: list[tuple[str, str, Any]] = []  # (tool_call_id, name, arguments)
         for message in messages:
             if message.get("role") != "assistant" or is_pinned(message):
                 continue
@@ -144,8 +148,12 @@ class EagerToolOutputClearShaper:
                 name = call.get("function", {}).get("name")
                 call_id = call.get("id")
                 if name in self.compactable_tools and call_id:
-                    target = _call_target(call.get("function", {}).get("arguments"))
-                    compactable.append((call_id, _stub_for_call(name, target)))
+                    compactable.append(
+                        (call_id, name, call.get("function", {}).get("arguments"))
+                    )
         if len(compactable) <= self.keep_recent:
             return {}
-        return dict(compactable[: -self.keep_recent])
+        return {
+            call_id: _stub_for_call(name, _call_target(arguments))
+            for call_id, name, arguments in compactable[: -self.keep_recent]
+        }

--- a/opencollab/opencollab/application/shaping/eager.py
+++ b/opencollab/opencollab/application/shaping/eager.py
@@ -1,0 +1,151 @@
+"""Eager, always-on tool-output clearing (cache-ready front rung).
+
+Unlike the reactive history layers (``reactive``) which no-op until an estimated
+context size crosses a trigger, this layer runs *unconditionally* on every model
+call. It is the cheapest, first/always-on rung at the FRONT of the shaping chain:
+it bounds file_read / tool-result accumulation BEFORE the 120k-gated reactive
+pipeline ever fires.
+
+It is a read-time projection over a *copy* of the message history: ``state.messages``
+and the persisted transcript stay untouched. It keeps the ``K`` most-recent
+compactable tool results verbatim and replaces every OLDER compactable result's
+content with a deterministic, message-derived stub. Pinned sources (identity /
+team / task, ``priority >= PIN_FLOOR``) and non-compactable messages are never
+touched, and the assistant ``tool_call`` <-> ``tool``-result pairing skeleton is
+preserved (the message and its ``tool_call_id`` survive — only the content shrinks).
+
+CACHE-READY PROPERTIES (unit-tested in ``tests/test_eager_tool_clear_shaper.py``):
+
+* **Deterministic** — ``shape(x)`` is byte-identical across repeated calls and
+  does NOT read any running token estimate / context-size measurement.
+* **Monotonic** — as the conversation grows by one tool exchange, a result
+  transitions full -> stub exactly once (when it ages past ``K``) and never back;
+  every already-stubbed message stays byte-identical, so the deep prefix stays
+  cacheable.
+* **Idempotent** — ``shape(shape(x)) == shape(x)``.
+
+OUT OF SCOPE: actual ``cache_control`` breakpoint wiring / enabling prompt
+caching. This layer only produces the deterministic/monotonic projection that
+makes such caching possible.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from opencollab.application.shaping.pipeline import is_pinned
+from opencollab.application.shaping.reactive import DEFAULT_COMPACTABLE_TOOLS
+
+# K most-recent compactable tool results kept verbatim; everything older is
+# stubbed. Aligned with the reactive keep-recent (``DEFAULT_TOOL_CLEAR_KEEP_RECENT``)
+# so the eager rung and the reactive layer agree on what "recent" means.
+DEFAULT_EAGER_KEEP_RECENT = 5
+
+# Marker prefix on every eager stub. A stub announces itself (no invisible
+# compression) and names the source tool + target so a reader / the model can
+# re-fetch deterministically. The full text lives in the transcript untouched.
+EAGER_STUB_PREFIX = "[Old tool result cleared"
+
+
+def _stub_for_call(tool_name: str, target: str | None) -> str:
+    """Deterministic, byte-stable stub naming the tool and its target.
+
+    A pure function of ``(tool_name, target)`` — no token counts, no message
+    index, no randomness — so the same old message yields an identical stub on
+    every turn (the monotonic / cacheable property).
+    """
+    where = f" {target}" if target else ""
+    return (
+        f"{EAGER_STUB_PREFIX}: {tool_name}{where}]"
+        " — re-read with offset/limit if needed."
+    )
+
+
+def _call_target(arguments: Any) -> str | None:
+    """Best-effort path/target lifted from a tool call's arguments.
+
+    Arguments are typically a JSON string; we only need a stable label for the
+    stub, so we read common keys when the payload is a dict and otherwise return
+    ``None``. Parsing is deterministic and never raises.
+    """
+    if isinstance(arguments, str):
+        import json
+
+        try:
+            arguments = json.loads(arguments)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(arguments, dict):
+        return None
+    for key in ("path", "file_path", "filename", "file", "pattern", "command"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+class EagerToolOutputClearShaper:
+    """Always-on, age-based, deterministic tool-output clearing.
+
+    Keeps the ``keep_recent`` most-recent compactable tool results verbatim and
+    replaces every older compactable result's content with a deterministic,
+    message-derived stub. Pinned sources and non-compactable messages are never
+    touched; the ``tool_call`` <-> result pairing skeleton is preserved. Runs on
+    every call with no estimate / trigger dependency.
+    """
+
+    def __init__(
+        self,
+        *,
+        compactable_tools: frozenset[str] = DEFAULT_COMPACTABLE_TOOLS,
+        keep_recent: int = DEFAULT_EAGER_KEEP_RECENT,
+    ):
+        self.compactable_tools = compactable_tools
+        self.keep_recent = max(1, keep_recent)  # never clear the most recent result
+
+    def shape(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        stubs = self._stubs_for_old_results(messages)
+        if not stubs:
+            return messages
+
+        out: list[dict[str, Any]] = []
+        changed = False
+        for message in messages:
+            stub = stubs.get(message.get("tool_call_id"))
+            if (
+                stub is not None
+                and message.get("role") == "tool"
+                and not is_pinned(message)
+                and message.get("content") != stub
+            ):
+                out.append({**message, "content": stub})
+                changed = True
+            else:
+                out.append(message)
+        return out if changed else messages
+
+    def _stubs_for_old_results(
+        self, messages: list[dict[str, Any]]
+    ) -> dict[str, str]:
+        """Map ``tool_call_id`` -> deterministic stub for every compactable result
+        older than the last ``keep_recent``.
+
+        Compactable calls are scanned in issue order from the assistant
+        ``tool_calls`` (the tool *name* lives on the call, not the ``role:"tool"``
+        answer), so age is positional and independent of any token estimate.
+        Pinned issuing turns are skipped. The last ``keep_recent`` ids are
+        excluded so they stay verbatim.
+        """
+        compactable: list[tuple[str, str]] = []  # (tool_call_id, stub)
+        for message in messages:
+            if message.get("role") != "assistant" or is_pinned(message):
+                continue
+            for call in message.get("tool_calls") or ():
+                name = call.get("function", {}).get("name")
+                call_id = call.get("id")
+                if name in self.compactable_tools and call_id:
+                    target = _call_target(call.get("function", {}).get("arguments"))
+                    compactable.append((call_id, _stub_for_call(name, target)))
+        if len(compactable) <= self.keep_recent:
+            return {}
+        return dict(compactable[: -self.keep_recent])

--- a/opencollab/opencollab/bootstrap/container.py
+++ b/opencollab/opencollab/bootstrap/container.py
@@ -53,6 +53,7 @@ from opencollab.application.shaping import (
     DEFAULT_TOOL_RESULT_BUDGET,
     AutoCompactShaper,
     ContextCollapseShaper,
+    EagerToolOutputClearShaper,
     LowPriorityContextShedShaper,
     OldHistorySnipShaper,
     PerToolResultBudgetShaper,
@@ -173,6 +174,7 @@ def _build_default_shaper(
     }
     return ShaperPipeline(
         (
+            EagerToolOutputClearShaper(compactable_tools=COMPACTABLE_TOOL_NAMES),
             PerToolResultBudgetShaper(DEFAULT_TOOL_RESULT_BUDGET),
             LowPriorityContextShedShaper(**history_kwargs),
             ToolOutputClearShaper(compactable_tools=COMPACTABLE_TOOL_NAMES, **history_kwargs),

--- a/opencollab/tests/test_eager_tool_clear_shaper.py
+++ b/opencollab/tests/test_eager_tool_clear_shaper.py
@@ -1,0 +1,229 @@
+"""Unit tests for the always-on, cache-ready EagerToolOutputClearShaper.
+
+These tests assert the three cache-ready properties explicitly — DETERMINISTIC,
+MONOTONIC, IDEMPOTENT — plus the structural guarantees (pinned / non-compactable
+untouched, ``tool_call`` pairing preserved, input never mutated).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from opencollab.application.shaping import (
+    EAGER_STUB_PREFIX,
+    EagerToolOutputClearShaper,
+)
+from opencollab.application.shaping.pipeline import PIN_FLOOR
+
+
+def _sys():
+    return {"role": "system", "content": "s"}
+
+
+def _call(tid, name="bash", arguments="{}"):
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": tid, "function": {"name": name, "arguments": arguments}}
+        ],
+    }
+
+
+def _tool(tid, content):
+    return {"role": "tool", "tool_call_id": tid, "content": content}
+
+
+def _orphaned_tool_ids(messages):
+    call_ids = {
+        tc["id"]
+        for m in messages
+        if m.get("role") == "assistant"
+        for tc in m.get("tool_calls", [])
+    }
+    result_ids = {m["tool_call_id"] for m in messages if m.get("role") == "tool"}
+    return result_ids - call_ids
+
+
+def _exchange(tid, name="bash", arguments="{}", body="x" * 500):
+    return [_call(tid, name=name, arguments=arguments), _tool(tid, body)]
+
+
+def _history(n, keep_names=None):
+    """A system seed plus ``n`` compactable bash tool exchanges t1..tn."""
+    out = [_sys()]
+    for i in range(1, n + 1):
+        out += _exchange(f"t{i}")
+    return out
+
+
+def _shaper(**kw):
+    return EagerToolOutputClearShaper(keep_recent=3, **kw)
+
+
+def _tool_content(messages, tid):
+    return next(m["content"] for m in messages if m.get("tool_call_id") == tid)
+
+
+def _is_stub(content):
+    return content.startswith(EAGER_STUB_PREFIX)
+
+
+# --- always-on (no estimate gate) ---
+
+
+def test_runs_with_no_trigger_clears_old_even_for_tiny_history():
+    # Bodies are tiny — far below any reactive trigger — yet the eager rung still
+    # stubs everything older than keep_recent. Proves it is NOT estimate-gated.
+    messages = [_sys()]
+    for i in range(1, 6):
+        messages += _exchange(f"t{i}", body="s")  # 1-char bodies
+    out = _shaper().shape(messages)
+    assert _is_stub(_tool_content(out, "t1"))
+    assert _is_stub(_tool_content(out, "t2"))
+    # last 3 verbatim
+    assert _tool_content(out, "t3") == "s"
+    assert _tool_content(out, "t5") == "s"
+
+
+def test_keeps_recent_k_verbatim_stubs_older():
+    out = _shaper().shape(_history(7))  # keep_recent=3
+    stubbed = {
+        m["tool_call_id"]
+        for m in out
+        if m.get("role") == "tool" and _is_stub(m["content"])
+    }
+    verbatim = {
+        m["tool_call_id"]
+        for m in out
+        if m.get("role") == "tool" and not _is_stub(m["content"])
+    }
+    assert stubbed == {"t1", "t2", "t3", "t4"}
+    assert verbatim == {"t5", "t6", "t7"}
+
+
+def test_noop_when_within_keep_recent():
+    # exactly keep_recent compactable results -> nothing older -> identity
+    msgs = _history(3)
+    assert _shaper().shape(msgs) is msgs
+
+
+# --- DETERMINISTIC ---
+
+
+def test_deterministic_byte_identical_across_calls():
+    messages = _history(8)
+    first = _shaper().shape(messages)
+    second = _shaper().shape(copy.deepcopy(messages))
+    assert first == second
+    # stub text is a pure function of the message, not a counter/uuid
+    assert _tool_content(first, "t1") == _tool_content(second, "t1")
+
+
+def test_deterministic_independent_of_context_size():
+    # Same logical message, two wildly different surrounding body sizes: the stub
+    # for an aged-out result must be byte-identical (no token-size dependence).
+    small = [_sys(), *_exchange("a", body="x"), *_exchange("b", body="x"),
+             *_exchange("c", body="x"), *_exchange("d", body="x")]
+    big = [_sys(), *_exchange("a", body="x" * 9000),
+           *_exchange("b", body="x" * 9000), *_exchange("c", body="x" * 9000),
+           *_exchange("d", body="x" * 9000)]
+    sh = EagerToolOutputClearShaper(keep_recent=3)
+    assert _tool_content(sh.shape(small), "a") == _tool_content(sh.shape(big), "a")
+
+
+def test_stub_names_tool_and_target():
+    messages = [
+        _sys(),
+        *_exchange("r", name="file_read",
+                   arguments='{"path": "src/foo.py"}'),
+        *_exchange("a"), *_exchange("b"), *_exchange("c"),
+    ]
+    out = EagerToolOutputClearShaper(keep_recent=3).shape(messages)
+    stub = _tool_content(out, "r")
+    assert "file_read" in stub and "src/foo.py" in stub
+
+
+# --- MONOTONIC ---
+
+
+def test_monotonic_one_more_exchange_flips_exactly_one_and_keeps_old_stubs():
+    sh = EagerToolOutputClearShaper(keep_recent=3)
+    turn_n = sh.shape(_history(6))  # stubs t1,t2,t3 ; verbatim t4,t5,t6
+    turn_n1 = sh.shape(_history(7))  # adds t7 ; t4 should now flip to stub
+
+    # t4 transitions full -> stub exactly once as it ages past K.
+    assert not _is_stub(_tool_content(turn_n, "t4"))
+    assert _is_stub(_tool_content(turn_n1, "t4"))
+
+    # Every already-stubbed message stays byte-identical (cacheable prefix).
+    for tid in ("t1", "t2", "t3"):
+        assert _tool_content(turn_n, tid) == _tool_content(turn_n1, tid)
+        assert _is_stub(_tool_content(turn_n1, tid))
+
+
+def test_monotonic_never_unstubs():
+    sh = EagerToolOutputClearShaper(keep_recent=3)
+    once = sh.shape(_history(8))
+    # feeding an already-shaped view back never restores a body
+    again = sh.shape(once)
+    for tid in ("t1", "t2", "t3", "t4", "t5"):
+        assert _is_stub(_tool_content(again, tid))
+
+
+# --- IDEMPOTENT ---
+
+
+def test_idempotent_shape_of_shape_equals_shape():
+    messages = _history(9)
+    once = _shaper().shape(messages)
+    twice = _shaper().shape(once)
+    assert twice == once
+    # second pass finds nothing to change -> returns the same object
+    assert twice is once
+
+
+# --- structural guarantees ---
+
+
+def test_non_compactable_tools_untouched():
+    messages = [
+        _sys(),
+        *_exchange("p1", name="apply_patch", body="p" * 500),
+        *_exchange("p2", name="apply_patch", body="p" * 500),
+        *_exchange("b1"), *_exchange("b2"), *_exchange("b3"), *_exchange("b4"),
+    ]
+    out = EagerToolOutputClearShaper(keep_recent=1).shape(messages)
+    # apply_patch results never stubbed regardless of age.
+    assert _tool_content(out, "p1") == "p" * 500
+    assert _tool_content(out, "p2") == "p" * 500
+
+
+def test_pinned_sources_never_touched():
+    pinned_call = {
+        **_call("pin", name="bash"),
+        "_ctx": {"priority": PIN_FLOOR + 5},
+    }
+    pinned_result = {**_tool("pin", "secret" * 100), "_ctx": {"priority": PIN_FLOOR + 5}}
+    messages = [
+        _sys(),
+        pinned_call, pinned_result,
+        *_exchange("a"), *_exchange("b"), *_exchange("c"), *_exchange("d"),
+    ]
+    out = EagerToolOutputClearShaper(keep_recent=3).shape(messages)
+    # The pinned result keeps its full body even though it is the oldest.
+    assert _tool_content(out, "pin") == "secret" * 100
+
+
+def test_preserves_tool_call_pairing_no_orphans():
+    out = _shaper().shape(_history(8))
+    assert _orphaned_tool_ids(out) == set()
+    # every tool message still present (content cleared, skeleton kept)
+    assert sum(1 for m in out if m.get("role") == "tool") == 8
+
+
+def test_input_messages_not_mutated():
+    messages = _history(8)
+    snapshot = copy.deepcopy(messages)
+    out = _shaper().shape(messages)
+    assert out is not messages
+    assert messages == snapshot  # persisted transcript view unchanged


### PR DESCRIPTION
…edding

Always-on, deterministic, age-based clearing of stale tool-result bodies, inserted as the first rung of the shaper pipeline (before the 120k-gated reactive layers). Keeps the last K=5 compactable tool results verbatim and stubs older ones, cutting read-driven context growth before it reaches the reactive trigger.

Cache-ready: clearing is a pure function of message position (no token-estimate dependency), monotonic (full->stub once, never back; older stubs stay byte-identical as history grows), and idempotent, so the stubbed prefix stays a stable cacheable prefix. cache_control wiring itself is deferred.

Suite 675 passing (was 662), ruff clean.