### PR TITLE
添加 LLM 用量记录与测试

### DIFF
--- a/opencollab/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/opencollab/adapters/llm/anthropic_provider.py
@@ -13,11 +13,12 @@ from opencollab.adapters.llm.retry import with_retry
 from opencollab.adapters.llm.types import DEFAULT_MAX_OUTPUT_TOKENS, LLMResponse, Usage
 
 
-def _anthropic_tool_choice(tool_choice: str | None) -> dict[str, Any] | None:
-    """Map an OpenAI-style ``tool_choice`` string to Anthropic's dict form.
+def _anthropic_tool_choice(tool_choice: Any) -> dict[str, Any] | None:
+    """Map OpenAI-style ``tool_choice`` values to Anthropic's dict form.
 
     Anthropic expects ``{"type": "auto"|"any"|"tool"}``; OpenAI's ``"required"``
-    (force *some* tool) maps to ``"any"``. ``None`` keeps the API default.
+    (force *some* tool) maps to ``"any"``. A named OpenAI function choice maps
+    to ``{"type": "tool", "name": ...}``. ``None`` keeps the API default.
     """
     if tool_choice is None:
         return None
@@ -25,6 +26,14 @@ def _anthropic_tool_choice(tool_choice: str | None) -> dict[str, Any] | None:
         return {"type": "any"}
     if tool_choice == "auto":
         return {"type": "auto"}
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function":
+            function = tool_choice.get("function") or {}
+            name = function.get("name")
+            if name:
+                return {"type": "tool", "name": name}
+        if tool_choice.get("type") == "tool" and tool_choice.get("name"):
+            return {"type": "tool", "name": tool_choice["name"]}
     return None
 
 
@@ -35,7 +44,7 @@ def _build_request_kwargs(
     temperature: float,
     thinking: bool = False,
     thinking_params: dict | None = None,
-    tool_choice: str | None = None,
+    tool_choice: Any = None,
     top_p: float | None = None,
 ) -> dict[str, Any]:
     system_parts, anthropic_messages = convert_to_anthropic_messages(messages)
@@ -86,7 +95,7 @@ async def complete_anthropic(
     max_retries: int,
     thinking: bool = False,
     thinking_params: dict | None = None,
-    tool_choice: str | None = None,
+    tool_choice: Any = None,
     top_p: float | None = None,
 ) -> LLMResponse:
     """Single-shot completion against the Anthropic API."""

--- a/opencollab/opencollab/adapters/llm/client.py
+++ b/opencollab/opencollab/adapters/llm/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 import openai
@@ -11,6 +12,7 @@ from opencollab.adapters.llm.anthropic_provider import complete_anthropic
 from opencollab.adapters.llm.openai_provider import complete_openai
 from opencollab.adapters.llm.providers import is_anthropic, warn_provider_near_miss
 from opencollab.adapters.llm.types import LLMResponse, model_context_window
+from opencollab.adapters.llm.usage_ledger import record_api_usage
 
 
 class LLMClient:
@@ -39,15 +41,20 @@ class LLMClient:
         if is_anthropic(provider):
             import anthropic
 
-            self._anthropic = anthropic.AsyncAnthropic(
-                api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"),
-                timeout=request_timeout,
-            )
+            self.base_url = base_url or os.environ.get("ANTHROPIC_BASE_URL")
+            anthropic_kwargs: dict[str, Any] = {
+                "api_key": api_key or os.environ.get("ANTHROPIC_API_KEY"),
+                "timeout": request_timeout,
+            }
+            if self.base_url:
+                anthropic_kwargs["base_url"] = self.base_url
+            self._anthropic = anthropic.AsyncAnthropic(**anthropic_kwargs)
             self._openai = None
         else:
+            self.base_url = base_url or os.environ.get("OPENAI_BASE_URL")
             self._openai = openai.AsyncOpenAI(
                 api_key=api_key or os.environ.get("OPENAI_API_KEY"),
-                base_url=base_url or os.environ.get("OPENAI_BASE_URL"),
+                base_url=self.base_url,
                 timeout=request_timeout,
             )
             self._anthropic = None
@@ -63,7 +70,7 @@ class LLMClient:
         temperature: float = 0.0,
         thinking: bool = False,
         thinking_params: dict[str, Any] | None = None,
-        tool_choice: str | None = None,
+        tool_choice: Any = None,
         top_p: float | None = None,
     ) -> LLMResponse:
         """Single-shot completion. Returns full response.
@@ -78,28 +85,50 @@ class LLMClient:
         ``top_p`` is ``None`` by default (provider default); when set it is sent
         as the nucleus-sampling knob. Unset == byte-identical request as today.
         """
-        if self._anthropic:
-            return await complete_anthropic(
-                self._anthropic,
-                self.model,
-                messages,
-                tools,
-                temperature,
-                self.max_retries,
-                thinking=thinking,
-                thinking_params=thinking_params,
-                tool_choice=tool_choice,
-                top_p=top_p,
+        start = time.monotonic()
+        try:
+            if self._anthropic:
+                response = await complete_anthropic(
+                    self._anthropic,
+                    self.model,
+                    messages,
+                    tools,
+                    temperature,
+                    self.max_retries,
+                    thinking=thinking,
+                    thinking_params=thinking_params,
+                    tool_choice=tool_choice,
+                    top_p=top_p,
+                )
+            else:
+                response = await complete_openai(
+                    self._openai,
+                    self.model,
+                    messages,
+                    tools,
+                    temperature,
+                    self.max_retries,
+                    thinking=thinking,
+                    thinking_params=thinking_params,
+                    tool_choice=tool_choice,
+                    top_p=top_p,
+                )
+            record_api_usage(
+                provider=self.provider,
+                model=self.model,
+                base_url=self.base_url,
+                latency_s=time.monotonic() - start,
+                status="success",
+                response=response,
             )
-        return await complete_openai(
-            self._openai,
-            self.model,
-            messages,
-            tools,
-            temperature,
-            self.max_retries,
-            thinking=thinking,
-            thinking_params=thinking_params,
-            tool_choice=tool_choice,
-            top_p=top_p,
-        )
+            return response
+        except Exception as exc:
+            record_api_usage(
+                provider=self.provider,
+                model=self.model,
+                base_url=self.base_url,
+                latency_s=time.monotonic() - start,
+                status="error",
+                error=exc,
+            )
+            raise

--- a/opencollab/opencollab/adapters/llm/usage_ledger.py
+++ b/opencollab/opencollab/adapters/llm/usage_ledger.py
@@ -1,0 +1,231 @@
+"""Append-only API usage ledger for provider calls."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from opencollab.adapters.llm.types import LLMResponse, Usage
+
+DEFAULT_GLM52_INPUT_USD_PER_MTOK = 1.4
+DEFAULT_GLM52_CACHED_INPUT_USD_PER_MTOK = 0.26
+DEFAULT_GLM52_OUTPUT_USD_PER_MTOK = 4.4
+SECRET_ENV_NAME_PARTS = ("API_KEY", "AUTH_TOKEN", "ACCESS_TOKEN", "CLIENT_TOKEN", "SECRET")
+URL_RE = re.compile(r"https?://[^\s'\"<>]+")
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)"
+    r"((?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token|client[-_ ]?token|token|secret|password)"
+    r"\s*[:=]\s*)[^\s,;'\")\]}]+"
+)
+SENSITIVE_TEXT_RE = re.compile(
+    r"(?i)((?:prompt|content|message|messages|input)\s*[:=]\s*)[^\r\n,;}\]]{1,500}"
+)
+
+
+def usage_log_path() -> Path | None:
+    raw = os.environ.get("OPENCOLLAB_API_USAGE_LOG")
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    return Path(stripped).expanduser()
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def pricing_for_model(model: str | None) -> dict[str, float | str]:
+    lowered = (model or "").lower()
+    if "glm" in lowered:
+        return {
+            "mode": "glm-5.2-default",
+            "input_usd_per_mtok": _float_env(
+                "GLM_INPUT_USD_PER_MTOK", DEFAULT_GLM52_INPUT_USD_PER_MTOK
+            ),
+            "cached_input_usd_per_mtok": _float_env(
+                "GLM_CACHED_INPUT_USD_PER_MTOK", DEFAULT_GLM52_CACHED_INPUT_USD_PER_MTOK
+            ),
+            "output_usd_per_mtok": _float_env(
+                "GLM_OUTPUT_USD_PER_MTOK", DEFAULT_GLM52_OUTPUT_USD_PER_MTOK
+            ),
+        }
+    return {
+        "mode": "unset",
+        "input_usd_per_mtok": _float_env("OPENCOLLAB_INPUT_USD_PER_MTOK", 0.0),
+        "cached_input_usd_per_mtok": _float_env("OPENCOLLAB_CACHED_INPUT_USD_PER_MTOK", 0.0),
+        "output_usd_per_mtok": _float_env("OPENCOLLAB_OUTPUT_USD_PER_MTOK", 0.0),
+    }
+
+
+def usage_cost_usd(usage: Usage, model: str | None) -> float:
+    pricing = pricing_for_model(model)
+    cached = max(int(getattr(usage, "cache_read_tokens", 0) or 0), 0)
+    cache_creation = max(int(getattr(usage, "cache_creation_tokens", 0) or 0), 0)
+    uncached_input = max(int(usage.input_tokens or 0) - cached - cache_creation, 0)
+    input_price = float(pricing["input_usd_per_mtok"])
+    cached_price = float(pricing["cached_input_usd_per_mtok"])
+    output_price = float(pricing["output_usd_per_mtok"])
+    return (
+        uncached_input / 1_000_000 * input_price
+        + cached / 1_000_000 * cached_price
+        + int(usage.output_tokens or 0) / 1_000_000 * output_price
+    )
+
+
+def _safe_base_url(base_url: str | None) -> dict[str, str | None]:
+    if not base_url:
+        return {"base_url": None, "base_url_host": None}
+    parsed = urlparse(base_url)
+    if parsed.scheme and parsed.hostname:
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        host_with_port = f"{host}:{port}" if port is not None else host
+        safe = f"{parsed.scheme}://{host_with_port}"
+        return {"base_url": safe, "base_url_host": host_with_port}
+    return {"base_url": "(unparsed)", "base_url_host": None}
+
+
+def _redact_secrets(text: str) -> str:
+    redacted = URL_RE.sub(lambda match: str(_safe_base_url(match.group(0))["base_url"]), text)
+    for name, value in os.environ.items():
+        if not value or len(value) < 8:
+            continue
+        upper = name.upper()
+        if any(part in upper for part in SECRET_ENV_NAME_PARTS):
+            redacted = redacted.replace(value, "[redacted]")
+    redacted = re.sub(
+        r"(?i)(bearer\s+)[a-z0-9._~+/=-]{8,}",
+        r"\1[redacted]",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)((?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token)\s*[:=]\s*)\S+",
+        r"\1[redacted]",
+        redacted,
+    )
+    redacted = SECRET_ASSIGNMENT_RE.sub(r"\1[redacted]", redacted)
+    redacted = SENSITIVE_TEXT_RE.sub(r"\1[redacted]", redacted)
+    return redacted
+
+
+def _usage_payload(usage: Usage, model: str | None) -> dict[str, Any]:
+    cached = max(int(getattr(usage, "cache_read_tokens", 0) or 0), 0)
+    cache_creation = max(int(getattr(usage, "cache_creation_tokens", 0) or 0), 0)
+    input_tokens = int(usage.input_tokens or 0)
+    payload: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "uncached_input_tokens": max(input_tokens - cached - cache_creation, 0),
+        "cached_input_tokens": cached,
+        "cache_creation_tokens": cache_creation,
+        "output_tokens": int(usage.output_tokens or 0),
+        "total_tokens": int(usage.total_tokens or 0),
+        "estimated": bool(getattr(usage, "estimated", False)),
+        "cost_usd": usage_cost_usd(usage, model),
+        "pricing": pricing_for_model(model),
+    }
+    raw_usage = getattr(usage, "raw_usage", None)
+    if raw_usage:
+        payload["raw_usage"] = raw_usage
+    return payload
+
+
+def build_usage_record(
+    *,
+    provider: str | None,
+    model: str | None,
+    base_url: str | None,
+    latency_s: float,
+    status: str,
+    response: LLMResponse | None = None,
+    error: BaseException | None = None,
+) -> dict[str, Any]:
+    usage = response.usage if response is not None else Usage()
+    record: dict[str, Any] = {
+        "schema": "opencollab.api_usage.v1",
+        "timestamp": time.time(),
+        "request_id": str(uuid.uuid4()),
+        "status": status,
+        "provider": provider,
+        "model": model,
+        "latency_s": round(latency_s, 4),
+        "pid": os.getpid(),
+        "cwd": os.getcwd(),
+        "argv0": Path(sys.argv[0]).name if sys.argv else None,
+        "run_id": os.environ.get("OPENCOLLAB_RUN_ID") or os.environ.get("OPENCOLLAB_USAGE_RUN_ID"),
+        "label": os.environ.get("OPENCOLLAB_USAGE_LABEL"),
+        **_safe_base_url(base_url),
+        "usage": _usage_payload(usage, model),
+    }
+    if response is not None:
+        record["finish_reason"] = response.finish_reason
+    if error is not None:
+        record["error"] = {
+            "type": type(error).__name__,
+            "message": _redact_secrets(str(error))[:1000],
+        }
+    return record
+
+
+def append_usage_record(record: dict[str, Any], path: Path | None = None) -> None:
+    target = path if path is not None else usage_log_path()
+    if target is None:
+        return
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    except Exception:
+        return
+
+
+def record_api_usage(
+    *,
+    provider: str | None,
+    model: str | None,
+    base_url: str | None,
+    latency_s: float,
+    status: str,
+    response: LLMResponse | None = None,
+    error: BaseException | None = None,
+) -> None:
+    append_usage_record(
+        build_usage_record(
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            latency_s=latency_s,
+            status=status,
+            response=response,
+            error=error,
+        )
+    )
+
+
+__all__ = [
+    "append_usage_record",
+    "build_usage_record",
+    "pricing_for_model",
+    "record_api_usage",
+    "usage_cost_usd",
+    "usage_log_path",
+]

--- a/opencollab/tests/test_llm_providers.py
+++ b/opencollab/tests/test_llm_providers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -294,6 +295,50 @@ def test_anthropic_tool_choice_required_maps_to_any():
     assert forced["tool_choice"] == {"type": "any"}
     default = build_anthropic_kwargs("claude", msgs, tools, 0.0)
     assert "tool_choice" not in default
+
+
+def test_anthropic_tool_choice_named_function_maps_to_named_tool():
+    tools = [{"function": {"name": "structured_output", "parameters": {}}}]
+    msgs = [{"role": "user", "content": "hi"}]
+
+    kwargs = build_anthropic_kwargs(
+        "claude",
+        msgs,
+        tools,
+        0.0,
+        tool_choice={"type": "function", "function": {"name": "structured_output"}},
+    )
+
+    assert kwargs["tool_choice"] == {"type": "tool", "name": "structured_output"}
+
+
+def test_llm_client_forwards_anthropic_base_url(monkeypatch):
+    captured = {}
+
+    class FakeAsyncAnthropic:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "anthropic",
+        SimpleNamespace(AsyncAnthropic=FakeAsyncAnthropic),
+    )
+
+    from opencollab.adapters.llm.client import LLMClient
+
+    client = LLMClient(
+        provider="anthropic",
+        model="claude",
+        api_key="k",
+        base_url="http://proxy.local",
+        request_timeout=12.0,
+    )
+
+    assert client.base_url == "http://proxy.local"
+    assert captured["base_url"] == "http://proxy.local"
+    assert captured["api_key"] == "k"
+    assert captured["timeout"] == 12.0
 
 
 def test_openai_estimates_output_from_tool_calls_when_no_content():

--- a/opencollab/tests/test_llm_usage_ledger.py
+++ b/opencollab/tests/test_llm_usage_ledger.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from opencollab.adapters.llm.client import LLMClient
+from opencollab.adapters.llm.types import Usage
+from opencollab.adapters.llm.usage_ledger import (
+    append_usage_record,
+    build_usage_record,
+    usage_cost_usd,
+    usage_log_path,
+)
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_glm_usage_cost_accounts_for_cache_discount(monkeypatch):
+    monkeypatch.delenv("GLM_INPUT_USD_PER_MTOK", raising=False)
+    monkeypatch.delenv("GLM_CACHED_INPUT_USD_PER_MTOK", raising=False)
+    monkeypatch.delenv("GLM_OUTPUT_USD_PER_MTOK", raising=False)
+    usage = Usage(input_tokens=1000, output_tokens=50, cache_read_tokens=800)
+
+    cost = usage_cost_usd(usage, "glm-5.2")
+
+    expected = (200 * 1.4 + 800 * 0.26 + 50 * 4.4) / 1_000_000
+    assert cost == pytest.approx(expected)
+
+
+def test_append_usage_record_writes_jsonl(tmp_path):
+    path = tmp_path / "api_usage.jsonl"
+    record = build_usage_record(
+        provider="openai",
+        model="glm-5.2",
+        base_url="http://127.0.0.1:18788/v1?token=hidden",
+        latency_s=0.25,
+        status="success",
+    )
+
+    append_usage_record(record, path)
+
+    rows = _read_jsonl(path)
+    assert len(rows) == 1
+    assert rows[0]["schema"] == "opencollab.api_usage.v1"
+    assert rows[0]["base_url"] == "http://127.0.0.1:18788"
+    assert "hidden" not in json.dumps(rows[0])
+
+
+def test_usage_log_is_disabled_without_explicit_path(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENCOLLAB_API_USAGE_LOG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    append_usage_record({"schema": "opencollab.api_usage.v1"})
+
+    assert usage_log_path() is None
+    assert not (tmp_path / ".opencollab").exists()
+
+
+def test_usage_record_strips_base_url_userinfo_and_query():
+    record = build_usage_record(
+        provider="openai",
+        model="glm-5.2",
+        base_url="https://user:secret@example.com:8443/v1?api_key=hidden",
+        latency_s=0.25,
+        status="success",
+    )
+    record_text = json.dumps(record)
+
+    assert record["base_url"] == "https://example.com:8443"
+    assert record["base_url_host"] == "example.com:8443"
+    assert "user" not in record_text
+    assert "secret" not in record_text
+    assert "hidden" not in record_text
+
+
+def test_error_message_redacts_url_token_and_prompt(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "local-secret-token")
+    error = RuntimeError(
+        "failed https://user:secret@example.com:8443/v1?token=hidden "
+        "token=abc123 prompt=very secret prompt content: very secret body "
+        "bearer local-secret-token"
+    )
+
+    record = build_usage_record(
+        provider="openai",
+        model="glm-5.2",
+        base_url="https://safe.example/v1",
+        latency_s=0.25,
+        status="error",
+        error=error,
+    )
+    record_text = json.dumps(record)
+
+    assert "https://example.com:8443" in record_text
+    assert "user" not in record_text
+    assert "hidden" not in record_text
+    assert "abc123" not in record_text
+    assert "very secret" not in record_text
+    assert "local-secret-token" not in record_text
+
+
+class _FakeCompletions:
+    async def create(self, **kwargs):
+        usage = SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+        )
+        message = SimpleNamespace(content="hi", tool_calls=None)
+        choice = SimpleNamespace(message=message, finish_reason="stop")
+        return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class _BoomCompletions:
+    async def create(self, **kwargs):
+        raise RuntimeError("upstream failed bearer local-secret-token")
+
+
+def test_llm_client_records_success_without_prompt_or_key(tmp_path, monkeypatch):
+    path = tmp_path / "api_usage.jsonl"
+    monkeypatch.setenv("OPENCOLLAB_API_USAGE_LOG", str(path))
+    monkeypatch.setenv("OPENAI_API_KEY", "local-secret-token")
+    client = LLMClient(
+        model="glm-5.2",
+        provider="openai",
+        base_url="http://127.0.0.1:18788/v1",
+        max_retries=0,
+    )
+    client._openai = SimpleNamespace(chat=SimpleNamespace(completions=_FakeCompletions()))
+
+    response = asyncio.run(client.complete([{"role": "user", "content": "very secret prompt"}]))
+
+    assert response.content == "hi"
+    rows = _read_jsonl(path)
+    assert len(rows) == 1
+    record_text = json.dumps(rows[0])
+    assert rows[0]["status"] == "success"
+    assert rows[0]["usage"]["input_tokens"] == 100
+    assert rows[0]["usage"]["cached_input_tokens"] == 40
+    assert rows[0]["usage"]["output_tokens"] == 20
+    assert "very secret prompt" not in record_text
+    assert "local-secret-token" not in record_text
+
+
+def test_llm_client_records_error_with_redaction(tmp_path, monkeypatch):
+    path = tmp_path / "api_usage.jsonl"
+    monkeypatch.setenv("OPENCOLLAB_API_USAGE_LOG", str(path))
+    monkeypatch.setenv("OPENAI_API_KEY", "local-secret-token")
+    client = LLMClient(
+        model="glm-5.2",
+        provider="openai",
+        base_url="http://127.0.0.1:18788/v1",
+        max_retries=0,
+    )
+    client._openai = SimpleNamespace(chat=SimpleNamespace(completions=_BoomCompletions()))
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(client.complete([{"role": "user", "content": "very secret prompt"}]))
+
+    rows = _read_jsonl(path)
+    assert len(rows) == 1
+    record_text = json.dumps(rows[0])
+    assert rows[0]["status"] == "error"
+    assert rows[0]["error"]["type"] == "RuntimeError"
+    assert "[redacted]" in rows[0]["error"]["message"]
+    assert "very secret prompt" not in record_text
+    assert "local-secret-token" not in record_text


### PR DESCRIPTION
这份改动添加可显式开启的 API 用量 JSONL 记录。记录内容包括成功与失败请求的 token、估算成本、延迟、provider、model，以及脱敏后的连接信息。默认配置下不会写日志，只有设置 OPENCOLLAB_API_USAGE_LOG 时才启用。

同时补充 Anthropic named tool_choice 与 base_url 透传相关测试。

验证结果：58 个相关测试通过，ruff 通过，compileall 通过。独立评审 Agent 已通过。