### PR TITLE
添加 SWE 评测状态层与检查点恢复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,20 @@ eval_work/
 .understand-anything/
 tmp/
 opencollab-glm52-*.json
+
+# Local GLM / SWE-bench evaluation run artifacts
+docs/monitoring/
+workflow_logs/
+**/workflow_logs/
+**/trajectories/
+**/orchestration.jsonl
+**/metrics*.jsonl
+**/monitor_snapshots.jsonl
+**/predictions*_raw.jsonl
+**/predictions_*_raw.jsonl
+**/*_official.json
+**/*_official_*.json
+
 *.aux
 *.fdb_latexmk
 *.fls

--- a/docs/swe_eval_harness_refactor.md
+++ b/docs/swe_eval_harness_refactor.md
@@ -1,0 +1,13 @@
+# SWE Eval Harness Refactor
+
+这次重构把评测 harness 分成三层。第一层读取 prediction、metric、checkpoint 和 eval report 等事实记录。第二层用纯函数判定任务状态，例如 empty patch、metric 与 patch 不匹配、ready for eval、eval done。第三层才做副作用，例如启动评测命令或写状态文件。
+
+恢复策略采用有限损失 checkpoint。`run_eval_task(..., checkpoint_interval_seconds=300)` 会在 workflow 运行期间周期捕获工作树 diff，并在退出前再捕获一次最终 diff。捕获文件位于每个任务的 workflow run 目录，例如 `trajectories/<task_id>/checkpoint.worktree.patch` 和 `checkpoint.worktree.json`。`checkpoint.worktree.json` 记录 `loss_bound_seconds`，默认值是 300 秒。
+
+这个 checkpoint 保存的是文件系统里的工作树变化。恢复时，`resume_from_checkpoint=True` 会在新的环境建立后、注入 SWE-bench 测试 patch 前，把最近的 `checkpoint.worktree.patch` apply 回去。这样可以恢复上一次已经写入磁盘的代码改动。模型尚未写入文件的推理过程、正在进行的工具调用和外部进程瞬时状态会重新执行。
+
+恢复前会先检查新环境的工作树是否已经有改动；若已有 diff，恢复会跳过并记录 `skipped_dirty_worktree`。如果最近一次捕获失败或捕获到空 diff，旧的非空 `checkpoint.worktree.patch` 会保留在磁盘上，但元数据会写 `submission_eligible=false` 和 `preserved_previous_patch=true`，避免旧 patch 被误当成当前成功结果。
+
+SWE-bench 的官方测试 patch 会在运行开始时注入环境，但 checkpoint 捕获时会把这些注入路径从临时 index 里移除。最终提交 patch 和恢复 patch 都只围绕模型产生的代码改动，避免把 grader 测试混入提交。
+
+`scripts/swe_auto_eval_driver.py` 和 `scripts/swe_v3_wave_watchdog.py` 都是薄入口。默认行为只读，输出 JSON/Markdown 状态。自动评测启动需要显式传 `--start-eval` 和 `--eval-command-template`，这样状态判断和副作用有清楚边界。

--- a/opencollab/opencollab/adapters/env.py
+++ b/opencollab/opencollab/adapters/env.py
@@ -271,6 +271,7 @@ class DockerEnvironment(Environment):
         shell_flag = "-lc" if self._command_prefix is not None else "-c"
         exec_argv += [self._container_id, "bash", shell_flag, self._wrap_command(cmd)]
 
+        proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *exec_argv,
@@ -284,11 +285,27 @@ class DockerEnvironment(Environment):
                 stderr=stderr.decode("utf-8", errors="replace"),
             )
         except asyncio.TimeoutError:
+            await self._terminate_exec_process(proc)
             return ExecResult(
                 returncode=self._timeout_returncode,
                 stdout="",
                 stderr=f"Command timed out after {timeout}s",
             )
+        except asyncio.CancelledError:
+            await self._terminate_exec_process(proc)
+            raise
+
+    async def _terminate_exec_process(self, proc: asyncio.subprocess.Process | None) -> None:
+        if proc is None:
+            return
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            logger.warning("docker exec process did not exit after kill")
 
     async def read_file(self, path: str) -> str:
         quoted_path = shlex.quote(path)
@@ -298,19 +315,45 @@ class DockerEnvironment(Environment):
         return result.stdout
 
     async def write_file(self, path: str, content: str) -> None:
-        import base64
-        encoded = base64.b64encode(content.encode()).decode()
-        quoted_path = shlex.quote(path)
-        result = await self.exec_cmd(
-            f"base64 -d > {quoted_path} <<'__OPENCOLLAB_B64__'\n"
-            f"{encoded}\n"
-            "__OPENCOLLAB_B64__"
-        )
-        if result.returncode != 0:
-            detail = (result.stderr or result.stdout).strip()
+        if not self._container_id:
+            raise RuntimeError("Container not started. Call setup() first.")
+
+        exec_argv = ["docker", "exec", "-i"]
+        if self._exec_workdir:
+            exec_argv += ["-w", self._exec_workdir]
+        exec_argv += [
+            self._container_id,
+            "bash",
+            "-c",
+            'mkdir -p -- "$(dirname -- "$1")" && cat > "$1"',
+            "opencollab-write",
+            path,
+        ]
+
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *exec_argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=content.encode("utf-8")),
+                timeout=120.0,
+            )
+        except asyncio.TimeoutError as exc:
+            await self._terminate_exec_process(proc)
+            raise OSError(f"docker write timed out for {path}") from exc
+        except asyncio.CancelledError:
+            await self._terminate_exec_process(proc)
+            raise
+
+        if (proc.returncode or 0) != 0:
+            detail = (stderr or stdout).decode("utf-8", errors="replace").strip()
             raise OSError(
                 f"docker write failed for {path} "
-                f"(exit {result.returncode}): {detail}"
+                f"(exit {proc.returncode}): {detail}"
             )
         written = await self.read_file(path)
         if written != content:

--- a/opencollab/opencollab/adapters/tools/base.py
+++ b/opencollab/opencollab/adapters/tools/base.py
@@ -44,6 +44,7 @@ class Tool:
     name: str = ""
     description: str = ""
     parameters: dict[str, Any] = {"type": "object", "properties": {}}
+    default_timeout: float | None = None
 
     def to_openai_schema(self) -> dict[str, Any]:
         """Convert to OpenAI function calling format."""

--- a/opencollab/opencollab/adapters/tools/bash.py
+++ b/opencollab/opencollab/adapters/tools/bash.py
@@ -17,6 +17,7 @@ from opencollab.application.tool_execution import ToolRuntime
 
 # Max chars to keep from stdout/stderr (ref: user feedback blind spot #1)
 MAX_OUTPUT_CHARS = 8_000
+DEFAULT_TIMEOUT = 120.0
 
 
 class BashTool(Tool):
@@ -28,6 +29,7 @@ class BashTool(Tool):
     """
 
     name = "bash"
+    default_timeout = DEFAULT_TIMEOUT
     description = (
         "Execute a shell command in the workspace. Returns stdout and stderr. "
         "Use this for installing packages, build/setup commands, and one-off "
@@ -64,7 +66,7 @@ class BashTool(Tool):
         runtime: ToolRuntime,
     ) -> str:
         cmd = params["command"]
-        timeout = params.get("timeout", 120.0)
+        timeout = params.get("timeout", DEFAULT_TIMEOUT)
         env = runtime.environment
         safety_policy = runtime.safety_policy
 

--- a/opencollab/opencollab/adapters/tools/fs.py
+++ b/opencollab/opencollab/adapters/tools/fs.py
@@ -321,18 +321,23 @@ class GrepTool(Tool):
         pattern = params["pattern"]
         search_path = params.get("path", ".")
         glob_pattern = params.get("glob")
-        max_results = params.get("max_results", 50)
+        raw_max_results = params.get("max_results", 50)
         env = runtime.environment
 
         if not env:
             return "Error: no execution environment available."
+        try:
+            max_results = int(raw_max_results)
+        except (TypeError, ValueError):
+            return "Error: max_results must be an integer."
+        max_results = max(1, min(max_results, 500))
 
         quoted_pattern = shlex.quote(pattern)
         quoted_search_path = shlex.quote(search_path)
         rg_cmd = f"rg -n --max-count {max_results} "
         if glob_pattern:
             rg_cmd += f"-g {shlex.quote(glob_pattern)} "
-        rg_cmd += f"{quoted_pattern} {quoted_search_path} 2>/dev/null"
+        rg_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null"
         # Fallback when rg is missing from PATH: grep MUST use -E (ERE) so that
         # `a|b|c` alternation works. Plain grep is BRE, where `|` is a literal
         # character — an alternation pattern then silently matches nothing. Also
@@ -344,7 +349,7 @@ class GrepTool(Tool):
         )
         if glob_pattern:
             rg_cmd += f"--include={shlex.quote(glob_pattern)} "
-        rg_cmd += f"{quoted_pattern} {quoted_search_path} 2>/dev/null | head -n {max_results}"
+        rg_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null | head -n {max_results}"
 
         result = await env.exec_cmd(rg_cmd, timeout=30)
         if result.stdout.strip():

--- a/opencollab/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/opencollab/adapters/tools/run_tests.py
@@ -9,10 +9,11 @@ makes an unverified "it passes" claim much harder to make by accident.
 
 Defaults to ``python -m pytest``; override ``runner`` for projects with a custom
 entry point (e.g. ``bin/test``). When the caller does NOT pin a runner, the tool
-probes the workspace for a project-native runner (sympy ``bin/test``, ``tox``,
-Django ``manage.py test``) and translates the pytest-style ``target`` node-id to
-the native invocation; it also auto-falls-back to the native runner if pytest is
-missing (``No module named pytest``). Output is truncated to protect the context.
+probes the workspace for a project-native runner (Go ``go test``, sympy
+``bin/test``, ``tox``, Django ``manage.py test``) and translates the pytest-style
+``target`` node-id to the native invocation; it also auto-falls-back to the
+native runner if pytest is missing (``No module named pytest``). Output is
+truncated to protect the context.
 
 Every run ALWAYS ends with a one-line ``Verdict: GREEN|RED`` (plus, on RED, a
 missing-substring hint and — when the same failing target keeps failing — an
@@ -38,6 +39,7 @@ from opencollab.application.tool_execution import ToolRuntime
 MAX_TRACEBACK_CHARS = 6_000
 DEFAULT_RUNNER = "python -m pytest"
 DEFAULT_TIMEOUT = 300.0
+GO_PATH_PREFIX = "PATH=/usr/local/go/bin:/usr/lib/go/bin:/opt/go/bin:$PATH"
 # After this many consecutive failing runs of the SAME target, nudge the model
 # to change approach instead of re-running the identical failing assertion.
 ESCALATE_AFTER = 3
@@ -48,6 +50,7 @@ ESCALATE_AFTER = 3
 _NATIVE_PROBES: tuple[tuple[str, str], ...] = (
     ("test -x bin/test", "python bin/test"),
     ("test -f manage.py", "python manage.py test"),
+    ("test -f go.mod", "go test"),
     ("test -f tox.ini", "tox"),
 )
 
@@ -67,16 +70,18 @@ class RunTestsTool(Tool):
     """
 
     name = "run_tests"
+    default_timeout = DEFAULT_TIMEOUT
     description = (
         "Run the project's test suite (pytest by default) and return a STRUCTURED "
         "result: pass/fail/error counts, the failing test node-ids, and the head of "
         "the first traceback — not raw stdout. Use it to VERIFY a fix instead of "
         "guessing. Pass `target` (a path or node-id like 'tests/test_x.py::test_y') "
         "to focus the run. "
-        "The runner is auto-detected for non-pytest projects (sympy bin/test, "
-        "tox, Django manage.py test) and pytest node-ids are translated; override "
-        "`runner` only to force a specific command. Read the final 'Verdict: "
-        "GREEN|RED' line as the authoritative pass/fail signal. "
+        "The runner is auto-detected for non-pytest projects (Go go.mod, sympy "
+        "bin/test, tox, Django manage.py test) and pytest node-ids are translated; "
+        "override `runner` only to force a specific command. For Go, pass `target` "
+        "like './internal/server' or './internal/server::TestEvaluate'. Read the "
+        "final 'Verdict: GREEN|RED' line as the authoritative pass/fail signal. "
         "Prefer this over bash for running the test suite; it returns a structured "
         "pass/fail signal. Warnings are NOISE, not failures: the pass/fail decision "
         "is exit-code + failed/error counts only, and warnings are reported on a "
@@ -108,8 +113,16 @@ class RunTestsTool(Tool):
         "required": [],
     }
 
-    def __init__(self, max_traceback_chars: int = MAX_TRACEBACK_CHARS):
+    def __init__(
+        self,
+        max_traceback_chars: int = MAX_TRACEBACK_CHARS,
+        *,
+        allow_runner_override: bool = True,
+        allow_extra_args: bool = True,
+    ):
         self.max_traceback_chars = max_traceback_chars
+        self.allow_runner_override = allow_runner_override
+        self.allow_extra_args = allow_extra_args
         # target -> consecutive RED count, for the escalation nudge. The tool
         # instance is shared across a task's workflow sessions (built once in
         # the eval toolset), so this survives across run_tests calls.
@@ -129,6 +142,16 @@ class RunTestsTool(Tool):
 
         if not env:
             return "Error: no execution environment available."
+        if pinned_runner and not self.allow_runner_override:
+            return (
+                "Error: runner override is disabled for this run_tests tool. "
+                "Omit `runner`; run_tests auto-detects pytest and project-native "
+                "runners such as Go go.mod, sympy bin/test, Django manage.py, and "
+                "tox. For Go, pass `target` like './internal/server' or "
+                "'./internal/server::TestEvaluate'."
+            )
+        if extra_args and not self.allow_extra_args:
+            return "Error: extra_args is disabled for this run_tests tool."
 
         runner = pinned_runner or DEFAULT_RUNNER
         result, cmd, runner = await self._run(
@@ -137,10 +160,14 @@ class RunTestsTool(Tool):
         )
         combined = result.stdout + ("\n" + result.stderr if result.stderr else "")
 
-        # Auto-fallback: if the caller did NOT pin a runner and pytest is absent,
-        # probe for a project-native runner and re-run once on the native path.
-        if pinned_runner is None and _pytest_missing(result.returncode, combined):
-            native = await _detect_native_runner(env)
+        # Auto-fallback: if the caller did NOT pin a runner and pytest is absent
+        # or unsuitable for a Go target, probe once and re-run on the native path.
+        if pinned_runner is None:
+            native = await _native_fallback_candidate(
+                env,
+                result.returncode,
+                combined,
+            )
             if native:
                 result, cmd, runner = await self._run(
                     env, native, target, extra_args, timeout, safety_policy,
@@ -193,23 +220,80 @@ class RunTestsTool(Tool):
 
 def _is_pytest_runner(runner: str) -> bool:
     """Whether ``runner`` invokes pytest (so pytest-only flags are safe)."""
-    return "pytest" in runner
+    try:
+        parts = shlex.split(runner)
+    except ValueError:
+        return False
+    return any(part == "pytest" or part.endswith("/pytest") for part in parts)
 
 
-def _translate_target(runner: str, target: str) -> str:
-    """Map a pytest node-id to what a native runner expects.
+def _is_go_runner(runner: str) -> bool:
+    """Whether ``runner`` invokes ``go test``."""
+    try:
+        parts = shlex.split(runner)
+    except ValueError:
+        return False
+    return len(parts) >= 2 and parts[0] == "go" and parts[1] == "test"
+
+
+def _go_runner_command(runner: str) -> str:
+    """Return a Go runner command with common Go install paths visible."""
+    return f"{GO_PATH_PREFIX} {runner}" if runner.strip().startswith("go ") else runner
+
+
+def _translate_native_target_args(target: str) -> list[str]:
+    """Map a pytest node-id to safely quoted native-runner arguments.
 
     sympy ``bin/test`` and friends take a file path or test name, not a
     ``path::node`` id. Drop the ``::`` selector and keep the leaf node name
     (sympy/unittest match on it) alongside the path.
     """
-    if not target or _is_pytest_runner(runner):
-        return target
+    if not target:
+        return []
     path, sep, node = target.partition("::")
     if not sep:
-        return target
+        return [shlex.quote(target)]
     leaf = node.split("::")[-1]
-    return f"{path} {leaf}" if leaf else path
+    args = [shlex.quote(path)]
+    if leaf:
+        args.append(shlex.quote(leaf))
+    return args
+
+
+def _translate_go_single_target(target: str) -> list[str]:
+    package, sep, node = target.partition("::")
+    package = package.strip()
+    if not package:
+        package = "./..."
+    if package.endswith(".go"):
+        package = package.rsplit("/", 1)[0] if "/" in package else "."
+    if package not in {".", "./..."} and not package.startswith(("./", "../", "/")):
+        package = "./" + package.strip("/")
+
+    args = [shlex.quote(package)]
+    if sep and node.strip():
+        test_name = node.split("::")[-1].strip()
+        if test_name:
+            args.extend(["-run", shlex.quote(test_name)])
+    return args
+
+
+def _translate_go_target_args(target: str) -> list[str]:
+    """Map pytest-like targets to safe ``go test`` package and ``-run`` args."""
+    if not target:
+        return ["./..."]
+    if "::" not in target:
+        try:
+            targets = shlex.split(target)
+        except ValueError:
+            targets = []
+        if len(targets) > 1 and all(not item.startswith("-") for item in targets):
+            args: list[str] = []
+            for item in targets:
+                args.extend(_translate_go_single_target(item))
+            return args
+
+    return _translate_go_single_target(target)
 
 
 def _build_command(runner: str, target: str, extra_args: str) -> str:
@@ -223,11 +307,12 @@ def _build_command(runner: str, target: str, extra_args: str) -> str:
         parts = [runner, "--tb=short", "-rfE", "-rA", "-p", "no:cacheprovider", "-q"]
         if target:
             parts.append(shlex.quote(target))
+    elif _is_go_runner(runner):
+        parts = [_go_runner_command(runner)]
+        parts.extend(_translate_go_target_args(target))
     else:
         parts = [runner]
-        native_target = _translate_target(runner, target)
-        if native_target:
-            parts.append(native_target)
+        parts.extend(_translate_native_target_args(target))
     if extra_args:
         parts.append(extra_args)
     return " ".join(parts)
@@ -245,9 +330,28 @@ async def _detect_native_runner(env: Any) -> str | None:
     return None
 
 
+async def _native_fallback_candidate(
+    env: Any,
+    returncode: int,
+    output: str,
+) -> str | None:
+    if _pytest_missing(returncode, output):
+        return await _detect_native_runner(env)
+    if _pytest_no_tests(returncode, output):
+        native = await _detect_native_runner(env)
+        if native and _is_go_runner(native):
+            return native
+    return None
+
+
 def _pytest_missing(returncode: int, output: str) -> bool:
     """Whether the run failed because pytest itself is absent."""
     return returncode == 127 or "No module named pytest" in output
+
+
+def _pytest_no_tests(returncode: int, output: str) -> bool:
+    """Whether pytest ran successfully enough to report an empty selection."""
+    return returncode == 5 and "no tests ran" in output.lower()
 
 
 def _summary_line(output: str) -> str | None:
@@ -357,15 +461,16 @@ def _format_report(
 ) -> str:
     if green is None:
         green = _is_green(returncode, output)
-    if _pytest_missing(returncode, output):
+    if _is_pytest_runner(runner) and _pytest_missing(returncode, output):
         # Still emit a parseable verdict so the gate/model is never left without
         # a signal. pytest-missing is RED (the named tests could not run) and
-        # points the model at the native-runner override.
+        # points the model at auto-detected native runners.
         return (
             f"Command: {cmd}\nExit code: {returncode}\n"
             "Error: pytest not found and no project-native runner detected. "
-            "Set `runner` to the project's test entry point (e.g. 'python "
-            "bin/test', 'tox', 'python manage.py test').\n"
+            "Omit `runner` so run_tests can auto-detect Go go.mod, sympy "
+            "bin/test, Django manage.py, or tox. For Go, pass `target` like "
+            "'./internal/server' or './internal/server::TestEvaluate'.\n"
             "Verdict: RED (tests could not run)\n"
             f"{truncate(output.strip(), 1_000)}"
         )

--- a/opencollab/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/opencollab/adapters/tools/run_tests.py
@@ -233,7 +233,7 @@ def _is_go_runner(runner: str) -> bool:
         parts = shlex.split(runner)
     except ValueError:
         return False
-    return len(parts) >= 2 and parts[0] == "go" and parts[1] == "test"
+    return len(parts) >= 2 and (parts[0] == "go" or parts[0].endswith("/go")) and parts[1] == "test"
 
 
 def _go_runner_command(runner: str) -> str:

--- a/opencollab/opencollab/application/async_timeout.py
+++ b/opencollab/opencollab/application/async_timeout.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def abandon_on_timeout(awaitable: Awaitable[T], timeout: float | None) -> T:
+    """Await ``awaitable`` with a hard caller-side timeout.
+
+    ``asyncio.wait_for`` waits for cancellation cleanup after the timeout fires.
+    Some provider coroutines can spend a long time in that cleanup path, which
+    keeps the caller stuck. This helper cancels the task at the deadline, drains
+    its eventual result in the background, and immediately raises TimeoutError to
+    the caller.
+    """
+    if timeout is None or timeout == float("inf") or timeout <= 0:
+        return await awaitable
+
+    task = asyncio.ensure_future(awaitable)
+    try:
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+    except asyncio.CancelledError:
+        task.cancel()
+        task.add_done_callback(_consume_task_result)
+        raise
+
+    if task in done:
+        return task.result()
+
+    task.cancel()
+    task.add_done_callback(_consume_task_result)
+    raise asyncio.TimeoutError
+
+
+def _consume_task_result(task: asyncio.Future) -> None:
+    try:
+        task.result()
+    except BaseException:
+        pass

--- a/opencollab/opencollab/application/session_run.py
+++ b/opencollab/opencollab/application/session_run.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from opencollab.application.async_timeout import abandon_on_timeout
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
 from opencollab.application.extension_valve import (
     EXTENSION_DENIED_NUDGE,
@@ -24,6 +25,7 @@ from opencollab.application.shaping import forced_shape
 from opencollab.application.tool_execution import ToolExecutionUseCase
 from opencollab.domain.pending import PendingRow, RowKind, RowStatus
 from opencollab.domain.session import SessionPhase, SessionState
+from opencollab.domain.tools import ToolProcessingResult
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +73,7 @@ _EMPTY_STOP_PLACEHOLDER = "[no output produced this turn]"
 # only (ephemeral). Soft: advise a write; hard: demand it + force a tool call.
 _READ_TOOLS = frozenset({"file_read", "grep"})
 _WRITE_TOOLS = frozenset({"file_write", "apply_patch"})
+_STRUCTURED_OUTPUT_TOOL = "structured_output"
 READS_NUDGE_SOFT = 8
 READS_NUDGE_HARD = 16
 
@@ -105,6 +108,7 @@ DEFAULT_COMMIT_RESERVE = 25_000
 # distill-as-you-read scout is never braked mid-stride.
 DEFAULT_WATCHDOG_K = 4
 DEFAULT_LOW_YIELD_M = 3
+DEFAULT_LOOP_BLOCKED_LIMIT = 3
 
 # Predictive overshoot guard (STEP 4a). The agreed ~80% wind-down trips on
 # ``used_tokens >= explore_threshold`` — but the very turn meant to submit can BE
@@ -301,6 +305,8 @@ class SessionRunUseCase:
         # (a model that ignored the forced tool_choice and called another/unknown
         # tool gets exactly ONE more turn before going terminal).
         self._wind_down_retried = False
+        self._pending_tool_allowlist: frozenset[str] | None = None
+        self._pending_tool_gate_label: str | None = None
 
     async def run_loop(self, cancel_event: asyncio.Event | None = None) -> str:
         """Drive the phase FSM until the turn finishes or suspends.
@@ -642,6 +648,18 @@ class SessionRunUseCase:
             self.state.transition_to(SessionPhase.CANCELLED, reason="interrupted by user")
             return
 
+        if self.state.loop_blocked_since_progress >= DEFAULT_LOOP_BLOCKED_LIMIT:
+            reason = (
+                "loop block limit reached: "
+                f"{self.state.loop_blocked_since_progress} repeated tool calls"
+            )
+            self.state.append_message(
+                {"role": "system", "content": f"[{reason.capitalize()}. Session stopped.]"}
+            )
+            await self.event_publisher.emit(self.event_factory.error("loop_blocked"))
+            self.state.transition_to(SessionPhase.STEP_LIMIT_EXCEEDED, reason=reason)
+            return
+
         # Enforcement wind-down (STEP 0) — gated; with enforcement OFF this whole
         # block is skipped and the budget trip below runs exactly as before. When
         # ON, at ~80% of the cap we force a single structured submit instead of
@@ -859,14 +877,26 @@ class SessionRunUseCase:
             self.state.fail()
             raise RuntimeError("Cannot execute tools before calling LLM")
 
-        tool_calls = pending.response.tool_calls
+        original_tool_calls = list(pending.response.tool_calls)
+        tool_calls, blocked_messages = self._apply_pending_tool_allowlist(original_tool_calls)
         immediate, deferred = self._split_tool_calls(tool_calls)
 
         # Fast path, unchanged: every tool is synchronous — run them, append
         # results, and autosave the step.
         if not deferred:
-            result = await self.tool_execution.process(tool_calls)
+            result = (
+                await self.tool_execution.process(tool_calls)
+                if tool_calls
+                else ToolProcessingResult()
+            )
+            result.messages_to_append = self._ordered_tool_messages(
+                original_tool_calls,
+                result.messages_to_append,
+                blocked_messages,
+            )
             result.apply_to(self.state)
+            self._pending_tool_allowlist = None
+            self._pending_tool_gate_label = None
             self.state.transition_to(SessionPhase.AUTOSAVING)
             return
 
@@ -875,7 +905,7 @@ class SessionRunUseCase:
         # original order, satisfying the LLM rule that every tool_call_id is
         # answered before the next model call.
         table = self.state.pending_events
-        order = {tc["id"]: i for i, tc in enumerate(tool_calls)}
+        order = {tc["id"]: i for i, tc in enumerate(original_tool_calls)}
 
         if immediate:
             proc = await self.tool_execution.process(immediate)
@@ -898,6 +928,18 @@ class SessionRunUseCase:
                         result=message["content"],
                     )
                 )
+
+        for message in blocked_messages:
+            tid = message["tool_call_id"]
+            table.add(
+                PendingRow(
+                    tool_call_id=tid,
+                    kind=RowKind.IMMEDIATE,
+                    order=order[tid],
+                    status=RowStatus.DONE,
+                    result=message["content"],
+                )
+            )
 
         for tc in deferred:
             tid = tc["id"]
@@ -924,6 +966,8 @@ class SessionRunUseCase:
                     )
                 )
 
+        self._pending_tool_allowlist = None
+        self._pending_tool_gate_label = None
         if table.is_complete():
             # Nothing is actually outstanding (e.g. all spawns were rejected
             # synchronously) — drain now and autosave instead of suspending on
@@ -970,7 +1014,7 @@ class SessionRunUseCase:
 
     def _build_steering_block(
         self, messages: list[dict]
-    ) -> tuple[dict | None, str | None, str | None]:
+    ) -> tuple[dict | None, Any | None, str | None]:
         """Build the per-turn closed-loop steering message + any tool_choice force.
 
         Returns ``(message, tool_choice_override_or_None, level)`` where ``level``
@@ -995,11 +1039,13 @@ class SessionRunUseCase:
         status = f"[Budget: ~{remaining_k}k/{total_k}k tokens left, ~{steps_left} steps left.]"
 
         reads = self.state.reads_since_last_edit
-        has_write = any(
-            getattr(t, "name", None) in _WRITE_TOOLS
+        tool_names = {
+            getattr(t, "name", None)
             for t in getattr(self.agent, "tools", []) or []
-        )
-        override: str | None = None
+        }
+        has_write = bool(tool_names & _WRITE_TOOLS)
+        has_structured_output = _STRUCTURED_OUTPUT_TOOL in tool_names
+        override: Any | None = None
         level: str | None = None
         extra = ""
         if has_write and reads >= READS_NUDGE_HARD:
@@ -1016,6 +1062,14 @@ class SessionRunUseCase:
                 " apply_patch before reading more."
             )
             level = "soft"
+        elif has_structured_output and reads >= READS_NUDGE_SOFT:
+            extra = (
+                f" You have read {reads} times without submitting structured output."
+                " STOP reading — your next action MUST be structured_output using"
+                " the evidence you already have."
+            )
+            override = _submit_tool_choice(_STRUCTURED_OUTPUT_TOOL)
+            level = "hard"
         return {"role": "user", "content": status + extra}, override, level
 
     def _fold_steering(self, last_user_msg: dict, steering_text: str) -> dict:
@@ -1031,6 +1085,83 @@ class SessionRunUseCase:
         else:
             folded = steering_text
         return {**last_user_msg, "content": folded}
+
+    def _write_only_tool_schemas(self, tools: list[dict] | None) -> list[dict] | None:
+        return self._tool_schemas_with_names(tools, _WRITE_TOOLS)
+
+    def _tool_schemas_with_names(
+        self, tools: list[dict] | None, names: frozenset[str]
+    ) -> list[dict] | None:
+        if not tools:
+            return tools
+        filtered = [
+            spec
+            for spec in tools
+            if spec.get("function", {}).get("name") in names
+        ]
+        return filtered or tools
+
+    def _hard_steering_tools(self) -> tuple[frozenset[str], str]:
+        tool_names = {
+            getattr(t, "name", None)
+            for t in getattr(self.agent, "tools", []) or []
+        }
+        if tool_names & _WRITE_TOOLS:
+            return _WRITE_TOOLS, "hard write gate"
+        if _STRUCTURED_OUTPUT_TOOL in tool_names:
+            return frozenset({_STRUCTURED_OUTPUT_TOOL}), "hard structured-output gate"
+        return frozenset(), "hard tool gate"
+
+    def _apply_pending_tool_allowlist(
+        self,
+        tool_calls: list[dict],
+    ) -> tuple[list[dict], list[dict]]:
+        allowed = self._pending_tool_allowlist
+        if allowed is None:
+            return tool_calls, []
+
+        kept: list[dict] = []
+        blocked: list[dict] = []
+        for tc in tool_calls:
+            func = tc.get("function", {})
+            name = func.get("name")
+            if name in allowed:
+                kept.append(tc)
+                continue
+            allowed_list = ", ".join(sorted(allowed))
+            gate_label = self._pending_tool_gate_label or "hard tool gate"
+            blocked.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.get("id"),
+                    "content": (
+                        f"Error: tool '{name}' is not allowed during the "
+                        f"{gate_label}. Use one of: {allowed_list}."
+                    ),
+                }
+            )
+        return kept, blocked
+
+    def _ordered_tool_messages(
+        self,
+        tool_calls: list[dict],
+        *message_groups: list[dict],
+    ) -> list[dict]:
+        by_id: dict[str, dict] = {}
+        extras: list[dict] = []
+        for group in message_groups:
+            for message in group:
+                tool_call_id = message.get("tool_call_id")
+                if isinstance(tool_call_id, str):
+                    by_id[tool_call_id] = message
+                else:
+                    extras.append(message)
+        ordered = [
+            by_id[tc["id"]]
+            for tc in tool_calls
+            if tc.get("id") in by_id
+        ]
+        return ordered + extras
 
     async def call_llm(self, tools: list[dict] | None) -> CompletionResponse:
         """Complete against the shaped view of history.
@@ -1074,6 +1205,15 @@ class SessionRunUseCase:
         )
         if steering is not None and not persisted:
             messages = [*messages, steering]
+        if steering_level == "hard":
+            hard_tools, gate_label = self._hard_steering_tools()
+            self._pending_tool_allowlist = hard_tools
+            self._pending_tool_gate_label = gate_label
+            tools = self._tool_schemas_with_names(tools, hard_tools)
+        else:
+            self._pending_tool_allowlist = None
+            self._pending_tool_gate_label = None
+
         try:
             return await self._complete(messages, tools, tool_choice_override)
         except Exception as exc:
@@ -1107,7 +1247,7 @@ class SessionRunUseCase:
         self,
         messages: list[dict],
         tools: list[dict] | None,
-        tool_choice_override: str | None = None,
+        tool_choice_override: Any | None = None,
     ) -> CompletionResponse:
         # ``tool_choice`` is read defensively (getattr) so duck-typed agent stubs
         # without the field keep working; ``None`` (the default) keeps the
@@ -1143,7 +1283,7 @@ class SessionRunUseCase:
             return await self._complete_with_choice(messages, tools, "auto")
 
     async def _complete_with_choice(
-        self, messages: list[dict], tools: list[dict] | None, tool_choice: str | None
+        self, messages: list[dict], tools: list[dict] | None, tool_choice: Any | None
     ) -> CompletionResponse:
         # ``thinking`` is read defensively (getattr) so duck-typed agent stubs
         # without the field keep working. When OFF (the default) the call is made
@@ -1193,9 +1333,7 @@ class SessionRunUseCase:
         """
         if self._per_call_timeout is None:
             return await self.llm.complete(**kwargs)
-        return await asyncio.wait_for(
-            self.llm.complete(**kwargs), timeout=self._per_call_timeout
-        )
+        return await abandon_on_timeout(self.llm.complete(**kwargs), self._per_call_timeout)
 
     async def _stop_on_context_overflow(self) -> None:
         """Graceful terminal stop when a prompt overflows the model window even
@@ -1261,29 +1399,36 @@ class SessionRunUseCase:
                     }
                     for tc in response.tool_calls
                 ]
+            usage = response.usage
+            input_tokens = getattr(usage, "input_tokens", 0)
+            total_tokens = getattr(usage, "total_tokens", input_tokens)
             payload = {
                 "model": self.agent.model,
                 "finish_reason": response.finish_reason,
                 "content": response.content,
                 "tool_calls": tool_calls_log,
-                "usage": {
-                    "input_tokens": response.usage.input_tokens,
-                    "output_tokens": response.usage.output_tokens,
-                    "total_tokens": response.usage.total_tokens,
-                    "cache_read_tokens": getattr(response.usage, "cache_read_tokens", 0),
-                    "cache_creation_tokens": getattr(response.usage, "cache_creation_tokens", 0),
+            }
+            if all(hasattr(usage, name) for name in ("input_tokens", "output_tokens", "total_tokens", "estimated")):
+                output_tokens = getattr(usage, "output_tokens", max(total_tokens - input_tokens, 0))
+                cache_read_tokens = getattr(usage, "cache_read_tokens", 0)
+                cache_creation_tokens = getattr(usage, "cache_creation_tokens", 0)
+                payload["usage"] = {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": total_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_creation_tokens": cache_creation_tokens,
                     "uncached_input_tokens": max(
-                        response.usage.input_tokens
-                        - getattr(response.usage, "cache_read_tokens", 0)
-                        - getattr(response.usage, "cache_creation_tokens", 0),
+                        input_tokens
+                        - cache_read_tokens
+                        - cache_creation_tokens,
                         0,
                     ),
-                    "estimated": response.usage.estimated,
-                },
-            }
-            raw_usage = getattr(response.usage, "raw_usage", None)
-            if raw_usage:
-                payload["usage"]["raw_usage"] = raw_usage
+                    "estimated": getattr(usage, "estimated", False),
+                }
+                raw_usage = getattr(usage, "raw_usage", None)
+                if raw_usage:
+                    payload["usage"]["raw_usage"] = raw_usage
             # Record provider chain-of-thought to the trajectory when present
             # (omitted otherwise, so non-thinking traces keep their prior shape).
             reasoning = getattr(response, "reasoning", None)
@@ -1292,7 +1437,7 @@ class SessionRunUseCase:
             self.tracer.log_step(
                 step_type="llm_call",
                 payload=payload,
-                tokens=response.usage.total_tokens,
+                tokens=total_tokens,
                 latency=latency,
             )
 

--- a/opencollab/opencollab/application/session_run.py
+++ b/opencollab/opencollab/application/session_run.py
@@ -1408,7 +1408,7 @@ class SessionRunUseCase:
                 "content": response.content,
                 "tool_calls": tool_calls_log,
             }
-            if all(hasattr(usage, name) for name in ("input_tokens", "output_tokens", "total_tokens", "estimated")):
+            if usage is not None:
                 output_tokens = getattr(usage, "output_tokens", max(total_tokens - input_tokens, 0))
                 cache_read_tokens = getattr(usage, "cache_read_tokens", 0)
                 cache_creation_tokens = getattr(usage, "cache_creation_tokens", 0)

--- a/opencollab/opencollab/application/tool_execution.py
+++ b/opencollab/opencollab/application/tool_execution.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
+import os
 import time
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
@@ -20,6 +22,14 @@ from opencollab.domain.tools import MAX_CALL_HASH_WINDOW, LoopDetection, ToolPro
 
 # Loop detection (ref: opencode doom_loop detection — 3 identical calls)
 MAX_SIMILAR_CALLS = 3
+
+# A single tool call must not be able to hold a session forever. Individual
+# tools still pass their own command timeout to the environment; this outer
+# guard catches hangs before that layer is reached, including approval hooks,
+# adapter bugs, or stuck subprocess creation.
+DEFAULT_TOOL_EXECUTION_TIMEOUT = float(os.environ.get("OPENCOLLAB_TOOL_EXECUTION_TIMEOUT", "180"))
+MAX_TOOL_EXECUTION_TIMEOUT = float(os.environ.get("OPENCOLLAB_TOOL_EXECUTION_MAX_TIMEOUT", "900"))
+TOOL_EXECUTION_TIMEOUT_GRACE = 10.0
 
 # Read-only, range-parameterized tools whose loop key is the FILE PATH alone, not
 # the full args. A model thrashing on one file re-reads it with SHIFTING line
@@ -304,7 +314,7 @@ class ToolExecutionUseCase:
 
             await self.event_publisher.emit(self.event_factory.tool_start(tool_name, args))
 
-            tool_output, tool_latency = await self.execute_tool(tool, args)
+            tool_output, tool_latency = await self.execute_tool(tool, args, tool_id=tool_id)
             # The full result is persisted; a per-tool-result budget shaper caps
             # what the model sees at call time (see application.shaping).
 
@@ -392,22 +402,60 @@ class ToolExecutionUseCase:
     def find_tool(self, tool_name: str):
         return self.agent.find_tool(tool_name)
 
-    async def execute_tool(self, tool, args: dict) -> tuple[str, float]:
+    async def execute_tool(
+        self,
+        tool,
+        args: dict,
+        *,
+        tool_id: str | None = None,
+    ) -> tuple[str, float]:
         """Run one tool, mapping any exception to an error string.
 
         Returns ``(output, latency_seconds)`` — never raises, so one failing
         tool cannot abort the rest of the batch.
         """
         start = time.monotonic()
-        runtime = self.tool_runtime()
+        runtime = self.tool_runtime(tool_call_id=tool_id)
+        timeout = self.tool_execution_timeout(tool, args)
         try:
-            result = await tool.execute_with_runtime(args, runtime)
+            result = await asyncio.wait_for(
+                tool.execute_with_runtime(args, runtime),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            tool_name = getattr(tool, "name", type(tool).__name__)
+            result = (
+                f"Tool execution timed out after {timeout:.1f}s "
+                f"while running '{tool_name}'."
+            )
         except PermissionError as e:
             result = f"Permission denied: {e}"
         except Exception as e:
             result = f"Tool execution error: {type(e).__name__}: {e}"
 
         return result, time.monotonic() - start
+
+    def tool_execution_timeout(self, tool: Any, args: dict) -> float:
+        requested = self._numeric_timeout((args or {}).get("timeout"))
+        base = requested if requested is not None else self._tool_default_timeout(tool)
+        return min(base + TOOL_EXECUTION_TIMEOUT_GRACE, MAX_TOOL_EXECUTION_TIMEOUT)
+
+    def _tool_default_timeout(self, tool: Any) -> float:
+        configured = self._numeric_timeout(getattr(tool, "default_timeout", None))
+        if configured is not None:
+            return configured
+        return DEFAULT_TOOL_EXECUTION_TIMEOUT
+
+    def _numeric_timeout(self, value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError):
+            return None
+        if timeout <= 0:
+            return None
+        return timeout
 
     def tool_runtime(self, tool_call_id: str | None = None) -> ToolRuntime:
         return ToolRuntime(

--- a/opencollab/opencollab/application/tool_execution.py
+++ b/opencollab/opencollab/application/tool_execution.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
+from opencollab.application.async_timeout import abandon_on_timeout
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
 from opencollab.application.ports import (
     AskUserPort,
@@ -418,7 +419,7 @@ class ToolExecutionUseCase:
         runtime = self.tool_runtime(tool_call_id=tool_id)
         timeout = self.tool_execution_timeout(tool, args)
         try:
-            result = await asyncio.wait_for(
+            result = await abandon_on_timeout(
                 tool.execute_with_runtime(args, runtime),
                 timeout=timeout,
             )
@@ -450,7 +451,7 @@ class ToolExecutionUseCase:
         return DEFAULT_TOOL_EXECUTION_TIMEOUT
 
     def _numeric_timeout(self, value: Any) -> float | None:
-        if value is None:
+        if value is None or isinstance(value, bool):
             return None
         try:
             timeout = float(value)

--- a/opencollab/opencollab/application/tool_execution.py
+++ b/opencollab/opencollab/application/tool_execution.py
@@ -423,7 +423,7 @@ class ToolExecutionUseCase:
                 timeout=timeout,
             )
         except asyncio.TimeoutError:
-            tool_name = getattr(tool, "name", type(tool).__name__)
+            tool_name = self._tool_display_name(tool)
             result = (
                 f"Tool execution timed out after {timeout:.1f}s "
                 f"while running '{tool_name}'."
@@ -434,6 +434,9 @@ class ToolExecutionUseCase:
             result = f"Tool execution error: {type(e).__name__}: {e}"
 
         return result, time.monotonic() - start
+
+    def _tool_display_name(self, tool: Any) -> str:
+        return str(getattr(tool, "name", type(tool).__name__))
 
     def tool_execution_timeout(self, tool: Any, args: dict) -> float:
         requested = self._numeric_timeout((args or {}).get("timeout"))

--- a/opencollab/opencollab/application/workflow.py
+++ b/opencollab/opencollab/application/workflow.py
@@ -30,6 +30,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from opencollab.application.async_timeout import abandon_on_timeout
 from opencollab.application.extension_valve import RequestExtensionTool
 from opencollab.application.ports import (
     EventPublisherPort,
@@ -333,7 +334,7 @@ class WorkflowContext:
             if schema is not None:
                 return await self._run_structured_agent(
                     prompt, schema=schema, label=label, tools=tools,
-                    isolation=isolation, budget=budget,
+                    isolation=isolation, timeout=timeout, budget=budget,
                 )
             # Enforcement wind-down (STEP 0): the scout path injects submit_findings
             # and the structural commit brake. OFF (the default) routes to the
@@ -402,9 +403,7 @@ class WorkflowContext:
             # already written to disk before the cancel survive in the env, so the
             # patch is still extractable. A non-positive timeout is treated as "no
             # bound" — the caller is already past the deadline; let the call run.
-            if timeout is not None and timeout != float("inf") and timeout > 0:
-                return await asyncio.wait_for(session.run_loop(), timeout=timeout)
-            return await session.run_loop()
+            return await abandon_on_timeout(session.run_loop(), timeout)
         except asyncio.TimeoutError:
             await self.log(f"agent timed out ({label or 'agent'}) after {timeout}s")
             return None
@@ -466,12 +465,7 @@ class WorkflowContext:
         text: str | None = None
         try:
             await session.add_user_message(prompt)
-            if timeout is not None and timeout != float("inf") and timeout > 0:
-                text = await asyncio.wait_for(
-                    session.run_loop(capture_done), timeout=timeout
-                )
-            else:
-                text = await session.run_loop(capture_done)
+            text = await abandon_on_timeout(session.run_loop(capture_done), timeout)
         except asyncio.TimeoutError:
             await self.log(f"agent timed out ({label or 'agent'}) after {timeout}s")
         except Exception as exc:  # noqa: BLE001 — one dead agent never kills the fleet
@@ -677,6 +671,7 @@ class WorkflowContext:
         label: str | None,
         tools: Sequence[Any] | None,
         isolation: bool,
+        timeout: float | None = None,
         budget: int | None = None,
     ) -> dict | None:
         """Run a schema-bound session, returning the validated payload or None.
@@ -729,9 +724,16 @@ class WorkflowContext:
         self._sessions.append(session)
         try:
             await session.add_user_message(seeded_prompt)
-            await session.run_loop(capture_done)
+            await self._run_session_loop(
+                session,
+                capture_done,
+                timeout=timeout,
+            )
             if _schema_satisfied(capture_tool.captured, schema):
                 return capture_tool.captured
+        except asyncio.TimeoutError:
+            await self.log(f"structured agent timed out ({label or 'agent'}) after {timeout}s")
+            return None
         except Exception as exc:  # noqa: BLE001 — one dead agent never kills the fleet
             await self.log(f"structured agent failed ({label or 'agent'}): {exc}")
             return None
@@ -751,6 +753,7 @@ class WorkflowContext:
             schema=schema,
             label=label,
             isolation=isolation,
+            timeout=timeout,
         )
 
     async def _forced_structured_commit(
@@ -763,6 +766,7 @@ class WorkflowContext:
         schema: dict[str, Any],
         label: str | None,
         isolation: bool,
+        timeout: float | None,
     ) -> dict | None:
         """Build a single-tool, forced-``tool_choice`` corrective session.
 
@@ -800,11 +804,27 @@ class WorkflowContext:
         try:
             self._carry_exploration(prior_session, session)
             await session.add_user_message(retry_prompt)
-            await session.run_loop(capture_done)
+            await self._run_session_loop(
+                session,
+                capture_done,
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            await self.log(f"structured retry timed out ({label or 'agent'}) after {timeout}s")
+            return None
         except Exception as exc:  # noqa: BLE001 — one dead agent never kills the fleet
             await self.log(f"structured retry failed ({label or 'agent'}): {exc}")
             return None
         return capture_tool.captured if _schema_satisfied(capture_tool.captured, schema) else None
+
+    @staticmethod
+    async def _run_session_loop(
+        session: Any,
+        cancel_event: asyncio.Event | None,
+        *,
+        timeout: float | None,
+    ) -> str:
+        return await abandon_on_timeout(session.run_loop(cancel_event), timeout)
 
     @staticmethod
     def _carry_exploration(prior_session: Any, session: Any) -> None:

--- a/opencollab/opencollab/domain/session.py
+++ b/opencollab/opencollab/domain/session.py
@@ -191,6 +191,10 @@ class SessionState:
     # physical tool-removal actuator was not satisfied on the first forced turn. A
     # session-lifetime latch like ``wind_down_done`` (not reset per user turn).
     forced_unsatisfied: bool = False
+    # Hard loop-block brake. Tool execution short-circuits repeated identical or
+    # path-normalized calls; this counter lets that short-circuit stop a session
+    # after repeated warnings instead of paying for more near-identical turns.
+    loop_blocked_since_progress: int = 0
     # Single-justified-extension valve (STEP 4b). At a wind-down trip the scout is
     # offered "commit OR justify one more read"; ``extension_offered`` latches that
     # the offer turn is outstanding so the NEXT precheck resolves the model's choice
@@ -366,6 +370,7 @@ class SessionState:
         self.low_yield_since_progress = 0
         self.distinct_evidence_count = 0
         self.steps_since_progress = 0
+        self.loop_blocked_since_progress = 0
         self._seen_result_hashes.clear()
         self.scout_ledger.clear()
 

--- a/opencollab/opencollab/domain/tools.py
+++ b/opencollab/opencollab/domain/tools.py
@@ -96,6 +96,7 @@ class ToolProcessingResult:
         reads it is gated, so the off path is unchanged.
         """
         distinct_before = state.distinct_evidence_count
+        made_progress = self.write_succeeded
         for i, (content_hash, call_hash, intrinsic_low_yield) in enumerate(self.evidence_signals):
             card = self.evidence_cards[i] if i < len(self.evidence_cards) else None
             state.record_evidence_signal(
@@ -109,6 +110,10 @@ class ToolProcessingResult:
                 state.steps_since_progress = 0
             else:
                 state.steps_since_progress += 1
+        if made_progress:
+            state.loop_blocked_since_progress = 0
+        elif self.loop_detections:
+            state.loop_blocked_since_progress += len(self.loop_detections)
 
     def apply_hashes_to(self, state: SessionState, max_window: int = MAX_CALL_HASH_WINDOW) -> None:
         """Apply only the loop-detection hashes, not the result messages.

--- a/opencollab/opencollab/harness/evaluator.py
+++ b/opencollab/opencollab/harness/evaluator.py
@@ -18,6 +18,7 @@ import shlex
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from opencollab.adapters.env import DockerEnvironment, Environment, LocalEnvironment
@@ -47,6 +48,7 @@ from opencollab.bootstrap.session_factory import (
     workflow_transcript_path,
 )
 from opencollab.domain.agent import Agent
+from opencollab.harness.swe_checkpoint import WorktreeCheckpoint, worktree_diff_command
 from opencollab.harness.test_injection import apply_test_patch
 
 EnvFactory = Callable[["EvalTask"], Awaitable[Environment]]
@@ -74,6 +76,7 @@ class EvalResult:
     # observability plus a hook for outer SWE drivers that need workflow-level
     # audit data when writing the final prediction patch.
     workflow_result: Any | None = None
+    checkpoint_result: Any | None = None
 
 
 @dataclass
@@ -475,6 +478,8 @@ async def run_eval_task(
     top_p: float | None = DEFAULT_TOP_P,
     thinking: bool = DEFAULT_THINKING,
     thinking_params: dict | None = None,
+    checkpoint_interval_seconds: float | None = None,
+    resume_from_checkpoint: bool = False,
 ) -> EvalResult:
     """Run a single evaluation task.
 
@@ -506,6 +511,8 @@ async def run_eval_task(
     env: Environment | None = None
     session: Session | None = None
     workflow_ctx: WorkflowContext | None = None
+    checkpoint: WorktreeCheckpoint | None = None
+    checkpoint_result: dict[str, Any] | None = None
     error: str | None = None
     patch = ""
     # Paths of any injected benchmark test files — checked out before patch
@@ -517,6 +524,14 @@ async def run_eval_task(
         env = await env_factory(task)
         tools = list(tools_factory())
 
+        if run_dir is not None and checkpoint_interval_seconds:
+            checkpoint = WorktreeCheckpoint(
+                Path(run_dir),
+                interval_seconds=checkpoint_interval_seconds,
+            )
+            if resume_from_checkpoint:
+                checkpoint_result = {"restore": (await checkpoint.restore_latest(env)).to_dict()}
+
         # SWE-bench test injection: apply the real FAIL_TO_PASS test into the
         # workspace BEFORE the workflow runs so the agent can verify against it.
         # Guarded on extras so single-session / non-SWE-bench paths are
@@ -525,6 +540,9 @@ async def run_eval_task(
         test_patch = (task.extras or {}).get("test_patch")
         if test_patch:
             injected_paths = await apply_test_patch(env, test_patch)
+
+        if checkpoint is not None:
+            await checkpoint.start(env, exclude_paths=injected_paths)
 
         # Orientation up front: a bounded repo map in the system prompt saves
         # the model its first N steps of ls/find exploration.
@@ -574,6 +592,12 @@ async def run_eval_task(
     except Exception as e:
         error = f"{type(e).__name__}: {e}"
 
+    if env and checkpoint is not None:
+        final_checkpoint = await checkpoint.stop(env, exclude_paths=injected_paths)
+        if checkpoint_result is None:
+            checkpoint_result = {}
+        checkpoint_result["final"] = final_checkpoint.to_dict()
+
     # Diff-exclusion (load-bearing): revert any injected benchmark test files
     # before extracting the patch so the submitted model_patch NEVER contains the
     # test edits. The grader applies its own test_patch; leaving these in would
@@ -596,14 +620,14 @@ async def run_eval_task(
             except Exception:
                 pass
 
-    # Extract git patch (best-effort even after errors)
+    # Extract git patch (best-effort even after errors). Use a temporary index so
+    # new files are included without mutating the environment's real git index.
     if env:
         try:
-            patch_result = await env.exec_cmd("git diff")
+            patch_result = await env.exec_cmd(worktree_diff_command(injected_paths))
             patch = patch_result.stdout
-            if not patch.strip():
-                patch_result = await env.exec_cmd("git diff HEAD")
-                patch = patch_result.stdout
+            if patch_result.returncode != 0:
+                patch = ""
         except Exception:
             pass
 
@@ -649,6 +673,7 @@ async def run_eval_task(
         trajectory_path=tracer.path,
         markup_recovered=markup_recovered,
         workflow_result=getattr(workflow_ctx, "workflow_result", None) if workflow_ctx else None,
+        checkpoint_result=checkpoint_result,
     )
 
 
@@ -698,4 +723,6 @@ def save_results(results: list[EvalResult], output_path: str) -> None:
                 "patch_lines": len(r.patch.splitlines()),
                 "trajectory": r.trajectory_path,
             }
+            if r.checkpoint_result is not None:
+                record["checkpoint_result"] = r.checkpoint_result
             f.write(json.dumps(record) + "\n")

--- a/opencollab/opencollab/harness/swe_checkpoint.py
+++ b/opencollab/opencollab/harness/swe_checkpoint.py
@@ -1,0 +1,310 @@
+"""Bounded-loss worktree checkpoints for long SWE-bench runs."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import shlex
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from opencollab.adapters.env import Environment
+
+CHECKPOINT_PATCH = "checkpoint.worktree.patch"
+CHECKPOINT_META = "checkpoint.worktree.json"
+ENV_RECOVERY_PATCH_PREFIX = "/tmp/opencollab-checkpoint-recovery-"
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def _patch_sha(patch: str) -> str:
+    if not patch:
+        return ""
+    return hashlib.sha256(patch.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def worktree_diff_command(exclude_paths: Sequence[str] = ()) -> str:
+    resets = ""
+    for path in exclude_paths:
+        if not str(path).strip():
+            continue
+        resets += f'GIT_INDEX_FILE="$idx" git reset -q HEAD -- {shlex.quote(str(path))} >/dev/null 2>&1 || true; '
+    return (
+        'idx=$(mktemp); trap \'rm -f "$idx"\' EXIT; '
+        'git read-tree --index-output="$idx" HEAD && '
+        'GIT_INDEX_FILE="$idx" git add -A && '
+        f"{resets}"
+        'GIT_INDEX_FILE="$idx" git diff --cached --binary HEAD'
+    )
+
+
+@dataclass(frozen=True)
+class CheckpointResult:
+    status: str
+    patch_bytes: int = 0
+    patch_sha256: str = ""
+    reason: str = ""
+    error: str = ""
+    preserved_previous_patch: bool = False
+    submission_eligible: bool = False
+    background_errors: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "patch_bytes": self.patch_bytes,
+            "patch_sha256": self.patch_sha256,
+            "reason": self.reason,
+            "error": self.error,
+            "preserved_previous_patch": self.preserved_previous_patch,
+            "submission_eligible": self.submission_eligible,
+            "background_errors": list(self.background_errors),
+        }
+
+
+class WorktreeCheckpoint:
+    """Periodic host-side checkpoint of the env worktree diff.
+
+    The checkpoint captures a submittable worktree patch, not model state. With
+    a 300-second interval, a crash can lose the current in-flight model/tool
+    turn plus at most one checkpoint interval of saved file edits.
+    """
+
+    def __init__(self, run_dir: Path, *, interval_seconds: float = 300.0) -> None:
+        self.run_dir = Path(run_dir)
+        self.interval_seconds = float(interval_seconds)
+        self.patch_path = self.run_dir / CHECKPOINT_PATCH
+        self.meta_path = self.run_dir / CHECKPOINT_META
+        self._stop = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self._background_errors: list[str] = []
+
+    async def capture(
+        self,
+        env: Environment,
+        *,
+        reason: str,
+        exclude_paths: Sequence[str] = (),
+    ) -> CheckpointResult:
+        exclude_paths = tuple(exclude_paths) + self._artifact_exclude_paths(env)
+        try:
+            result = await env.exec_cmd(worktree_diff_command(exclude_paths), timeout=120)
+        except Exception as exc:  # noqa: BLE001
+            return self._write_failure(reason=reason, error=f"{type(exc).__name__}: {exc}")
+        if result.returncode != 0:
+            return self._write_failure(reason=reason, error=result.stderr[:1000])
+
+        patch = result.stdout
+        patch_bytes = len(patch.encode("utf-8", errors="surrogatepass"))
+        patch_sha = _patch_sha(patch)
+        preserved = self._has_existing_patch()
+        if patch.strip():
+            try:
+                _atomic_write(self.patch_path, patch)
+            except Exception as exc:  # noqa: BLE001
+                return self._write_failure(reason=reason, error=f"{type(exc).__name__}: {exc}")
+            preserved = False
+        meta = self._meta(
+            "written" if patch.strip() else "empty",
+            reason=reason,
+            patch_bytes=patch_bytes,
+            patch_sha256=patch_sha,
+            preserved_previous_patch=preserved and not patch.strip(),
+            submission_eligible=bool(patch.strip()),
+        )
+        self._write_meta(meta)
+        return CheckpointResult(
+            status=str(meta["status"]),
+            patch_bytes=patch_bytes,
+            patch_sha256=patch_sha,
+            reason=reason,
+            preserved_previous_patch=bool(meta["preserved_previous_patch"]),
+            submission_eligible=bool(meta["submission_eligible"]),
+        )
+
+    async def restore_latest(self, env: Environment) -> CheckpointResult:
+        if not self.patch_path.exists():
+            return CheckpointResult(status="missing", reason="restore")
+        patch = self.patch_path.read_text(encoding="utf-8", errors="replace")
+        if not patch.strip():
+            return CheckpointResult(status="empty", reason="restore")
+        meta = self._load_meta()
+        if isinstance(meta, dict) and meta.get("submission_eligible") is False:
+            return CheckpointResult(
+                status="skipped_not_submission_eligible",
+                patch_bytes=len(patch.encode("utf-8", errors="surrogatepass")),
+                patch_sha256=_patch_sha(patch),
+                reason="restore",
+                preserved_previous_patch=bool(meta.get("preserved_previous_patch")),
+                submission_eligible=False,
+            )
+        precheck = await env.exec_cmd(worktree_diff_command(self._artifact_exclude_paths(env)), timeout=120)
+        if precheck.returncode != 0:
+            return CheckpointResult(
+                status="failed",
+                reason="restore",
+                error=precheck.stderr[:1000],
+            )
+        if precheck.stdout.strip():
+            return CheckpointResult(
+                status="skipped_dirty_worktree",
+                patch_bytes=len(patch.encode("utf-8", errors="surrogatepass")),
+                patch_sha256=_patch_sha(patch),
+                reason="restore",
+                error="worktree already has changes",
+            )
+        recovery_patch_path = self._env_recovery_patch_path()
+        await env.write_file(recovery_patch_path, patch)
+        result = await env.exec_cmd(
+            f"git apply --binary --whitespace=nowarn {shlex.quote(recovery_patch_path)}",
+            timeout=120,
+        )
+        patch_bytes = len(patch.encode("utf-8", errors="surrogatepass"))
+        patch_sha = _patch_sha(patch)
+        if result.returncode == 0:
+            return CheckpointResult(
+                status="restored",
+                patch_bytes=patch_bytes,
+                patch_sha256=patch_sha,
+                reason="restore",
+                submission_eligible=True,
+            )
+        return CheckpointResult(
+            status="failed",
+            patch_bytes=patch_bytes,
+            patch_sha256=patch_sha,
+            reason="restore",
+            error=result.stderr[:1000],
+        )
+
+    async def start(self, env: Environment, *, exclude_paths: Sequence[str] = ()) -> None:
+        if self.interval_seconds <= 0:
+            return
+        if self._task is not None:
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run(env, exclude_paths=tuple(exclude_paths)))
+
+    async def stop(self, env: Environment, *, exclude_paths: Sequence[str] = ()) -> CheckpointResult:
+        if self._task is not None:
+            self._stop.set()
+            try:
+                await self._task
+            except Exception as exc:  # noqa: BLE001
+                self._background_errors.append(f"{type(exc).__name__}: {exc}")
+            finally:
+                self._task = None
+        result = await self.capture(env, reason="final", exclude_paths=exclude_paths)
+        if self._background_errors:
+            return CheckpointResult(
+                status=result.status,
+                patch_bytes=result.patch_bytes,
+                patch_sha256=result.patch_sha256,
+                reason=result.reason,
+                error=result.error,
+                preserved_previous_patch=result.preserved_previous_patch,
+                submission_eligible=result.submission_eligible,
+                background_errors=tuple(self._background_errors),
+            )
+        return result
+
+    async def _run(self, env: Environment, *, exclude_paths: Sequence[str]) -> None:
+        while True:
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self.interval_seconds)
+                return
+            except asyncio.TimeoutError:
+                result = await self.capture(env, reason="periodic", exclude_paths=exclude_paths)
+                if result.error:
+                    self._background_errors.append(result.error)
+
+    def _meta(
+        self,
+        status: str,
+        *,
+        reason: str,
+        patch_bytes: int = 0,
+        patch_sha256: str = "",
+        error: str = "",
+        preserved_previous_patch: bool = False,
+        submission_eligible: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "schema": "opencollab.swe_worktree_checkpoint.v1",
+            "status": status,
+            "reason": reason,
+            "captured_at": time.time(),
+            "checkpoint_interval_seconds": self.interval_seconds,
+            "loss_bound_seconds": self.interval_seconds,
+            "patch_path": str(self.patch_path),
+            "patch_bytes": patch_bytes,
+            "patch_sha256": patch_sha256,
+            "error": error,
+            "preserved_previous_patch": preserved_previous_patch,
+            "submission_eligible": submission_eligible,
+        }
+
+    def _has_existing_patch(self) -> bool:
+        try:
+            return bool(self.patch_path.read_text(encoding="utf-8", errors="replace").strip())
+        except OSError:
+            return False
+
+    def _artifact_exclude_paths(self, env: Environment) -> tuple[str, ...]:
+        workspace = getattr(env, "workspace", "") or ""
+        try:
+            root = Path(workspace).resolve(strict=False)
+        except OSError:
+            return ()
+
+        paths: list[str] = []
+        for artifact_path in (self.patch_path, self.meta_path):
+            try:
+                rel = artifact_path.resolve(strict=False).relative_to(root)
+            except (OSError, ValueError):
+                continue
+            paths.append(rel.as_posix())
+        return tuple(paths)
+
+    def _load_meta(self) -> dict[str, Any] | None:
+        try:
+            value = json.loads(self.meta_path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    def _env_recovery_patch_path(self) -> str:
+        digest = hashlib.sha256(str(self.run_dir.resolve(strict=False)).encode()).hexdigest()[:16]
+        return f"{ENV_RECOVERY_PATCH_PREFIX}{digest}.patch"
+
+    def _write_meta(self, meta: dict[str, Any]) -> None:
+        try:
+            _atomic_write(self.meta_path, json.dumps(meta, ensure_ascii=False, indent=2) + "\n")
+        except OSError:
+            pass
+
+    def _write_failure(self, *, reason: str, error: str) -> CheckpointResult:
+        preserved = self._has_existing_patch()
+        meta = self._meta(
+            "failed",
+            reason=reason,
+            error=error,
+            preserved_previous_patch=preserved,
+            submission_eligible=False,
+        )
+        self._write_meta(meta)
+        return CheckpointResult(
+            status="failed",
+            reason=reason,
+            error=error,
+            preserved_previous_patch=preserved,
+            submission_eligible=False,
+        )

--- a/opencollab/opencollab/harness/swe_eval_decision.py
+++ b/opencollab/opencollab/harness/swe_eval_decision.py
@@ -1,0 +1,189 @@
+"""Pure state decisions for SWE-bench generation and evaluation runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from opencollab.harness.swe_eval_records import (
+    metric_done_with_advisory_gap,
+    metric_status,
+    prediction_patch,
+    row_patch_sha,
+    row_record_id,
+)
+
+
+class TaskState(StrEnum):
+    NEEDS_GENERATION = "needs_generation"
+    GENERATION_ACTIVE = "generation_active"
+    EMPTY_PATCH_INVALID = "empty_patch_invalid"
+    BLOCKED_MISSING_METRIC = "blocked_missing_metric"
+    BLOCKED_METRIC_PAIRING = "blocked_metric_pairing"
+    WORKFLOW_INCOMPLETE = "workflow_incomplete"
+    WORKFLOW_FAILED = "workflow_failed"
+    READY_FOR_EVAL = "ready_for_eval"
+    EVAL_ACTIVE = "eval_active"
+    EVAL_DONE = "eval_done"
+    TECHNICAL_EVAL_FAILED = "technical_eval_failed"
+
+
+TERMINAL_WORKFLOW_STATUSES = {
+    "infra_invalid",
+    "budget_exceeded",
+    "timeout",
+    "patch_guard_failed",
+}
+
+TECHNICAL_EVAL_STATUSES = {
+    "technical_eval_failed",
+    "eval_failed",
+    "eval_start_failed",
+    "eval_driver_error",
+    "blocked_missing_eval_deps",
+    "blocked_missing_eval_image",
+    "blocked_missing_eval_spec",
+}
+
+
+@dataclass(frozen=True)
+class EvalReportSummary:
+    done_count: int = 0
+    active_count: int = 0
+    failed_count: int = 0
+    resolved_count: int = 0
+    unresolved_count: int = 0
+    ignored_patch_mismatch_count: int = 0
+    report_paths: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "done_count": self.done_count,
+            "active_count": self.active_count,
+            "failed_count": self.failed_count,
+            "resolved_count": self.resolved_count,
+            "unresolved_count": self.unresolved_count,
+            "ignored_patch_mismatch_count": self.ignored_patch_mismatch_count,
+            "report_paths": list(self.report_paths),
+        }
+
+
+@dataclass(frozen=True)
+class TaskSnapshot:
+    task_id: str
+    active_generation: bool = False
+    active_eval: bool = False
+    prediction: dict[str, Any] | None = None
+    metric: dict[str, Any] | None = None
+    metric_pairing: str = ""
+    eval_summary: EvalReportSummary = field(default_factory=EvalReportSummary)
+
+
+@dataclass(frozen=True)
+class TaskDecision:
+    task_id: str
+    state: TaskState
+    ready_for_eval: bool
+    terminal: bool
+    patch_len: int
+    patch_sha256: str
+    workflow_status: str
+    metric_pairing: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task": self.task_id,
+            "state": self.state.value,
+            "ready_for_eval": self.ready_for_eval,
+            "terminal": self.terminal,
+            "patch_len": self.patch_len,
+            "patch_sha256": self.patch_sha256,
+            "workflow_status": self.workflow_status,
+            "metric_pairing": self.metric_pairing,
+            "reason": self.reason,
+        }
+
+
+def official_eval_eligible(
+    *,
+    patch_len: int,
+    workflow_status: str,
+    active_generation: bool,
+    metric: dict[str, Any] | None,
+    allow_advisory_gap: bool = False,
+) -> bool:
+    if active_generation or patch_len <= 0:
+        return False
+    if workflow_status in {"done", "done_with_timeout_patch"} and not metric_done_with_advisory_gap(metric):
+        return True
+    if allow_advisory_gap and workflow_status in {"advisory_gap", "done"}:
+        return True
+    return False
+
+
+def decide_task(snapshot: TaskSnapshot, *, allow_advisory_gap: bool = False) -> TaskDecision:
+    patch = prediction_patch(snapshot.prediction)
+    patch_len = len(patch)
+    patch_sha = row_patch_sha(snapshot.prediction)
+    status = metric_status(snapshot.metric)
+
+    def decision(state: TaskState, reason: str, *, ready: bool = False, terminal: bool = False) -> TaskDecision:
+        return TaskDecision(
+            task_id=snapshot.task_id,
+            state=state,
+            ready_for_eval=ready,
+            terminal=terminal,
+            patch_len=patch_len,
+            patch_sha256=patch_sha,
+            workflow_status=status,
+            metric_pairing=snapshot.metric_pairing,
+            reason=reason,
+        )
+
+    if snapshot.active_generation:
+        return decision(TaskState.GENERATION_ACTIVE, "generation session is active")
+    if snapshot.prediction is None:
+        return decision(TaskState.NEEDS_GENERATION, "no prediction row")
+    if patch_len <= 0:
+        return decision(TaskState.EMPTY_PATCH_INVALID, "latest prediction has an empty patch", terminal=True)
+    if snapshot.metric is None:
+        if snapshot.metric_pairing.startswith("record_id_patch_sha"):
+            return decision(TaskState.BLOCKED_METRIC_PAIRING, snapshot.metric_pairing, terminal=True)
+        return decision(TaskState.BLOCKED_MISSING_METRIC, snapshot.metric_pairing or "missing metric")
+    if snapshot.active_eval or snapshot.eval_summary.active_count:
+        return decision(TaskState.EVAL_ACTIVE, "evaluation session is active")
+    if snapshot.eval_summary.done_count:
+        return decision(TaskState.EVAL_DONE, "matching evaluation report is done", terminal=True)
+    if snapshot.eval_summary.failed_count:
+        return decision(TaskState.TECHNICAL_EVAL_FAILED, "matching evaluation report failed", terminal=True)
+
+    ready = official_eval_eligible(
+        patch_len=patch_len,
+        workflow_status=status,
+        active_generation=snapshot.active_generation,
+        metric=snapshot.metric,
+        allow_advisory_gap=allow_advisory_gap,
+    )
+    if ready:
+        return decision(TaskState.READY_FOR_EVAL, "non-empty patch with terminal workflow metric", ready=True)
+    if status in TERMINAL_WORKFLOW_STATUSES:
+        return decision(TaskState.WORKFLOW_FAILED, status, terminal=True)
+    return decision(TaskState.WORKFLOW_INCOMPLETE, status or "workflow metric is not terminal")
+
+
+def task_status_row(snapshot: TaskSnapshot, *, allow_advisory_gap: bool = False) -> dict[str, Any]:
+    decision = decide_task(snapshot, allow_advisory_gap=allow_advisory_gap)
+    row = decision.to_dict()
+    checkpoint_result = {}
+    if isinstance(snapshot.metric, dict) and isinstance(snapshot.metric.get("checkpoint_result"), dict):
+        checkpoint_result = snapshot.metric["checkpoint_result"]
+    row.update(
+        {
+            "record_id": row_record_id(snapshot.prediction),
+            "eval": snapshot.eval_summary.to_dict(),
+            "checkpoint_result": checkpoint_result,
+        }
+    )
+    return row

--- a/opencollab/opencollab/harness/swe_eval_decision.py
+++ b/opencollab/opencollab/harness/swe_eval_decision.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum
 from typing import Any
 
 from opencollab.harness.swe_eval_records import (
@@ -15,7 +15,7 @@ from opencollab.harness.swe_eval_records import (
 )
 
 
-class TaskState(StrEnum):
+class TaskState(str, Enum):
     NEEDS_GENERATION = "needs_generation"
     GENERATION_ACTIVE = "generation_active"
     EMPTY_PATCH_INVALID = "empty_patch_invalid"

--- a/opencollab/opencollab/harness/swe_eval_discovery.py
+++ b/opencollab/opencollab/harness/swe_eval_discovery.py
@@ -1,0 +1,198 @@
+"""Read-only SWE-bench run discovery for thin status scripts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from opencollab.harness.swe_eval_decision import (
+    TECHNICAL_EVAL_STATUSES,
+    EvalReportSummary,
+    TaskSnapshot,
+)
+from opencollab.harness.swe_eval_records import (
+    latest_paired_rows,
+    patch_sha_matches,
+    read_jsonl,
+    row_patch_sha,
+    row_task_id,
+    task_ids,
+)
+
+
+@dataclass(frozen=True)
+class EvalReport:
+    task_id: str
+    patch_sha: str
+    status: str
+    resolved_count: int = 0
+    unresolved_count: int = 0
+    path: str = ""
+
+
+def _status_from_official_payload(task_id: str, payload: dict[str, Any]) -> tuple[str, int, int, str] | None:
+    item = payload.get(task_id)
+    if not isinstance(item, dict):
+        return None
+    patch_sha = str(item.get("patch_sha256") or item.get("patch_sha") or item.get("model_patch_sha256") or "")
+    status = str(item.get("status") or "")
+    if status in TECHNICAL_EVAL_STATUSES or item.get("error") is True:
+        return "technical_eval_failed", 0, 0, patch_sha
+    if not isinstance(item.get("resolved"), bool):
+        return None
+    resolved = 1 if item["resolved"] else 0
+    unresolved = 0 if item["resolved"] else 1
+    return "done", resolved, unresolved, patch_sha
+
+
+def _status_from_summary_payload(payload: dict[str, Any]) -> tuple[str, int, int]:
+    status = str(payload.get("status") or "")
+    resolved = payload.get("resolved_instances")
+    unresolved = payload.get("unresolved_instances")
+    if resolved is None and isinstance(payload.get("resolved_ids"), list):
+        resolved = len(payload["resolved_ids"])
+    if unresolved is None and isinstance(payload.get("unresolved_ids"), list):
+        unresolved = len(payload["unresolved_ids"])
+    return status, int(resolved or 0), int(unresolved or 0)
+
+
+def _report_from_json(path: Path) -> EvalReport | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    task_id = str(payload.get("instance_id") or payload.get("task_id") or "")
+    status = ""
+    resolved = 0
+    unresolved = 0
+    patch_sha = ""
+    if task_id:
+        status, resolved, unresolved = _status_from_summary_payload(payload)
+    else:
+        for key, value in payload.items():
+            if not isinstance(value, dict):
+                continue
+            official = _status_from_official_payload(str(key), payload)
+            if official is None:
+                continue
+            task_id = str(key)
+            status, resolved, unresolved, patch_sha = official
+            break
+    if not task_id:
+        return None
+    patch_sha = patch_sha or str(
+        payload.get("patch_sha256")
+        or payload.get("patch_sha")
+        or payload.get("model_patch_sha256")
+        or ""
+    )
+    return EvalReport(
+        task_id=task_id,
+        patch_sha=patch_sha,
+        status=status,
+        resolved_count=resolved,
+        unresolved_count=unresolved,
+        path=str(path),
+    )
+
+
+def _report_path_sort_key(path: Path) -> tuple[int, str]:
+    try:
+        mtime_ns = path.stat().st_mtime_ns
+    except OSError:
+        mtime_ns = 0
+    return mtime_ns, str(path)
+
+
+def discover_eval_reports(side_dir: Path) -> list[EvalReport]:
+    if not side_dir.exists():
+        return []
+    reports: list[EvalReport] = []
+    for path in sorted(side_dir.rglob("*.json"), key=_report_path_sort_key):
+        report = _report_from_json(path)
+        if report is not None:
+            reports.append(report)
+    return reports
+
+
+def summarize_eval_reports(
+    reports: list[EvalReport],
+    *,
+    task_id: str,
+    current_patch_sha: str,
+    active_eval: bool = False,
+) -> EvalReportSummary:
+    ignored = 0
+    latest: EvalReport | None = None
+    for report in reports:
+        if report.task_id != task_id:
+            continue
+        if current_patch_sha:
+            if not report.patch_sha or not patch_sha_matches(report.patch_sha, current_patch_sha):
+                ignored += 1
+                continue
+        if report.status == "done" or report.status in TECHNICAL_EVAL_STATUSES:
+            latest = report
+
+    done = int(latest is not None and latest.status == "done")
+    failed = int(latest is not None and latest.status in TECHNICAL_EVAL_STATUSES)
+    paths = [latest.path] if latest is not None and latest.path else []
+    return EvalReportSummary(
+        done_count=done,
+        active_count=1 if active_eval else 0,
+        failed_count=failed,
+        resolved_count=latest.resolved_count if done and latest is not None else 0,
+        unresolved_count=latest.unresolved_count if done and latest is not None else 0,
+        ignored_patch_mismatch_count=ignored,
+        report_paths=tuple(paths),
+    )
+
+
+def build_snapshots(
+    run_dir: Path,
+    *,
+    tasks: list[str] | None = None,
+    side_name: str = "official_eval_auto",
+    active_generation_tasks: set[str] | None = None,
+    active_eval_tasks: set[str] | None = None,
+) -> list[TaskSnapshot]:
+    predictions = read_jsonl(run_dir / "predictions.jsonl")
+    metrics = read_jsonl(run_dir / "metrics.jsonl")
+    selected_tasks = tasks or task_ids(predictions, metrics)
+    reports = discover_eval_reports(run_dir / side_name)
+    active_generation_tasks = active_generation_tasks or set()
+    active_eval_tasks = active_eval_tasks or set()
+    snapshots: list[TaskSnapshot] = []
+    for task_id in selected_tasks:
+        pair = latest_paired_rows(predictions, metrics, task_id)
+        current_sha = row_patch_sha(pair.prediction)
+        active_eval = task_id in active_eval_tasks
+        snapshots.append(
+            TaskSnapshot(
+                task_id=task_id,
+                active_generation=task_id in active_generation_tasks,
+                active_eval=active_eval,
+                prediction=pair.prediction,
+                metric=pair.metric,
+                metric_pairing=pair.status,
+                eval_summary=summarize_eval_reports(
+                    reports,
+                    task_id=task_id,
+                    current_patch_sha=current_sha,
+                    active_eval=active_eval,
+                ),
+            )
+        )
+    return snapshots
+
+
+def rows_by_task(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(row_task_id(row), []).append(row)
+    return grouped

--- a/opencollab/opencollab/harness/swe_eval_records.py
+++ b/opencollab/opencollab/harness/swe_eval_records.py
@@ -23,7 +23,10 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         if not line.strip():
             continue
-        value = json.loads(line)
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
         if isinstance(value, dict):
             rows.append(value)
     return rows

--- a/opencollab/opencollab/harness/swe_eval_records.py
+++ b/opencollab/opencollab/harness/swe_eval_records.py
@@ -1,0 +1,158 @@
+"""Small, pure helpers for SWE-bench prediction/metric records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PairedRows:
+    prediction: dict[str, Any] | None
+    metric: dict[str, Any] | None
+    status: str
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, dict):
+            rows.append(value)
+    return rows
+
+
+def prediction_patch(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return str(row.get("model_patch") or row.get("patch") or "")
+
+
+def row_task_id(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    for key in ("instance_id", "task_id", "id"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def row_record_id(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    for key in ("record_id", "attempt_id", "workflow_record_id"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def row_explicit_patch_sha(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    for key in ("patch_sha256", "patch_sha", "model_patch_sha256"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def patch_sha(patch: str) -> str:
+    if not patch:
+        return ""
+    return hashlib.sha256(patch.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def row_patch_sha(row: dict[str, Any] | None) -> str:
+    explicit = row_explicit_patch_sha(row)
+    if explicit:
+        return explicit
+    return patch_sha(prediction_patch(row))
+
+
+def patch_sha_matches(left: str | None, right: str | None) -> bool:
+    left_value = str(left or "")
+    right_value = str(right or "")
+    if not left_value or not right_value:
+        return False
+    return left_value.startswith(right_value) or right_value.startswith(left_value)
+
+
+def workflow_result(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    value = row.get("workflow_result")
+    return value if isinstance(value, dict) else {}
+
+
+def metric_status(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    result = workflow_result(row)
+    return str(row.get("workflow_status") or result.get("status") or "")
+
+
+def metric_done_with_advisory_gap(row: dict[str, Any] | None) -> bool:
+    if not isinstance(row, dict):
+        return False
+    result = workflow_result(row)
+    return bool(row.get("done_with_advisory_gap") or result.get("done_with_advisory_gap"))
+
+
+def task_ids(predictions: list[dict[str, Any]], metrics: list[dict[str, Any]]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for row in [*predictions, *metrics]:
+        task_id = row_task_id(row)
+        if task_id and task_id not in seen:
+            seen.add(task_id)
+            ordered.append(task_id)
+    return ordered
+
+
+def latest_paired_rows(
+    predictions: list[dict[str, Any]],
+    metrics: list[dict[str, Any]],
+    task_id: str,
+) -> PairedRows:
+    matched_predictions = [row for row in predictions if row_task_id(row) == task_id]
+    matched_metrics = [row for row in metrics if row_task_id(row) == task_id]
+    if not matched_predictions:
+        return PairedRows(None, matched_metrics[-1] if matched_metrics else None, "missing_prediction")
+
+    prediction = matched_predictions[-1]
+    record_id = row_record_id(prediction)
+    current_sha = row_patch_sha(prediction)
+
+    if record_id:
+        record_metrics = [row for row in matched_metrics if row_record_id(row) == record_id]
+        if record_metrics:
+            metric = record_metrics[-1]
+            metric_sha = row_patch_sha(metric)
+            if current_sha and metric_sha and not patch_sha_matches(metric_sha, current_sha):
+                return PairedRows(prediction, None, "record_id_patch_sha_mismatch")
+            if current_sha and not metric_sha:
+                return PairedRows(prediction, None, "record_id_patch_sha_missing")
+            return PairedRows(prediction, metric, "record_id")
+        return PairedRows(prediction, None, "missing_metric_for_record_id")
+
+    if current_sha:
+        for metric in reversed(matched_metrics):
+            metric_sha = row_patch_sha(metric)
+            if metric_sha and patch_sha_matches(metric_sha, current_sha):
+                return PairedRows(prediction, metric, "patch_sha")
+        if row_explicit_patch_sha(prediction):
+            return PairedRows(prediction, None, "missing_metric_for_patch_sha")
+
+    legacy_metrics = [row for row in matched_metrics if not row_record_id(row) and not row_explicit_patch_sha(row)]
+    if legacy_metrics:
+        return PairedRows(prediction, legacy_metrics[-1], "legacy_latest")
+    return PairedRows(prediction, None, "missing_metric")

--- a/opencollab/tests/test_docker_env.py
+++ b/opencollab/tests/test_docker_env.py
@@ -22,13 +22,23 @@ class FakeProc:
     def __init__(self, stdout=b"", stderr=b"", returncode=0, hang=False):
         self._stdout = stdout
         self._stderr = stderr
-        self.returncode = returncode
+        self.returncode = None if hang and returncode == 0 else returncode
         self._hang = hang
+        self.killed = False
+        self.communicated_input = None
 
-    async def communicate(self):
+    async def communicate(self, input=None):
+        self.communicated_input = input
         if self._hang:
             await asyncio.sleep(3600)
         return self._stdout, self._stderr
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
 
 
 class FakeDocker:
@@ -38,7 +48,7 @@ class FakeDocker:
         self.calls = []
         self._procs = list(procs or [])
 
-    async def __call__(self, *argv, stdout=None, stderr=None):
+    async def __call__(self, *argv, stdin=None, stdout=None, stderr=None):
         self.calls.append(list(argv))
         if self._procs:
             return self._procs.pop(0)
@@ -175,7 +185,8 @@ def test_callable_command_prefix_wraps_command(monkeypatch):
 
 
 def test_timeout_returns_default_negative_one(monkeypatch):
-    fake = FakeDocker([FakeProc(hang=True)])
+    proc = FakeProc(hang=True)
+    fake = FakeDocker([proc])
     patch_docker(monkeypatch, fake)
 
     env = DockerEnvironment(container_id="cid")
@@ -183,16 +194,42 @@ def test_timeout_returns_default_negative_one(monkeypatch):
 
     assert result.returncode == -1
     assert "timed out after 0.01s" in result.stderr
+    assert proc.killed
 
 
 def test_timeout_returncode_is_parameterized(monkeypatch):
-    fake = FakeDocker([FakeProc(hang=True)])
+    proc = FakeProc(hang=True)
+    fake = FakeDocker([proc])
     patch_docker(monkeypatch, fake)
 
     env = DockerEnvironment(container_id="cid", timeout_returncode=124)
     result = run(env.exec_cmd("sleep 999", timeout=0.01))
 
     assert result.returncode == 124
+    assert proc.killed
+
+
+def test_cancelled_exec_kills_docker_exec_process(monkeypatch):
+    async def scenario():
+        proc = FakeProc(hang=True)
+        fake = FakeDocker([proc])
+        patch_docker(monkeypatch, fake)
+        env = DockerEnvironment(container_id="cid")
+
+        task = asyncio.create_task(env.exec_cmd("sleep 999", timeout=60))
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if fake.calls:
+                break
+        assert fake.calls
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return proc.killed
+
+    assert run(scenario())
 
 
 def test_read_file_reads_via_cat(monkeypatch):
@@ -205,4 +242,33 @@ def test_read_file_reads_via_cat(monkeypatch):
     assert body == "file body"
     assert fake.calls == [
         ["docker", "exec", "cid", "bash", "-c", "cat -- /testbed/a.py"]
+    ]
+
+
+def test_write_file_streams_content_over_stdin(monkeypatch):
+    content = "x" * 200_000
+    write_proc = FakeProc(returncode=0)
+    fake = FakeDocker([write_proc, FakeProc(stdout=content.encode(), returncode=0)])
+    patch_docker(monkeypatch, fake)
+
+    env = DockerEnvironment(container_id="cid", exec_workdir="/testbed")
+    run(env.write_file("big.txt", content))
+
+    assert fake.calls[0] == [
+        "docker",
+        "exec",
+        "-i",
+        "-w",
+        "/testbed",
+        "cid",
+        "bash",
+        "-c",
+        'mkdir -p -- "$(dirname -- "$1")" && cat > "$1"',
+        "opencollab-write",
+        "big.txt",
+    ]
+    assert write_proc.communicated_input == content.encode()
+    assert content not in " ".join(fake.calls[0])
+    assert fake.calls[1] == [
+        "docker", "exec", "-w", "/testbed", "cid", "bash", "-c", "cat -- big.txt"
     ]

--- a/opencollab/tests/test_evaluator.py
+++ b/opencollab/tests/test_evaluator.py
@@ -17,6 +17,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def is_worktree_diff_cmd(cmd: str) -> bool:
+    return "git diff --cached --binary HEAD" in cmd
+
+
 class FakeLLMClient:
     def __init__(self, *args, **kwargs):
         self.calls = []
@@ -39,7 +43,7 @@ class FakeEnv(Environment):
 
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
         self.cmds.append(cmd)
-        if cmd.startswith("git diff"):
+        if is_worktree_diff_cmd(cmd) or cmd.startswith("git diff"):
             return ExecResult(returncode=0, stdout=self.diff, stderr="")
         return ExecResult(returncode=0, stdout="", stderr="")
 
@@ -84,6 +88,36 @@ def test_run_eval_task_empty_diff_not_produced(monkeypatch, tmp_path):
 
     assert result.patch_produced is False
     assert result.patch == ""
+
+
+def test_run_eval_task_staged_extraction_includes_new_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(container, "LLMClient", FakeLLMClient)
+    env = FakeEnv(
+        diff=(
+            "diff --git a/new_module.py b/new_module.py\n"
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            "+++ b/new_module.py\n"
+            "@@ -0,0 +1 @@\n"
+            "+value = 1\n"
+        )
+    )
+
+    async def env_factory(task):
+        return env
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="new-file", description="add file"),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+        )
+    )
+
+    assert any(is_worktree_diff_cmd(cmd) for cmd in env.cmds)
+    assert "new file mode" in result.patch
+    assert result.patch_produced is True
 
 
 def test_run_eval_task_honors_injected_params(monkeypatch, tmp_path):
@@ -292,7 +326,7 @@ class InjectFakeEnv(Environment):
             path = cmd[len("git clean -fq -- "):].strip().strip("'\"")
             self.cleaned.add(path)
             return ExecResult(returncode=0, stdout="", stderr="")
-        if cmd.startswith("git diff"):
+        if is_worktree_diff_cmd(cmd) or cmd.startswith("git diff"):
             parts = [f"diff --git a/{self.src_path} b/{self.src_path}\n+fix\n"]
             if self._leaks(self.mod_path, untracked=False):
                 parts.append(f"diff --git a/{self.mod_path} b/{self.mod_path}\n+assert thing\n")

--- a/opencollab/tests/test_evaluator_workflow.py
+++ b/opencollab/tests/test_evaluator_workflow.py
@@ -30,6 +30,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def is_worktree_diff_cmd(cmd: str) -> bool:
+    return "git diff --cached --binary HEAD" in cmd
+
+
 class FakeEnv(Environment):
     def __init__(self, diff="diff --git a/x b/x\n+new\n"):
         self.diff = diff
@@ -38,12 +42,33 @@ class FakeEnv(Environment):
 
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
         self.cmds.append(cmd)
-        if cmd.startswith("git diff"):
+        if is_worktree_diff_cmd(cmd) or cmd.startswith("git diff"):
             return ExecResult(returncode=0, stdout=self.diff, stderr="")
         return ExecResult(returncode=0, stdout="", stderr="")
 
     async def cleanup(self) -> None:
         self.cleaned_up = True
+
+
+class CheckpointEnv(FakeEnv):
+    def __init__(self, diff="diff --git a/x b/x\n+checkpoint\n", diff_outputs=None):
+        super().__init__(diff=diff)
+        self.writes: list[tuple[str, str]] = []
+        self.diff_outputs = list(diff_outputs or [])
+
+    async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
+        self.cmds.append(cmd)
+        if is_worktree_diff_cmd(cmd):
+            stdout = self.diff_outputs.pop(0) if self.diff_outputs else self.diff
+            return ExecResult(returncode=0, stdout=stdout, stderr="")
+        if cmd.startswith("git apply"):
+            return ExecResult(returncode=0, stdout="", stderr="")
+        if cmd.startswith("git diff"):
+            return ExecResult(returncode=0, stdout=self.diff, stderr="")
+        return ExecResult(returncode=0, stdout="", stderr="")
+
+    async def write_file(self, path: str, content: str) -> None:
+        self.writes.append((path, content))
 
 
 class FakeSession:
@@ -198,6 +223,334 @@ def test_workflow_mode_writes_per_task_run_folder(tmp_path):
     assert manifest["workflow"] == "wf"
     assert manifest["task_id"] == "wf1"
     assert manifest["sessions"] == 1
+
+
+def test_workflow_checkpoint_writes_bounded_loss_patch(tmp_path):
+    env = CheckpointEnv()
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="ckpt", description="x"),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+        )
+    )
+
+    run_dir = tmp_path / "trajectories" / "ckpt"
+    patch_path = run_dir / "checkpoint.worktree.patch"
+    meta = json.loads((run_dir / "checkpoint.worktree.json").read_text(encoding="utf-8"))
+    assert patch_path.read_text(encoding="utf-8") == env.diff
+    assert meta["status"] == "written"
+    assert meta["reason"] == "final"
+    assert meta["loss_bound_seconds"] == 300
+    assert meta["submission_eligible"] is True
+    assert result.checkpoint_result["final"]["status"] == "written"
+
+
+def test_workflow_checkpoint_restore_applies_before_test_injection(tmp_path):
+    env = CheckpointEnv(diff_outputs=["", "diff --git a/x b/x\n+after\n"])
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    run_dir = tmp_path / "trajectories" / "restore"
+    run_dir.mkdir(parents=True)
+    checkpoint_patch = "diff --git a/pkg/a.py b/pkg/a.py\n+restored\n"
+    (run_dir / "checkpoint.worktree.patch").write_text(checkpoint_patch, encoding="utf-8")
+
+    result = run(
+        run_eval_task(
+            EvalTask(
+                task_id="restore",
+                description="x",
+                extras={
+                    "test_patch": (
+                        "diff --git a/tests/test_x.py b/tests/test_x.py\n"
+                        "--- a/tests/test_x.py\n"
+                        "+++ b/tests/test_x.py\n"
+                        "@@ -0,0 +1 @@\n"
+                        "+test\n"
+                    ),
+                },
+            ),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+            resume_from_checkpoint=True,
+        )
+    )
+
+    recovery_path, recovery_content = env.writes[0]
+    assert recovery_path.startswith("/tmp/opencollab-checkpoint-recovery-")
+    assert recovery_path.endswith(".patch")
+    assert recovery_content == checkpoint_patch
+    restore_index = next(i for i, cmd in enumerate(env.cmds) if cmd.startswith("git apply"))
+    test_injection_index = next(i for i, cmd in enumerate(env.cmds) if "opencollab_test_patch" in cmd)
+    assert restore_index < test_injection_index
+    assert result.checkpoint_result["restore"]["status"] == "restored"
+
+
+def test_workflow_checkpoint_restore_skips_dirty_worktree(tmp_path):
+    env = CheckpointEnv(diff_outputs=["diff --git a/dirty b/dirty\n+dirty\n"])
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    run_dir = tmp_path / "trajectories" / "dirty"
+    run_dir.mkdir(parents=True)
+    (run_dir / "checkpoint.worktree.patch").write_text(
+        "diff --git a/pkg/a.py b/pkg/a.py\n+restored\n",
+        encoding="utf-8",
+    )
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="dirty", description="x"),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+            resume_from_checkpoint=True,
+        )
+    )
+
+    assert result.checkpoint_result["restore"]["status"] == "skipped_dirty_worktree"
+    assert not any(cmd.startswith("git apply") for cmd in env.cmds)
+
+
+def test_workflow_checkpoint_restore_uses_nonempty_patch_when_metadata_is_corrupt(tmp_path):
+    env = CheckpointEnv(diff_outputs=["", "diff --git a/x b/x\n+after\n"])
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    run_dir = tmp_path / "trajectories" / "corrupt"
+    run_dir.mkdir(parents=True)
+    checkpoint_patch = "diff --git a/pkg/a.py b/pkg/a.py\n+restored\n"
+    (run_dir / "checkpoint.worktree.patch").write_text(checkpoint_patch, encoding="utf-8")
+    (run_dir / "checkpoint.worktree.json").write_text("{bad json", encoding="utf-8")
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="corrupt", description="x"),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+            resume_from_checkpoint=True,
+        )
+    )
+
+    assert result.checkpoint_result["restore"]["status"] == "restored"
+    recovery_path, recovery_content = env.writes[0]
+    assert recovery_path.startswith("/tmp/opencollab-checkpoint-recovery-")
+    assert recovery_path.endswith(".patch")
+    assert recovery_content == checkpoint_patch
+
+
+def test_workflow_checkpoint_restore_path_is_private_per_run_dir(tmp_path):
+    first_env = CheckpointEnv(diff_outputs=["", "diff --git a/x b/x\n+after\n"])
+    second_env = CheckpointEnv(diff_outputs=["", "diff --git a/x b/x\n+after\n"])
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    for task_id, env in (("first", first_env), ("second", second_env)):
+        run_dir = tmp_path / "trajectories" / task_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "checkpoint.worktree.patch").write_text(
+            "diff --git a/pkg/a.py b/pkg/a.py\n+restored\n",
+            encoding="utf-8",
+        )
+
+        async def env_factory(task, env=env):
+            return env
+
+        run(
+            run_eval_task(
+                EvalTask(task_id=task_id, description="x"),
+                output_dir=str(tmp_path),
+                tools_factory=list,
+                env_factory=env_factory,
+                workflow=wf,
+                checkpoint_interval_seconds=300,
+                resume_from_checkpoint=True,
+            )
+        )
+
+    assert first_env.writes[0][0] != second_env.writes[0][0]
+    assert first_env.writes[0][0].startswith("/tmp/opencollab-checkpoint-recovery-")
+    assert second_env.writes[0][0].startswith("/tmp/opencollab-checkpoint-recovery-")
+
+
+def test_workflow_checkpoint_restore_respects_ineligible_metadata(tmp_path):
+    env = CheckpointEnv()
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    run_dir = tmp_path / "trajectories" / "ineligible"
+    run_dir.mkdir(parents=True)
+    (run_dir / "checkpoint.worktree.patch").write_text(
+        "diff --git a/pkg/a.py b/pkg/a.py\n+old\n",
+        encoding="utf-8",
+    )
+    (run_dir / "checkpoint.worktree.json").write_text(
+        json.dumps({"submission_eligible": False, "preserved_previous_patch": True}),
+        encoding="utf-8",
+    )
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="ineligible", description="x"),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+            resume_from_checkpoint=True,
+        )
+    )
+
+    assert result.checkpoint_result["restore"]["status"] == "skipped_not_submission_eligible"
+    assert not env.writes
+
+
+def test_workflow_checkpoint_excludes_injected_test_paths(tmp_path):
+    env = CheckpointEnv()
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    run(
+        run_eval_task(
+            EvalTask(
+                task_id="exclude",
+                description="x",
+                extras={
+                    "test_patch": (
+                        "diff --git a/tests/test_x.py b/tests/test_x.py\n"
+                        "--- a/tests/test_x.py\n"
+                        "+++ b/tests/test_x.py\n"
+                        "@@ -0,0 +1 @@\n"
+                        "+test\n"
+                    ),
+                },
+            ),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+        )
+    )
+
+    checkpoint_cmds = [cmd for cmd in env.cmds if "git diff --cached --binary HEAD" in cmd]
+    assert checkpoint_cmds
+    assert "git reset -q HEAD -- tests/test_x.py" in checkpoint_cmds[-1]
+
+
+def test_workflow_checkpoint_excludes_own_artifacts_inside_workspace(tmp_path):
+    env = CheckpointEnv(diff_outputs=["", "diff --git a/x b/x\n+after\n"])
+    env.workspace = str(tmp_path)
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    output_dir = tmp_path / "eval_results"
+    run_dir = output_dir / "trajectories" / "inside"
+    run_dir.mkdir(parents=True)
+    checkpoint_patch = "diff --git a/pkg/a.py b/pkg/a.py\n+restored\n"
+    (run_dir / "checkpoint.worktree.patch").write_text(checkpoint_patch, encoding="utf-8")
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="inside", description="x"),
+            output_dir=str(output_dir),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+            resume_from_checkpoint=True,
+        )
+    )
+
+    checkpoint_cmds = [cmd for cmd in env.cmds if "git diff --cached --binary HEAD" in cmd]
+    assert checkpoint_cmds
+    assert result.checkpoint_result["restore"]["status"] == "restored"
+    assert "git reset -q HEAD -- eval_results/trajectories/inside/checkpoint.worktree.patch" in checkpoint_cmds[0]
+    assert "git reset -q HEAD -- eval_results/trajectories/inside/checkpoint.worktree.json" in checkpoint_cmds[0]
+
+
+def test_workflow_checkpoint_capture_failure_preserves_previous_patch(tmp_path):
+    class FailingCheckpointEnv(CheckpointEnv):
+        async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
+            self.cmds.append(cmd)
+            if "git diff --cached --binary HEAD" in cmd:
+                return ExecResult(returncode=1, stdout="", stderr="diff failed")
+            return ExecResult(returncode=0, stdout="", stderr="")
+
+    env = FailingCheckpointEnv()
+
+    async def env_factory(task):
+        return env
+
+    async def wf(ctx, args):
+        return {"status": "done"}
+
+    run_dir = tmp_path / "trajectories" / "preserve"
+    run_dir.mkdir(parents=True)
+    old_patch = "diff --git a/pkg/a.py b/pkg/a.py\n+old\n"
+    (run_dir / "checkpoint.worktree.patch").write_text(old_patch, encoding="utf-8")
+
+    result = run(
+        run_eval_task(
+            EvalTask(task_id="preserve", description="x"),
+            output_dir=str(tmp_path),
+            tools_factory=list,
+            env_factory=env_factory,
+            workflow=wf,
+            checkpoint_interval_seconds=300,
+        )
+    )
+
+    meta = json.loads((run_dir / "checkpoint.worktree.json").read_text(encoding="utf-8"))
+    assert (run_dir / "checkpoint.worktree.patch").read_text(encoding="utf-8") == old_patch
+    assert meta["status"] == "failed"
+    assert meta["preserved_previous_patch"] is True
+    assert meta["submission_eligible"] is False
+    assert result.patch_produced is False
 
 
 def test_eval_factory_threads_per_role_transcript_path(monkeypatch, tmp_path):

--- a/opencollab/tests/test_gen_prediction_workflow.py
+++ b/opencollab/tests/test_gen_prediction_workflow.py
@@ -7,8 +7,14 @@ module from the repo-root ``swebench/`` dir, the same way the script bootstraps.
 
 from __future__ import annotations
 
+import asyncio
+import os
+import shlex
+import shutil
+import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -211,6 +217,112 @@ def test_extract_patch_guarded_reextracts_after_cleanup(monkeypatch):
     assert patch == "diff --git a/pkg/widget.py b/pkg/widget.py"
 
 
+def test_cleanup_patch_paths_command_has_legacy_git_fallbacks():
+    cmd = gpw._cleanup_patch_paths_command(["yarn.lock", "tmp/check file.py"])
+
+    assert "git restore --staged --worktree --" in cmd
+    assert "git reset -q HEAD --" in cmd
+    assert "git checkout --" in cmd
+    assert "git clean -fdq --" in cmd
+    assert "'tmp/check file.py'" in cmd
+
+
+def test_cleanup_patch_paths_command_removes_tracked_noise_without_touching_allowed(tmp_path):
+    real_git = shutil.which("git")
+    if not real_git:
+        pytest.skip("git unavailable")
+
+    repo = tmp_path
+
+    def run(args):
+        return subprocess.run(args, cwd=repo, text=True, capture_output=True, check=True)
+
+    run(["git", "init"])
+    (repo / "pkg.py").write_text("old\n", encoding="utf-8")
+    (repo / "yarn.lock").write_text("lock\n", encoding="utf-8")
+    run(["git", "add", "pkg.py", "yarn.lock"])
+    run(["git", "-c", "user.name=OpenCollab", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+    (repo / "pkg.py").write_text("new\n", encoding="utf-8")
+    (repo / "yarn.lock").write_text("rewritten\n", encoding="utf-8")
+    run(["git", "add", "pkg.py", "yarn.lock"])
+
+    subprocess.run(
+        ["bash", "-lc", gpw._cleanup_patch_paths_command(["yarn.lock"])],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    staged = run(["git", "diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged == ["pkg.py"]
+    assert (repo / "pkg.py").read_text(encoding="utf-8") == "new\n"
+    assert (repo / "yarn.lock").read_text(encoding="utf-8") == "lock\n"
+
+
+def test_cleanup_patch_paths_command_falls_back_when_git_restore_is_missing(tmp_path):
+    real_git = shutil.which("git")
+    if not real_git:
+        pytest.skip("git unavailable")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "if [ \"$1\" = \"restore\" ]; then",
+                "  echo 'git restore unavailable' >&2",
+                "  exit 1",
+                "fi",
+                f"exec {shlex.quote(real_git)} \"$@\"",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    fake_env = {**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+    def run(args, *, env=None):
+        return subprocess.run(
+            args,
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+    run([real_git, "init"])
+    (repo / "pkg.py").write_text("old\n", encoding="utf-8")
+    (repo / "yarn.lock").write_text("lock\n", encoding="utf-8")
+    run([real_git, "add", "pkg.py", "yarn.lock"])
+    run([real_git, "-c", "user.name=OpenCollab", "-c", "user.email=test@example.com", "commit", "-m", "init"])
+
+    (repo / "pkg.py").write_text("new\n", encoding="utf-8")
+    (repo / "yarn.lock").write_text("rewritten\n", encoding="utf-8")
+    run([real_git, "add", "pkg.py", "yarn.lock"])
+
+    subprocess.run(
+        ["bash", "-lc", gpw._cleanup_patch_paths_command(["yarn.lock"])],
+        cwd=repo,
+        env=fake_env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    staged = run([real_git, "diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged == ["pkg.py"]
+    assert (repo / "pkg.py").read_text(encoding="utf-8") == "new\n"
+    assert (repo / "yarn.lock").read_text(encoding="utf-8") == "lock\n"
+
+
 def test_json_safe_degrades_unknown_objects():
     class Thing:
         def __str__(self):
@@ -252,3 +364,131 @@ def test_evaltask_contract_matches_non_blind_extras():
         "tests/test_widget.py::test_empty",
         "tests/test_widget.py::test_none",
     ]
+
+
+def test_generate_forwards_checkpoint_options(monkeypatch, tmp_path):
+    captured = {}
+
+    async def fake_run_eval_task(task, **kwargs):
+        captured["task"] = task
+        captured["kwargs"] = kwargs
+        return EvalResult(
+            task_id=task.task_id,
+            patch="diff --git a/pkg/a.py b/pkg/a.py\n+fixed\n",
+            patch_produced=True,
+            tokens_used=1,
+            steps=1,
+            duration=1.0,
+            workflow_result={"allowed_patch_paths": ["pkg/a.py"]},
+        )
+
+    monkeypatch.setattr(gpw, "run_eval_task", fake_run_eval_task)
+    monkeypatch.setattr(gpw.gp, "start_container", lambda image, name: "cid")
+    monkeypatch.setattr(gpw.gp, "remove_container_and_clear_marker", lambda run_dir, cid: True)
+    monkeypatch.setattr(
+        gpw,
+        "extract_patch_guarded",
+        lambda *args, **kwargs: ("diff --git a/pkg/a.py b/pkg/a.py\n+fixed\n", []),
+    )
+    args = SimpleNamespace(
+        timeout=10,
+        budget=1000,
+        max_steps=3,
+        keep_container=False,
+        blind_validation=False,
+        checkpoint_interval_seconds=300,
+        resume=True,
+        output=str(tmp_path / "predictions.jsonl"),
+    )
+    cfg = {
+        "model": "m",
+        "provider": "openai",
+        "api_key": "k",
+        "base_url": "http://local",
+        "temperature": 0.0,
+        "thinking": False,
+    }
+
+    patch, metrics = asyncio.run(
+        gpw.generate(FIXTURE, "image", cfg, args, gpw.generate_review_fix, "generate_review_fix")
+    )
+
+    assert patch.strip()
+    assert metrics["checkpoint_result"] is None
+    assert captured["kwargs"]["checkpoint_interval_seconds"] == 300
+    assert captured["kwargs"]["resume_from_checkpoint"] is True
+
+
+def test_generate_marks_non_error_patch_as_done(monkeypatch):
+    async def fake_run_eval_task(task, **kwargs):
+        return EvalResult(
+            task_id=task.task_id,
+            patch="diff --git a/pkg/a.py b/pkg/a.py\n+fixed\n",
+            patch_produced=True,
+            tokens_used=1,
+            steps=1,
+            duration=1.0,
+            workflow_result={},
+        )
+
+    monkeypatch.setattr(gpw, "run_eval_task", fake_run_eval_task)
+    monkeypatch.setattr(gpw.gp, "start_container", lambda image, name: "cid")
+    monkeypatch.setattr(gpw.gp, "remove_container_and_clear_marker", lambda run_dir, cid: True)
+    monkeypatch.setattr(
+        gpw,
+        "extract_patch_guarded",
+        lambda *args, **kwargs: ("diff --git a/pkg/a.py b/pkg/a.py\n+fixed\n", []),
+    )
+    args = SimpleNamespace(
+        timeout=10,
+        budget=1000,
+        max_steps=3,
+        keep_container=False,
+        blind_validation=False,
+        checkpoint_interval_seconds=0,
+        resume=False,
+        output="predictions.jsonl",
+    )
+    cfg = {
+        "model": "m",
+        "provider": "openai",
+        "api_key": "k",
+        "base_url": "http://local",
+        "temperature": 0.0,
+        "thinking": False,
+    }
+
+    _patch, metrics = asyncio.run(
+        gpw.generate(FIXTURE, "image", cfg, args, gpw.generate_review_fix, "generate_review_fix")
+    )
+
+    assert metrics["workflow_status"] == "done"
+
+
+def test_container_marker_survives_failed_remove(monkeypatch, tmp_path):
+    gpw.gp.write_container_marker(tmp_path, "cid123", "name123")
+    monkeypatch.setattr(gpw.gp, "remove_container", lambda cid: False)
+
+    removed = gpw.gp.remove_container_and_clear_marker(tmp_path, "cid123")
+
+    assert removed is False
+    assert (tmp_path / "container.id").read_text(encoding="utf-8") == "cid123\n"
+    assert (tmp_path / "container.name").read_text(encoding="utf-8") == "name123\n"
+
+
+def test_output_records_share_record_id_and_patch_sha():
+    patch = "diff --git a/pkg/a.py b/pkg/a.py\n+fixed\n"
+
+    prediction, metrics = gpw.build_output_records(
+        instance_id="task-1",
+        model_name="model",
+        patch=patch,
+        metrics={"workflow_status": "done"},
+        record_id="record-1",
+    )
+
+    assert prediction["record_id"] == "record-1"
+    assert metrics["record_id"] == "record-1"
+    assert prediction["patch_sha256"] == gpw._patch_sha256(patch)
+    assert metrics["patch_sha256"] == prediction["patch_sha256"]
+    assert metrics["instance_id"] == prediction["instance_id"]

--- a/opencollab/tests/test_run_tests_tool.py
+++ b/opencollab/tests/test_run_tests_tool.py
@@ -219,6 +219,38 @@ def test_run_tests_honors_runner_options_and_safety_policy():
     assert safety.cmd_calls == [(expected, None)]
 
 
+def test_run_tests_can_disable_runner_override_before_exec():
+    env = FakeEnv(stdout=PASS_OUTPUT)
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        RunTestsTool(allow_runner_override=False).execute_with_runtime(
+            {"runner": "python -c 'open(\"pwned\", \"w\").write(\"x\")'"},
+            runtime,
+        )
+    )
+
+    assert "runner override is disabled" in result
+    assert "Omit `runner`" in result
+    assert "Go go.mod" in result
+    assert env.exec_calls == []
+
+
+def test_run_tests_can_disable_extra_args_before_exec():
+    env = FakeEnv(stdout=PASS_OUTPUT)
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        RunTestsTool(allow_extra_args=False).execute_with_runtime(
+            {"extra_args": "; touch pwned"},
+            runtime,
+        )
+    )
+
+    assert result == "Error: extra_args is disabled for this run_tests tool."
+    assert env.exec_calls == []
+
+
 def test_run_tests_pytest_path_emits_green_verdict():
     env = FakeEnv(stdout=PASS_OUTPUT)
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
@@ -269,6 +301,66 @@ def test_run_tests_falls_back_to_native_runner_when_pytest_missing():
     assert "Verdict: GREEN" in result
 
 
+def test_run_tests_falls_back_to_go_runner_when_pytest_missing():
+    env = ScriptedEnv([
+        ("python -m pytest", 1, "No module named pytest"),
+        ("test -f go.mod", 0, ""),
+        ("go test ./internal/server", 0, "ok\tmodule/internal/server\t0.01s"),
+    ])
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        RunTestsTool(allow_runner_override=False, allow_extra_args=False).execute_with_runtime(
+            {"target": "internal/server"}, runtime
+        )
+    )
+
+    cmds = [c for c, _ in env.exec_calls]
+    assert any("go test ./internal/server" in c for c in cmds)
+    assert "runner override is disabled" not in result
+    assert "Verdict: GREEN" in result
+
+
+def test_run_tests_falls_back_to_go_runner_when_pytest_finds_no_tests():
+    env = ScriptedEnv([
+        ("python -m pytest", 5, "no tests ran in 0.01s"),
+        ("test -f go.mod", 0, ""),
+        ("go test ./internal/server", 0, "ok\tmodule/internal/server\t0.01s"),
+    ])
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        RunTestsTool(allow_runner_override=False, allow_extra_args=False).execute_with_runtime(
+            {"target": "internal/server"}, runtime
+        )
+    )
+
+    cmds = [c for c, _ in env.exec_calls]
+    assert any("go test ./internal/server" in c for c in cmds)
+    assert "no tests ran" not in result
+    assert "Verdict: GREEN" in result
+
+
+def test_run_tests_native_fallback_quotes_translated_target():
+    env = ScriptedEnv([
+        ("python -m pytest", 1, "No module named pytest"),
+        ("test -x bin/test", 0, ""),
+        ("python bin/test", 0, "tests passed"),
+    ])
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        RunTestsTool(allow_runner_override=False, allow_extra_args=False).execute_with_runtime(
+            {"target": "tests/test_x.py::test_two; touch pwned"}, runtime
+        )
+    )
+
+    cmds = [c for c, _ in env.exec_calls]
+    native = next(c for c in cmds if "python bin/test" in c)
+    assert native == "python bin/test tests/test_x.py 'test_two; touch pwned'"
+    assert "Verdict: GREEN" in result
+
+
 def test_run_tests_pinned_runner_suppresses_autodetect():
     env = ScriptedEnv([("bin/test", 0, "ok")])
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
@@ -308,6 +400,44 @@ def test_build_command_native_runner_omits_pytest_flags_and_translates():
     cmd = _build_command("python bin/test", "tests/test_x.py::test_two", "")
     assert "--tb=short" not in cmd and "-rA" not in cmd
     assert "::" not in cmd and "test_two" in cmd
+
+
+def test_build_command_native_runner_quotes_translated_target():
+    from opencollab.adapters.tools.run_tests import _build_command
+    cmd = _build_command("python bin/test", "tests/test_x.py::test_two; touch pwned", "")
+    assert cmd == "python bin/test tests/test_x.py 'test_two; touch pwned'"
+
+
+def test_build_command_go_runner_translates_package_and_test_name():
+    from opencollab.adapters.tools.run_tests import _build_command
+    cmd = _build_command("go test", "internal/server/evaluator_test.go::TestEvaluate", "")
+    assert cmd == (
+        "PATH=/usr/local/go/bin:/usr/lib/go/bin:/opt/go/bin:$PATH "
+        "go test ./internal/server -run TestEvaluate"
+    )
+
+
+def test_build_command_go_runner_translates_multiple_packages():
+    from opencollab.adapters.tools.run_tests import _build_command
+    cmd = _build_command("go test", "./internal/server/... ./rpc/flipt/...", "-count=1")
+    assert cmd == (
+        "PATH=/usr/local/go/bin:/usr/lib/go/bin:/opt/go/bin:$PATH "
+        "go test ./internal/server/... ./rpc/flipt/... -count=1"
+    )
+
+
+def test_go_runner_command_not_found_is_not_reported_as_pytest_missing():
+    from opencollab.adapters.tools.run_tests import _format_report
+    result = _format_report(
+        "go test ./...",
+        127,
+        "bash: line 2: go: command not found",
+        runner="go test",
+        green=False,
+    )
+    assert "pytest not found" not in result
+    assert "go: command not found" in result
+    assert "Verdict: RED" in result
 
 
 def test_run_tests_requires_execution_environment():

--- a/opencollab/tests/test_session_run_loop.py
+++ b/opencollab/tests/test_session_run_loop.py
@@ -8,6 +8,7 @@ from opencollab.application.event_bus import EventBus
 from opencollab.application.session_run import (
     READS_NUDGE_HARD,
     READS_NUDGE_SOFT,
+    PendingStep,
     SessionRunUseCase,
 )
 from opencollab.domain.pending import RowKind, RowStatus
@@ -260,6 +261,24 @@ def test_run_loop_cancel_event_appends_interrupt_and_sets_phase():
     assert events == [("error", {"reason": "cancelled", "aid": -1})]
 
 
+def test_run_loop_loop_block_limit_stops_before_next_llm_call():
+    events, bus = collect_events()
+    state = SessionState(
+        messages=[{"role": "system", "content": "sys"}],
+        loop_blocked_since_progress=3,
+    )
+    llm = FakeLLM()
+    runner = build_runner(state=state, llm=llm, event_bus=bus)
+
+    result = run(runner.run_loop())
+
+    assert result == ""
+    assert llm.calls == []
+    assert state.phase is SessionPhase.STEP_LIMIT_EXCEEDED
+    assert state.terminal_reason == "loop block limit reached: 3 repeated tool calls"
+    assert events == [("error", {"reason": "loop_blocked", "aid": -1})]
+
+
 def test_run_loop_llm_step_events_trace_and_message_shape():
     events, bus = collect_events()
     schemas = [{"type": "function", "function": {"name": "fake_tool"}}]
@@ -333,9 +352,26 @@ class _ToolStub:
         self.name = name
 
 
+def _tool_schema(name):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
 def _agent_with_tools(*names):
     agent = FakeAgent()
     agent.tools = [_ToolStub(n) for n in names]
+    return agent
+
+
+def _agent_with_tool_schemas(*names):
+    agent = FakeAgent([_tool_schema(name) for name in names])
+    agent.tools = [_ToolStub(name) for name in names]
     return agent
 
 
@@ -419,6 +455,225 @@ def test_steering_hard_rung_forces_tool_choice_through_run_loop():
     run(runner.run_loop())
 
     assert llm.calls[0]["tool_choice"] == "required"
+
+
+def test_steering_hard_rung_limits_provider_tools_to_writes():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_HARD,
+    )
+    llm = FakeLLM([llm_response(content="done")])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        agent=_agent_with_tool_schemas(
+            "file_read",
+            "grep",
+            "file_write",
+            "apply_patch",
+            "run_tests",
+        ),
+    )
+
+    run(runner.run_loop())
+
+    sent_tool_names = [spec["function"]["name"] for spec in llm.calls[0]["tools"]]
+    assert llm.calls[0]["tool_choice"] == "required"
+    assert sent_tool_names == ["file_write", "apply_patch"]
+
+
+def test_steering_structured_hard_rung_forces_structured_output():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_HARD,
+    )
+    llm = FakeLLM([llm_response(content="done")])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        agent=_agent_with_tool_schemas("structured_output", "file_read", "grep"),
+    )
+
+    run(runner.run_loop())
+
+    sent_tool_names = [spec["function"]["name"] for spec in llm.calls[0]["tools"]]
+    assert sent_tool_names == ["structured_output"]
+    assert llm.calls[0]["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "structured_output"},
+    }
+    assert "structured_output using" in llm.calls[0]["messages"][-1]["content"]
+
+
+def test_steering_structured_commit_gate_uses_soft_threshold():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_SOFT,
+    )
+    llm = FakeLLM([llm_response(content="done")])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        agent=_agent_with_tool_schemas("structured_output", "file_read", "grep"),
+    )
+
+    run(runner.run_loop())
+
+    sent_tool_names = [spec["function"]["name"] for spec in llm.calls[0]["tools"]]
+    assert sent_tool_names == ["structured_output"]
+    assert llm.calls[0]["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "structured_output"},
+    }
+
+
+def test_steering_write_gate_wins_when_write_tools_are_also_present():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_HARD,
+    )
+    llm = FakeLLM([llm_response(content="done")])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        agent=_agent_with_tool_schemas(
+            "structured_output",
+            "file_read",
+            "grep",
+            "file_write",
+            "apply_patch",
+        ),
+    )
+
+    run(runner.run_loop())
+
+    sent_tool_names = [spec["function"]["name"] for spec in llm.calls[0]["tools"]]
+    assert sent_tool_names == ["file_write", "apply_patch"]
+    assert llm.calls[0]["tool_choice"] == "required"
+    assert "MUST be a file_write or apply_patch edit" in llm.calls[0]["messages"][-1]["content"]
+
+
+def test_steering_hard_rung_blocks_read_tool_call_before_execution():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_HARD,
+    )
+    read_call = tool_call(call_id="r1", name="file_read", arguments='{"path": "a.py"}')
+    llm = FakeLLM(
+        [
+            llm_response(content="try read", tool_calls=[read_call], finish_reason="tool_calls"),
+            llm_response(content="done"),
+        ]
+    )
+    tool_execution = FakeToolExecution()
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        tool_execution=tool_execution,
+        agent=_agent_with_tool_schemas("file_read", "file_write", "apply_patch"),
+    )
+
+    result = run(runner.run_loop())
+
+    tool_messages = [
+        m for m in state.messages if m.get("role") == "tool" and m.get("tool_call_id")
+    ]
+    assert result == "done"
+    assert tool_execution.calls == []
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["tool_call_id"] == "r1"
+    assert "not allowed during the hard write gate" in tool_messages[0]["content"]
+    assert state.reads_since_last_edit == READS_NUDGE_HARD
+
+
+def test_steering_structured_hard_rung_blocks_read_tool_call_before_execution():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_HARD,
+    )
+    read_call = tool_call(call_id="r1", name="file_read", arguments='{"path": "a.py"}')
+    llm = FakeLLM(
+        [
+            llm_response(content="try read", tool_calls=[read_call], finish_reason="tool_calls"),
+            llm_response(content="done"),
+        ]
+    )
+    tool_execution = FakeToolExecution()
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        tool_execution=tool_execution,
+        agent=_agent_with_tool_schemas("structured_output", "file_read", "grep"),
+    )
+
+    result = run(runner.run_loop())
+
+    tool_messages = [
+        m for m in state.messages if m.get("role") == "tool" and m.get("tool_call_id")
+    ]
+    assert result == "done"
+    assert tool_execution.calls == []
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["tool_call_id"] == "r1"
+    assert "not allowed during the hard structured-output gate" in tool_messages[0]["content"]
+    assert state.reads_since_last_edit == READS_NUDGE_HARD
+
+
+def test_steering_hard_rung_executes_allowed_write_from_mixed_batch():
+    state = SessionState(
+        messages=[{"role": "tool", "content": "prev"}],
+        used_tokens=1_000,
+        step_count=1,
+        reads_since_last_edit=READS_NUDGE_HARD,
+    )
+    read_call = tool_call(call_id="r1", name="file_read", arguments='{"path": "a.py"}')
+    write_call = tool_call(call_id="w1", name="apply_patch", arguments='{"patch": "..."}')
+    llm = FakeLLM(
+        [
+            llm_response(
+                content="mixed",
+                tool_calls=[read_call, write_call],
+                finish_reason="tool_calls",
+            ),
+            llm_response(content="done"),
+        ]
+    )
+    tool_execution = FakeToolExecution(
+        ToolProcessingResult(
+            messages_to_append=[{"role": "tool", "tool_call_id": "w1", "content": "patched"}],
+            write_succeeded=True,
+        )
+    )
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        tool_execution=tool_execution,
+        agent=_agent_with_tool_schemas("file_read", "file_write", "apply_patch"),
+    )
+
+    result = run(runner.run_loop())
+
+    tool_messages = [
+        m for m in state.messages if m.get("role") == "tool" and m.get("tool_call_id")
+    ]
+    assert result == "done"
+    assert tool_execution.calls == [[write_call]]
+    assert [m["tool_call_id"] for m in tool_messages] == ["r1", "w1"]
+    assert "not allowed during the hard write gate" in tool_messages[0]["content"]
+    assert tool_messages[1]["content"] == "patched"
+    assert state.reads_since_last_edit == 0
 
 
 def test_steering_reaches_provider_and_is_persisted():
@@ -895,6 +1150,34 @@ def test_mixed_batch_buffers_immediate_and_resumes_in_order():
     ]
 
 
+def test_deferred_batch_with_blocked_tool_uses_original_order():
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    state.phase = SessionPhase.EXECUTING_TOOLS
+    blocked_read = tool_call(call_id="r1", name="file_read", arguments='{"path": "a.py"}')
+    deferred_spawn = tool_call(call_id="s1", name="spawn_agent", arguments="{}")
+    te = FakeToolExecutionDeferred(deferred_outcomes={"s1": (9, None)})
+    runner = build_runner(state=state, tool_execution=te)
+    runner._pending = PendingStep(
+        response=llm_response(
+            content="mixed",
+            tool_calls=[blocked_read, deferred_spawn],
+            finish_reason="tool_calls",
+        ),
+        latency=0.0,
+    )
+    runner._pending_tool_allowlist = frozenset({"spawn_agent"})
+    runner._pending_tool_gate_label = "test gate"
+
+    run(runner.execute_pending_tools())
+
+    assert state.phase is SessionPhase.AWAITING_EVENTS
+    assert state.pending_events.rows["r1"].order == 0
+    assert state.pending_events.rows["s1"].order == 1
+    assert "not allowed during the test gate" in state.pending_events.rows["r1"].result
+    assert te.process_calls == []
+    assert te.deferred_calls == [deferred_spawn]
+
+
 def test_mixed_batch_folds_in_reads_counter_for_immediate_reads():
     # Regression: a mixed batch (immediate read + deferred spawn) buffers its
     # result messages, so the reads-without-write counter must still fold in via
@@ -1137,6 +1420,23 @@ class SlowLLM:
         return self.response
 
 
+class CancelCleanupLLM:
+    def __init__(self):
+        self.calls = []
+        self.cancel_seen = asyncio.Event()
+        self.release_cancel = asyncio.Event()
+
+    async def complete(self, messages, tools=None, temperature=0.0, **kwargs):
+        self.calls.append(copy.deepcopy(messages))
+        gate = asyncio.Event()
+        try:
+            await gate.wait()
+        except asyncio.CancelledError:
+            self.cancel_seen.set()
+            await self.release_cancel.wait()
+            raise
+
+
 def test_per_call_timeout_raises_on_slow_generation():
     import pytest
 
@@ -1151,6 +1451,28 @@ def test_per_call_timeout_raises_on_slow_generation():
 
     assert state.phase is SessionPhase.ERROR
     assert len(llm.calls) == 1  # the call was attempted (then cancelled)
+
+
+def test_per_call_timeout_returns_before_cancel_cleanup_finishes():
+    async def scenario():
+        state = SessionState(messages=[{"role": "system", "content": "sys"}])
+        llm = CancelCleanupLLM()
+        runner = build_runner(state=state, llm=llm, per_call_timeout=0.01)
+
+        raised = False
+        try:
+            await asyncio.wait_for(runner.run_loop(), timeout=0.5)
+        except asyncio.TimeoutError:
+            raised = True
+
+        assert raised is True
+        assert state.phase is SessionPhase.ERROR
+        assert "TimeoutError" in (state.terminal_reason or "")
+        llm.release_cancel.set()
+        await asyncio.sleep(0)
+        assert llm.cancel_seen.is_set()
+
+    run(scenario())
 
 
 def test_per_call_timeout_none_does_not_bound_the_call():

--- a/opencollab/tests/test_swe_eval_status.py
+++ b/opencollab/tests/test_swe_eval_status.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from opencollab.harness.swe_eval_decision import TaskSnapshot, TaskState, decide_task, task_status_row
+from opencollab.harness.swe_eval_discovery import (
+    EvalReport,
+    build_snapshots,
+    summarize_eval_reports,
+)
+from opencollab.harness.swe_eval_records import (
+    latest_paired_rows,
+    patch_sha,
+    row_patch_sha,
+)
+
+
+def _patch(body: str = "+fixed\n") -> str:
+    return "diff --git a/pkg/a.py b/pkg/a.py\n@@\n" + body
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def test_latest_paired_rows_rejects_record_id_patch_sha_mismatch():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "attempt-1",
+        "model_patch": _patch("+new\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "attempt-1",
+        "patch_sha256": patch_sha(_patch("+different\n")),
+        "workflow_status": "done",
+    }
+
+    pair = latest_paired_rows([prediction], [metric], "task-1")
+
+    assert pair.prediction == prediction
+    assert pair.metric is None
+    assert pair.status == "record_id_patch_sha_mismatch"
+
+
+def test_empty_patch_is_terminal_and_not_ready_for_eval():
+    prediction = {"instance_id": "task-1", "record_id": "r1", "model_patch": ""}
+    snapshot = build_snapshots_from_rows([prediction], [])[0]
+
+    decision = decide_task(snapshot)
+
+    assert decision.state == TaskState.EMPTY_PATCH_INVALID
+    assert decision.terminal is True
+    assert decision.ready_for_eval is False
+
+
+def test_matching_done_eval_report_finishes_only_current_patch():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    reports = [
+        EvalReport(
+            task_id="task-1",
+            patch_sha=patch_sha(_patch("+old\n")),
+            status="done",
+            resolved_count=1,
+            path="old.json",
+        ),
+        EvalReport(
+            task_id="task-1",
+            patch_sha=row_patch_sha(prediction),
+            status="done",
+            unresolved_count=1,
+            path="current.json",
+        ),
+    ]
+    snapshot = build_snapshots_from_rows(
+        [prediction],
+        [metric],
+        reports=reports,
+    )[0]
+
+    row = task_status_row(snapshot)
+
+    assert row["state"] == "eval_done"
+    assert row["eval"]["done_count"] == 1
+    assert row["eval"]["ignored_patch_mismatch_count"] == 1
+    assert row["eval"]["resolved_count"] == 0
+    assert row["eval"]["unresolved_count"] == 1
+
+
+def test_done_metric_without_matching_eval_report_is_ready_for_eval():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    reports = [
+        EvalReport(
+            task_id="task-1",
+            patch_sha=patch_sha(_patch("+old\n")),
+            status="done",
+            resolved_count=1,
+            path="old.json",
+        )
+    ]
+    snapshot = build_snapshots_from_rows([prediction], [metric], reports=reports)[0]
+
+    decision = decide_task(snapshot)
+
+    assert decision.state == TaskState.READY_FOR_EVAL
+    assert decision.ready_for_eval is True
+
+
+def test_matching_done_eval_report_supersedes_earlier_infra_failure():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    reports = [
+        EvalReport(
+            task_id="task-1",
+            patch_sha=row_patch_sha(prediction),
+            status="technical_eval_failed",
+            path="first-docker-refused.json",
+        ),
+        EvalReport(
+            task_id="task-1",
+            patch_sha=row_patch_sha(prediction),
+            status="done",
+            resolved_count=1,
+            path="rerun-resolved.json",
+        ),
+    ]
+    snapshot = build_snapshots_from_rows([prediction], [metric], reports=reports)[0]
+
+    row = task_status_row(snapshot)
+
+    assert row["state"] == "eval_done"
+    assert row["eval"]["done_count"] == 1
+    assert row["eval"]["failed_count"] == 0
+    assert row["eval"]["resolved_count"] == 1
+    assert row["eval"]["report_paths"] == ["rerun-resolved.json"]
+
+
+def test_later_infra_failure_supersedes_earlier_done_report():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    reports = [
+        EvalReport(
+            task_id="task-1",
+            patch_sha=row_patch_sha(prediction),
+            status="done",
+            unresolved_count=1,
+            path="old-unclassified.json",
+        ),
+        EvalReport(
+            task_id="task-1",
+            patch_sha=row_patch_sha(prediction),
+            status="technical_eval_failed",
+            path="classified-redis.json",
+        ),
+    ]
+    snapshot = build_snapshots_from_rows([prediction], [metric], reports=reports)[0]
+
+    row = task_status_row(snapshot)
+
+    assert row["state"] == "technical_eval_failed"
+    assert row["eval"]["done_count"] == 0
+    assert row["eval"]["failed_count"] == 1
+    assert row["eval"]["unresolved_count"] == 0
+    assert row["eval"]["report_paths"] == ["classified-redis.json"]
+
+
+def test_eval_report_without_patch_sha_does_not_finish_current_patch():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    reports = [
+        EvalReport(
+            task_id="task-1",
+            patch_sha="",
+            status="done",
+            resolved_count=1,
+            path="old-without-sha.json",
+        )
+    ]
+    snapshot = build_snapshots_from_rows([prediction], [metric], reports=reports)[0]
+
+    row = task_status_row(snapshot)
+
+    assert row["state"] == "ready_for_eval"
+    assert row["eval"]["done_count"] == 0
+    assert row["eval"]["ignored_patch_mismatch_count"] == 1
+
+
+def test_task_status_row_surfaces_checkpoint_result_from_metric():
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+        "checkpoint_result": {"final": {"status": "written", "loss_bound_seconds": 300}},
+    }
+    snapshot = build_snapshots_from_rows([prediction], [metric])[0]
+
+    row = task_status_row(snapshot)
+
+    assert row["checkpoint_result"]["final"]["status"] == "written"
+    assert row["checkpoint_result"]["final"]["loss_bound_seconds"] == 300
+
+
+def test_status_script_defaults_to_read_only_summary(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    _write_jsonl(run_dir / "predictions.jsonl", [prediction])
+    _write_jsonl(run_dir / "metrics.jsonl", [metric])
+    script = Path(__file__).resolve().parents[2] / "scripts" / "swe_auto_eval_driver.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--run-dir", str(run_dir)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["start_eval"] is False
+    assert summary["totals"]["ready_for_eval"] == 1
+    assert summary["tasks"][0]["state"] == "ready_for_eval"
+    assert "actions" not in summary
+
+
+def test_status_script_dry_run_requires_explicit_start_eval(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    _write_jsonl(run_dir / "predictions.jsonl", [prediction])
+    _write_jsonl(run_dir / "metrics.jsonl", [metric])
+    script = Path(__file__).resolve().parents[2] / "scripts" / "swe_auto_eval_driver.py"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--run-dir",
+            str(run_dir),
+            "--start-eval",
+            "--dry-run",
+            "--eval-command-template",
+            "echo {task} {patch_sha}",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["actions"][0]["action"] == "dry_run"
+    assert summary["actions"][0]["command"][0] == "echo"
+
+
+def test_status_script_limits_eval_starts_by_default(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    predictions = []
+    metrics = []
+    for task in ("task-1", "task-2"):
+        prediction = {
+            "instance_id": task,
+            "record_id": f"{task}-r1",
+            "model_patch": _patch("+current\n"),
+        }
+        predictions.append(prediction)
+        metrics.append(
+            {
+                "instance_id": task,
+                "record_id": f"{task}-r1",
+                "patch_sha256": row_patch_sha(prediction),
+                "workflow_status": "done",
+            }
+        )
+    _write_jsonl(run_dir / "predictions.jsonl", predictions)
+    _write_jsonl(run_dir / "metrics.jsonl", metrics)
+    script = Path(__file__).resolve().parents[2] / "scripts" / "swe_auto_eval_driver.py"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--run-dir",
+            str(run_dir),
+            "--start-eval",
+            "--dry-run",
+            "--eval-command-template",
+            "echo {task}",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["totals"]["ready_for_eval"] == 2
+    assert len(summary["actions"]) == 1
+
+
+def test_wave_watchdog_summarizes_runs_config_without_actions(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    _write_jsonl(run_dir / "predictions.jsonl", [prediction])
+    _write_jsonl(run_dir / "metrics.jsonl", [metric])
+    runs_config = tmp_path / "runs.json"
+    runs_config.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "local",
+                    "base_run_dir": str(run_dir),
+                    "tasks": ["task-1"],
+                    "workflow": "single-agent",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    script = Path(__file__).resolve().parents[2] / "scripts" / "swe_v3_wave_watchdog.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--runs-config", str(runs_config)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["schema"] == "opencollab.swe_wave_status.v1"
+    assert summary["totals"]["ready_for_eval"] == 1
+    assert summary["runs"][0]["tasks"][0]["state"] == "ready_for_eval"
+
+
+def build_snapshots_from_rows(
+    predictions: list[dict],
+    metrics: list[dict],
+    *,
+    reports: list[EvalReport] | None = None,
+):
+    run_reports = reports or []
+    tasks = {row["instance_id"] for row in [*predictions, *metrics]}
+    snapshots = []
+    for task_id in sorted(tasks):
+        pair = latest_paired_rows(predictions, metrics, task_id)
+        active_eval = False
+        snapshots.append(
+            TaskSnapshot(
+                task_id=task_id,
+                prediction=pair.prediction,
+                metric=pair.metric,
+                metric_pairing=pair.status,
+                eval_summary=summarize_eval_reports(
+                    run_reports,
+                    task_id=task_id,
+                    current_patch_sha=row_patch_sha(pair.prediction),
+                    active_eval=active_eval,
+                ),
+            )
+        )
+    return snapshots
+
+
+def test_build_snapshots_reads_prediction_metric_and_summary_report(tmp_path):
+    run_dir = tmp_path / "run"
+    side_dir = run_dir / "official_eval_auto" / "task-1"
+    side_dir.mkdir(parents=True)
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    _write_jsonl(run_dir / "predictions.jsonl", [prediction])
+    _write_jsonl(run_dir / "metrics.jsonl", [metric])
+    (side_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "instance_id": "task-1",
+                "patch_sha256": row_patch_sha(prediction),
+                "status": "done",
+                "resolved_instances": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshots = build_snapshots(run_dir)
+
+    row = task_status_row(snapshots[0])
+    assert row["state"] == "eval_done"
+    assert row["eval"]["resolved_count"] == 1
+
+
+def test_build_snapshots_reads_nested_direct_eval_technical_failure(tmp_path):
+    run_dir = tmp_path / "run"
+    side_dir = run_dir / "official_eval_auto" / "reports" / "task-1"
+    side_dir.mkdir(parents=True)
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    _write_jsonl(run_dir / "predictions.jsonl", [prediction])
+    _write_jsonl(run_dir / "metrics.jsonl", [metric])
+    (side_dir / "report.json").write_text(
+        json.dumps(
+            {
+                "task-1": {
+                    "schema": "opencollab.prolite_direct_eval.v1",
+                    "status": "technical_eval_failed",
+                    "resolved": False,
+                    "error": True,
+                    "patch_sha256": row_patch_sha(prediction),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshots = build_snapshots(run_dir)
+
+    row = task_status_row(snapshots[0])
+    assert row["state"] == "technical_eval_failed"
+    assert row["eval"]["failed_count"] == 1
+    assert row["eval"]["done_count"] == 0
+
+
+def test_build_snapshots_prefers_newer_matching_eval_report(tmp_path):
+    run_dir = tmp_path / "run"
+    side_dir = run_dir / "official_eval_auto" / "task-1"
+    side_dir.mkdir(parents=True)
+    prediction = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "model_patch": _patch("+current\n"),
+    }
+    metric = {
+        "instance_id": "task-1",
+        "record_id": "r1",
+        "patch_sha256": row_patch_sha(prediction),
+        "workflow_status": "done",
+    }
+    _write_jsonl(run_dir / "predictions.jsonl", [prediction])
+    _write_jsonl(run_dir / "metrics.jsonl", [metric])
+    old_report = side_dir / "old-summary.json"
+    old_report.write_text(
+        json.dumps(
+            {
+                "instance_id": "task-1",
+                "patch_sha256": row_patch_sha(prediction),
+                "status": "done",
+                "unresolved_instances": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    new_report = side_dir / "redis-classified.json"
+    new_report.write_text(
+        json.dumps(
+            {
+                "task-1": {
+                    "status": "technical_eval_failed",
+                    "error": True,
+                    "patch_sha256": row_patch_sha(prediction),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(old_report, ns=(1, 1))
+    os.utime(new_report, ns=(2, 2))
+
+    snapshots = build_snapshots(run_dir)
+
+    row = task_status_row(snapshots[0])
+    assert row["state"] == "technical_eval_failed"
+    assert row["eval"]["done_count"] == 0
+    assert row["eval"]["failed_count"] == 1
+    assert row["eval"]["report_paths"] == [str(new_report)]

--- a/opencollab/tests/test_tool_dispatch.py
+++ b/opencollab/tests/test_tool_dispatch.py
@@ -9,6 +9,8 @@ and the layer boundary of ``tool_execution.py`` (the home of ``ToolRuntime``).
 import asyncio
 from pathlib import Path
 
+import opencollab.application.tool_execution as tool_execution_mod
+from opencollab.adapters.tools.run_tests import RunTestsTool
 from opencollab.application.tool_execution import ToolExecutionUseCase, ToolRuntime
 from opencollab.domain.session import SessionState
 
@@ -57,6 +59,13 @@ class RuntimeNativeTool:
         return "runtime result"
 
 
+class HangingTool(RuntimeNativeTool):
+    async def execute_with_runtime(self, params, runtime):
+        self.runtime_calls.append((params, runtime))
+        await asyncio.sleep(3600)
+        return "unreachable"
+
+
 def _tool_call(args: str = "{}") -> dict:
     return {"id": "c1", "function": {"name": "fake_tool", "arguments": args}}
 
@@ -80,6 +89,50 @@ def test_use_case_invokes_tool_execute_with_runtime():
     assert params == {"value": 1}
     assert isinstance(runtime, ToolRuntime)
     assert runtime.environment is env
+
+
+def test_use_case_times_out_hung_tool(monkeypatch):
+    monkeypatch.setattr(tool_execution_mod, "DEFAULT_TOOL_EXECUTION_TIMEOUT", 0.01)
+    tool = HangingTool()
+    use_case = ToolExecutionUseCase(
+        agent=FakeAgent([tool]),
+        environment=FakeEnv(),
+        state=SessionState(messages=[]),
+        event_publisher=FakeEventPublisher(),
+    )
+
+    result = run(use_case.process([_tool_call()]))
+
+    assert "Tool execution timed out after" in result.messages_to_append[0]["content"]
+    assert "fake_tool" in result.messages_to_append[0]["content"]
+    assert len(tool.runtime_calls) == 1
+
+
+def test_outer_timeout_uses_tool_default_timeout_before_framework_fallback():
+    use_case = ToolExecutionUseCase(
+        agent=FakeAgent([]),
+        environment=FakeEnv(),
+        state=SessionState(messages=[]),
+        event_publisher=FakeEventPublisher(),
+    )
+
+    assert use_case.tool_execution_timeout(RunTestsTool(), {}) == 310.0
+
+
+def test_explicit_timeout_stays_in_tool_args():
+    tool = RuntimeNativeTool()
+    use_case = ToolExecutionUseCase(
+        agent=FakeAgent([tool]),
+        environment=FakeEnv(),
+        state=SessionState(messages=[]),
+        event_publisher=FakeEventPublisher(),
+    )
+
+    result = run(use_case.process([_tool_call('{"timeout": 12}')]))
+
+    assert result.messages_to_append[0]["content"] == "runtime result"
+    assert tool.runtime_calls[0][0] == {"timeout": 12}
+    assert use_case.tool_execution_timeout(tool, {"timeout": 12}) == 22.0
 
 
 def test_runtime_exposes_confirm_fn_from_permission_policy():

--- a/opencollab/tests/test_tool_execution_use_case.py
+++ b/opencollab/tests/test_tool_execution_use_case.py
@@ -424,6 +424,19 @@ def test_short_circuit_loop_block_is_traced():
     assert step["payload"]["count"] == 3
 
 
+def test_loop_block_short_circuit_counts_toward_hard_brake():
+    state = SessionState(messages=[])
+    use_case, _ = build_use_case(state=state)
+    call_hash = use_case.tool_call_hash("fake_tool", {"value": 1})
+    state.replace_recent_tool_hashes([call_hash, call_hash])
+
+    result = run(use_case.process([tool_call(arguments='{"value": 1}')]))
+    result.apply_to(state)
+
+    assert state.loop_blocked_since_progress == 1
+    assert result.loop_detections == [LoopDetection(tool="fake_tool", count=3)]
+
+
 def test_application_tool_execution_module_does_not_import_outer_layers():
     package_root = Path(__file__).resolve().parents[1]
     source = (package_root / "opencollab/application/tool_execution.py").read_text(encoding="utf-8")

--- a/opencollab/tests/test_tool_runtime_contract.py
+++ b/opencollab/tests/test_tool_runtime_contract.py
@@ -416,6 +416,40 @@ def test_grep_tool_preserves_env_exec_path_without_path_safety():
     assert timeout == 30
 
 
+def test_grep_tool_rejects_non_integer_max_results_before_exec():
+    env = FakeEnv(stdout="src/app.py:1:needle\n")
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        GrepTool().execute_with_runtime(
+            {"pattern": "needle", "max_results": "1; touch pwned"},
+            runtime,
+        )
+    )
+
+    assert result == "Error: max_results must be an integer."
+    assert env.exec_calls == []
+
+
+def test_grep_tool_terminates_options_before_pattern_and_path():
+    env = FakeEnv(stdout="")
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    run(
+        GrepTool().execute_with_runtime(
+            {"pattern": "--pre=touch pwned", "path": "--debug"},
+            runtime,
+        )
+    )
+
+    cmd, _ = env.exec_calls[0]
+    assert "rg -n --max-count 50 -- '--pre=touch pwned' --debug" in cmd
+    assert (
+        "grep -rEn --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.opencollab "
+        "-- '--pre=touch pwned' --debug"
+    ) in cmd
+
+
 def test_file_read_description_teaches_distill_and_forbids_reread():
     # The file_read description is the UNIVERSAL carrier of the anti-thrash rule:
     # every workflow/team that has the tool sees it, regardless of its prompt. Pins

--- a/opencollab/tests/test_workflow_context.py
+++ b/opencollab/tests/test_workflow_context.py
@@ -68,6 +68,22 @@ class FakeSession:
         return self._tokens
 
 
+class CancelCleanupSession(FakeSession):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancel_seen = asyncio.Event()
+        self.release_cancel = asyncio.Event()
+
+    async def run_loop(self, cancel_event: asyncio.Event | None = None) -> str:
+        gate = asyncio.Event()
+        try:
+            await gate.wait()
+        except asyncio.CancelledError:
+            self.cancel_seen.set()
+            await self.release_cancel.wait()
+            raise
+
+
 class FakeFactory:
     """Hands out pre-scripted sessions in build order, recording build calls."""
 
@@ -677,6 +693,75 @@ async def test_agent_timeout_bounds_run_loop_and_returns_none():
 
     assert result is None
     assert any("timed out" in e.message for e in sink.events)
+
+
+@pytest.mark.asyncio
+async def test_structured_agent_timeout_bounds_first_pass_and_returns_none():
+    gate = asyncio.Event()
+    session = FakeSession(reply="ok", gate=gate)
+    sink = RecordingSink()
+    ctx = WorkflowContext(FakeFactory([session]), event_sink=sink)
+
+    result = await ctx.agent(
+        "slow structured",
+        schema={
+            "type": "object",
+            "required": ["verdict"],
+            "properties": {"verdict": {"type": "string"}},
+        },
+        timeout=0.01,
+    )
+
+    assert result is None
+    assert any("structured agent timed out" in e.message for e in sink.events)
+
+
+@pytest.mark.asyncio
+async def test_structured_agent_timeout_bounds_forced_retry_and_returns_none():
+    first = FakeSession(reply="prose instead of structured output")
+    gate = asyncio.Event()
+    retry = FakeSession(reply="ok", gate=gate)
+    sink = RecordingSink()
+    ctx = WorkflowContext(FakeFactory([first, retry]), event_sink=sink)
+
+    result = await ctx.agent(
+        "needs structured",
+        schema={
+            "type": "object",
+            "required": ["verdict"],
+            "properties": {"verdict": {"type": "string"}},
+        },
+        timeout=0.01,
+    )
+
+    assert result is None
+    assert any("structured retry timed out" in e.message for e in sink.events)
+
+
+@pytest.mark.asyncio
+async def test_structured_agent_timeout_returns_before_cancel_cleanup_finishes():
+    session = CancelCleanupSession()
+    sink = RecordingSink()
+    ctx = WorkflowContext(FakeFactory([session]), event_sink=sink)
+
+    result = await asyncio.wait_for(
+        ctx.agent(
+            "slow structured",
+            schema={
+                "type": "object",
+                "required": ["verdict"],
+                "properties": {"verdict": {"type": "string"}},
+            },
+            timeout=0.01,
+        ),
+        timeout=0.5,
+    )
+
+    assert result is None
+    assert any("structured agent timed out" in e.message for e in sink.events)
+    session.release_cancel.set()
+    await asyncio.sleep(0)
+    assert session.cancel_seen.is_set()
 
 
 @pytest.mark.asyncio

--- a/scripts/swe_auto_eval_driver.py
+++ b/scripts/swe_auto_eval_driver.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Thin SWE-bench evaluation status driver.
+
+The script defaults to read-only status generation. Starting evaluation is a
+separate action and requires an explicit command template, keeping classification
+logic testable and side-effect free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PKG_ROOT = REPO_ROOT / "opencollab"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+from opencollab.harness.swe_eval_decision import task_status_row  # noqa: E402
+from opencollab.harness.swe_eval_discovery import build_snapshots  # noqa: E402
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_markdown(path: Path, summary: dict) -> None:
+    lines = [
+        "# SWE Auto Eval Status",
+        "",
+        f"- run_dir: `{summary['run_dir']}`",
+        f"- side_name: `{summary['side_name']}`",
+        f"- tasks: `{summary['totals']['tasks']}`",
+        f"- ready_for_eval: `{summary['totals']['ready_for_eval']}`",
+        f"- eval_done: `{summary['totals']['eval_done']}`",
+        f"- technical_eval_failed: `{summary['totals']['technical_eval_failed']}`",
+        "",
+        "| task | state | patch | wf | eval | reason |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in summary["tasks"]:
+        eval_summary = row["eval"]
+        eval_label = "none"
+        if eval_summary["active_count"]:
+            eval_label = "active"
+        elif eval_summary["done_count"]:
+            eval_label = f"done r={eval_summary['resolved_count']} u={eval_summary['unresolved_count']}"
+        elif eval_summary["failed_count"]:
+            eval_label = "technical_failed"
+        lines.append(
+            "| {task} | {state} | {patch} | {wf} | {eval} | {reason} |".format(
+                task=row["task"],
+                state=row["state"],
+                patch=row["patch_len"],
+                wf=row["workflow_status"],
+                eval=eval_label,
+                reason=row["reason"],
+            )
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_summary(args: argparse.Namespace) -> dict:
+    active_generation = set(args.active_generation_task or [])
+    active_eval = set(args.active_eval_task or [])
+    snapshots = build_snapshots(
+        args.run_dir,
+        tasks=args.task or None,
+        side_name=args.side_name,
+        active_generation_tasks=active_generation,
+        active_eval_tasks=active_eval,
+    )
+    rows = [task_status_row(snapshot, allow_advisory_gap=args.eval_advisory_gap) for snapshot in snapshots]
+    totals = {
+        "tasks": len(rows),
+        "ready_for_eval": sum(1 for row in rows if row["ready_for_eval"]),
+        "eval_done": sum(1 for row in rows if row["state"] == "eval_done"),
+        "technical_eval_failed": sum(1 for row in rows if row["state"] == "technical_eval_failed"),
+        "empty_patch_invalid": sum(1 for row in rows if row["state"] == "empty_patch_invalid"),
+    }
+    return {
+        "schema": "opencollab.swe_auto_eval_status.v1",
+        "run_dir": str(args.run_dir),
+        "side_name": args.side_name,
+        "start_eval": bool(args.start_eval),
+        "totals": totals,
+        "tasks": rows,
+    }
+
+
+def _format_eval_command(template: str, row: dict) -> list[str]:
+    formatted = template.format(
+        task=shlex.quote(row["task"]),
+        patch_sha=shlex.quote(row["patch_sha256"]),
+        record_id=shlex.quote(row.get("record_id") or ""),
+    )
+    return shlex.split(formatted)
+
+
+def maybe_start_eval(args: argparse.Namespace, summary: dict) -> list[dict]:
+    if not args.start_eval:
+        return []
+    if not args.eval_command_template:
+        raise SystemExit("--start-eval requires --eval-command-template")
+    actions: list[dict] = []
+    for row in summary["tasks"]:
+        if len(actions) >= args.max_eval_starts:
+            break
+        if not row["ready_for_eval"]:
+            continue
+        command = _format_eval_command(args.eval_command_template, row)
+        if args.dry_run:
+            actions.append({"task": row["task"], "action": "dry_run", "command": command})
+            continue
+        proc = subprocess.Popen(command, cwd=args.run_dir)
+        actions.append({"task": row["task"], "action": "started", "pid": proc.pid, "command": command})
+    return actions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize and optionally start SWE-bench eval tasks.")
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--side-name", default="official_eval_auto")
+    parser.add_argument("--task", action="append", default=[])
+    parser.add_argument("--active-generation-task", action="append", default=[])
+    parser.add_argument("--active-eval-task", action="append", default=[])
+    parser.add_argument("--eval-advisory-gap", action="store_true")
+    parser.add_argument("--json-output", type=Path, default=None)
+    parser.add_argument("--markdown-output", type=Path, default=None)
+    parser.add_argument("--start-eval", action="store_true")
+    parser.add_argument("--eval-command-template", default="")
+    parser.add_argument("--max-eval-starts", type=int, default=1)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    args.run_dir = args.run_dir.resolve()
+    summary = build_summary(args)
+    actions = maybe_start_eval(args, summary)
+    if actions:
+        summary["actions"] = actions
+    if args.json_output:
+        _write_json(args.json_output, summary)
+    if args.markdown_output:
+        _write_markdown(args.markdown_output, summary)
+    if not args.json_output and not args.markdown_output:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/swe_auto_eval_driver.py
+++ b/scripts/swe_auto_eval_driver.py
@@ -118,7 +118,13 @@ def maybe_start_eval(args: argparse.Namespace, summary: dict) -> list[dict]:
         if args.dry_run:
             actions.append({"task": row["task"], "action": "dry_run", "command": command})
             continue
-        proc = subprocess.Popen(command, cwd=args.run_dir)
+        try:
+            proc = subprocess.Popen(command, cwd=args.run_dir)
+        except OSError as exc:
+            actions.append(
+                {"task": row["task"], "action": "failed_to_start", "error": str(exc), "command": command}
+            )
+            continue
         actions.append({"task": row["task"], "action": "started", "pid": proc.pid, "command": command})
     return actions
 
@@ -134,7 +140,14 @@ def main() -> int:
     parser.add_argument("--json-output", type=Path, default=None)
     parser.add_argument("--markdown-output", type=Path, default=None)
     parser.add_argument("--start-eval", action="store_true")
-    parser.add_argument("--eval-command-template", default="")
+    parser.add_argument(
+        "--eval-command-template",
+        default="",
+        help=(
+            "Command template parsed with shlex; shell redirection and pipes are not interpreted. "
+            "Use bash -lc when shell syntax is required."
+        ),
+    )
     parser.add_argument("--max-eval-starts", type=int, default=1)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()

--- a/scripts/swe_v3_wave_watchdog.py
+++ b/scripts/swe_v3_wave_watchdog.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Read-only SWE-bench wave status watchdog.
+
+This entry point summarizes configured runs using the pure harness status layer.
+It deliberately avoids remote repair, generation starts, and eval starts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PKG_ROOT = REPO_ROOT / "opencollab"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+from opencollab.harness.swe_eval_decision import task_status_row  # noqa: E402
+from opencollab.harness.swe_eval_discovery import build_snapshots  # noqa: E402
+
+
+def _load_runs(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("runs config must be a JSON list")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _configured_tasks(run: dict) -> list[str]:
+    tasks = run.get("tasks")
+    if isinstance(tasks, list):
+        return [str(task) for task in tasks if str(task)]
+    proxies = run.get("remote_proxy_base_urls")
+    if isinstance(proxies, dict):
+        return [str(task) for task in proxies if str(task)]
+    return []
+
+
+def _run_status(run: dict, *, default_side_name: str, allow_advisory_gap: bool) -> dict:
+    base = Path(str(run.get("base_run_dir") or ""))
+    tasks = _configured_tasks(run)
+    side_name = str(run.get("side_name") or default_side_name)
+    item = {
+        "name": str(run.get("name") or base.name or "run"),
+        "base_run_dir": str(base),
+        "base_exists": base.exists(),
+        "workflow": str(run.get("workflow") or ""),
+        "dataset": str(run.get("dataset") or ""),
+        "side_name": side_name,
+        "tasks": [],
+    }
+    if not base.exists():
+        return item
+    snapshots = build_snapshots(base, tasks=tasks or None, side_name=side_name)
+    item["tasks"] = [
+        task_status_row(snapshot, allow_advisory_gap=allow_advisory_gap)
+        for snapshot in snapshots
+    ]
+    return item
+
+
+def _totals(runs: list[dict]) -> dict[str, int]:
+    totals = {
+        "runs": len(runs),
+        "tasks": 0,
+        "ready_for_eval": 0,
+        "eval_done": 0,
+        "technical_eval_failed": 0,
+        "empty_patch_invalid": 0,
+        "missing_base": 0,
+    }
+    for run in runs:
+        if not run.get("base_exists"):
+            totals["missing_base"] += 1
+        for task in run.get("tasks") or []:
+            totals["tasks"] += 1
+            totals["ready_for_eval"] += int(bool(task.get("ready_for_eval")))
+            totals["eval_done"] += int(task.get("state") == "eval_done")
+            totals["technical_eval_failed"] += int(task.get("state") == "technical_eval_failed")
+            totals["empty_patch_invalid"] += int(task.get("state") == "empty_patch_invalid")
+    return totals
+
+
+def build_summary(args: argparse.Namespace) -> dict:
+    runs = [
+        _run_status(run, default_side_name=args.side_name, allow_advisory_gap=args.eval_advisory_gap)
+        for run in _load_runs(args.runs_config)
+    ]
+    return {
+        "schema": "opencollab.swe_wave_status.v1",
+        "runs_config": str(args.runs_config),
+        "side_name": args.side_name,
+        "totals": _totals(runs),
+        "runs": runs,
+    }
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_markdown(path: Path, summary: dict) -> None:
+    totals = summary["totals"]
+    lines = [
+        "# SWE Wave Status",
+        "",
+        f"- runs: `{totals['runs']}`",
+        f"- tasks: `{totals['tasks']}`",
+        f"- ready_for_eval: `{totals['ready_for_eval']}`",
+        f"- eval_done: `{totals['eval_done']}`",
+        f"- technical_eval_failed: `{totals['technical_eval_failed']}`",
+        "",
+        "| run | task | state | patch | wf | eval |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for run in summary["runs"]:
+        if not run["base_exists"]:
+            lines.append(f"| {run['name']} |  | base_missing |  |  |  |")
+            continue
+        for task in run["tasks"]:
+            eval_summary = task["eval"]
+            eval_label = "none"
+            if eval_summary["done_count"]:
+                eval_label = f"done r={eval_summary['resolved_count']} u={eval_summary['unresolved_count']}"
+            elif eval_summary["active_count"]:
+                eval_label = "active"
+            elif eval_summary["failed_count"]:
+                eval_label = "technical_failed"
+            lines.append(
+                "| {run} | {task} | {state} | {patch} | {wf} | {eval} |".format(
+                    run=run["name"],
+                    task=task["task"],
+                    state=task["state"],
+                    patch=task["patch_len"],
+                    wf=task["workflow_status"],
+                    eval=eval_label,
+                )
+            )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize configured SWE-bench wave runs.")
+    parser.add_argument("--runs-config", type=Path, required=True)
+    parser.add_argument("--side-name", default="official_eval_auto")
+    parser.add_argument("--eval-advisory-gap", action="store_true")
+    parser.add_argument("--json-output", type=Path, default=None)
+    parser.add_argument("--markdown-output", type=Path, default=None)
+    args = parser.parse_args()
+
+    args.runs_config = args.runs_config.resolve()
+    summary = build_summary(args)
+    if args.json_output:
+        _write_json(args.json_output, summary)
+    if args.markdown_output:
+        _write_markdown(args.markdown_output, summary)
+    if not args.json_output and not args.markdown_output:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swebench/gen_prediction.py
+++ b/swebench/gen_prediction.py
@@ -78,6 +78,12 @@ Rules:
 """
 
 
+def unique_container_name(prefix: str, instance_id: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    max_instance_chars = max(1, 63 - len(prefix) - len(suffix) - 1)
+    return f"{prefix}{instance_id[:max_instance_chars]}-{suffix}"
+
+
 def _docker(*args: str, timeout: int | None = None) -> subprocess.CompletedProcess:
     if timeout is None:
         timeout = int(os.environ.get("OPENCOLLAB_DOCKER_TIMEOUT", "60"))
@@ -99,14 +105,46 @@ def start_container(image: str, name: str) -> str:
     if res.returncode != 0:
         raise RuntimeError(f"docker run failed: {res.stderr.strip()}")
     cid = res.stdout.strip()[:12]
-    # Repo is owned by root in the image; allow git to operate on it.
-    safe_dir = _docker("exec", cid, "bash", "-lc",
-                       f"git config --global --add safe.directory {DOCKER_WORKDIR}")
-    _check_docker(safe_dir, "docker git safe.directory setup")
+    ensure_workdir = _docker(
+        "exec", cid, "bash", "-lc",
+        """
+set -e
+if [ -e /testbed/.git ]; then
+  exit 0
+fi
+if { [ -e /testbed ] || [ -L /testbed ]; } && [ ! -e /testbed/.git ]; then
+  rm -rf /testbed
+fi
+if [ ! -e /testbed ]; then
+  for d in /app /workspace /repo /src; do
+    if [ -e "$d/.git" ]; then
+      ln -s "$d" /testbed
+      exit 0
+    fi
+  done
+  found=$(find / -maxdepth 3 -name .git 2>/dev/null | head -1 || true)
+  if [ -n "$found" ]; then
+    ln -s "$(dirname "$found")" /testbed
+    exit 0
+  fi
+fi
+echo "unable to prepare /testbed: no repository checkout found" >&2
+exit 2
+""",
+    )
+    try:
+        _check_docker(ensure_workdir, "docker /testbed workdir setup")
+        # Repo is owned by root in the image; allow git to operate on it.
+        safe_dir = _docker("exec", cid, "bash", "-lc",
+                           f"git config --global --add safe.directory {DOCKER_WORKDIR}")
+        _check_docker(safe_dir, "docker git safe.directory setup")
+    except Exception:
+        remove_container(cid)
+        raise
     return cid
 
 
-def remove_container(cid: str) -> None:
+def remove_container(cid: str) -> bool:
     """Best-effort teardown of a throwaway container.
 
     Cleanup must NEVER lose an already-computed result: under heavy daemon load
@@ -118,10 +156,40 @@ def remove_container(cid: str) -> None:
     Swallow any failure with a warning instead.
     """
     try:
-        _docker("rm", "-f", cid, timeout=30)
+        result = _docker("rm", "-f", cid, timeout=30)
     except Exception as exc:  # noqa: BLE001 — teardown must never propagate
         print(f"  warning: container cleanup failed for {cid}: {exc!r} "
               f"(best-effort, continuing)")
+        return False
+    detail = (result.stderr or result.stdout or "").strip()
+    if result.returncode != 0 and "No such container" not in detail:
+        print(
+            f"  warning: container cleanup failed for {cid}: "
+            f"exit {result.returncode}: {detail[:500]} (best-effort, continuing)"
+        )
+        return False
+    return True
+
+
+def write_container_marker(run_dir: Path, cid: str, name: str) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "container.id").write_text(cid + "\n", encoding="utf-8")
+    (run_dir / "container.name").write_text(name + "\n", encoding="utf-8")
+
+
+def clear_container_marker(run_dir: Path) -> None:
+    for marker in ("container.id", "container.name"):
+        try:
+            (run_dir / marker).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def remove_container_and_clear_marker(run_dir: Path, cid: str) -> bool:
+    removed = remove_container(cid)
+    if removed:
+        clear_container_marker(run_dir)
+    return removed
 
 
 def build_task(instance: dict) -> str:
@@ -226,8 +294,10 @@ def main() -> None:
     print(f"Image:    {image}")
     print(f"Model:    {cfg['model']} (provider={cfg['provider']})")
 
-    name = f"oc-gen-{iid}-{uuid.uuid4().hex[:6]}"[:60]
+    name = unique_container_name("oc-gen-", iid)
     cid = start_container(image, name)
+    run_dir = Path(args.output).parent
+    write_container_marker(run_dir, cid, name)
     print(f"Container: {cid}")
     try:
         task = build_task(instance)
@@ -235,7 +305,7 @@ def main() -> None:
         patch = extract_patch(cid)
     finally:
         if not args.keep_container:
-            remove_container(cid)
+            remove_container_and_clear_marker(run_dir, cid)
         else:
             print(f"  (left container {cid} running: {name})")
 

--- a/swebench/gen_prediction_workflow.py
+++ b/swebench/gen_prediction_workflow.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import shlex
@@ -60,6 +61,7 @@ from opencollab.harness.workflows import generate_review_fix  # noqa: E402
 DEFAULT_BUDGET = 1_000_000
 DEFAULT_MAX_STEPS = 60  # per workflow session; 60 proved enough to act, 40 did not
 DEFAULT_TIMEOUT = 1800.0  # the workflow runs up to 3 sequential sessions
+DEFAULT_CHECKPOINT_INTERVAL_SECONDS = 300.0
 BLIND_BY_DEFAULT_WORKFLOWS = {"validation-council-solve", "swe-committee-v2"}
 VALIDATION_ARTIFACT_MARKERS = (
     "opencollab-validation",
@@ -227,12 +229,45 @@ def _json_safe(value: object) -> object:
     return str(value)
 
 
+def _patch_sha256(patch: str) -> str:
+    if not patch:
+        return ""
+    return hashlib.sha256(patch.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
 def _result_metrics(result) -> dict:
     return {
         field.name: _json_safe(getattr(result, field.name))
         for field in fields(result)
         if field.name != "patch"
     }
+
+
+def build_output_records(
+    *,
+    instance_id: str,
+    model_name: str,
+    patch: str,
+    metrics: dict,
+    record_id: str | None = None,
+) -> tuple[dict, dict]:
+    record_id = record_id or uuid.uuid4().hex
+    patch_sha256 = _patch_sha256(patch)
+    prediction = {
+        "instance_id": instance_id,
+        "record_id": record_id,
+        "patch_sha256": patch_sha256,
+        "model_name_or_path": model_name,
+        "model_patch": patch,
+    }
+    metric_record = {
+        **metrics,
+        "instance_id": instance_id,
+        "record_id": record_id,
+        "patch_sha256": patch_sha256,
+        "model_name_or_path": model_name,
+    }
+    return prediction, metric_record
 
 
 def _looks_like_validation_artifact(path: str) -> bool:
@@ -283,13 +318,21 @@ def _patch_paths_to_remove(
 def _remove_patch_paths(cid: str, paths: list[str]) -> None:
     if not paths:
         return
-    quoted = " ".join(shlex.quote(path) for path in paths)
-    cmd = (
-        f"git restore --staged --worktree -- {quoted} 2>/dev/null || true; "
-        f"git clean -fdq -- {quoted}"
-    )
+    cmd = _cleanup_patch_paths_command(paths)
     res = gp._docker("exec", "-w", gp.DOCKER_WORKDIR, cid, "bash", "-lc", cmd)
     gp._check_docker(res, "remove validation artifacts before patch extraction")
+
+
+def _cleanup_patch_paths_command(paths: list[str]) -> str:
+    quoted = " ".join(shlex.quote(path) for path in paths)
+    return "\n".join(
+        [
+            f"git restore --staged --worktree -- {quoted} 2>/dev/null || true",
+            f"git reset -q HEAD -- {quoted} 2>/dev/null || true",
+            f"git checkout -- {quoted} 2>/dev/null || true",
+            f"git clean -fdq -- {quoted}",
+        ]
+    )
 
 
 def extract_patch_guarded(
@@ -334,8 +377,10 @@ async def generate(
 ) -> tuple[str, dict]:
     """Run the chosen workflow in a fresh container; return (patch, metrics)."""
     iid = instance["instance_id"]
-    name = f"oc-wf-{iid}-{uuid.uuid4().hex[:6]}"[:60]
+    name = gp.unique_container_name("oc-wf-", iid)
     cid = gp.start_container(image, name)
+    run_dir = Path(args.output).parent
+    gp.write_container_marker(run_dir, cid, name)
     print(f"Container: {cid}")
     try:
         # Attach mode: run_eval_task's internal env.cleanup() no-ops on attached
@@ -380,6 +425,12 @@ async def generate(
             top_p=cfg.get("top_p"),
             thinking=cfg.get("thinking", False),
             thinking_params=cfg.get("thinking_params") or None,
+            checkpoint_interval_seconds=(
+                args.checkpoint_interval_seconds
+                if args.checkpoint_interval_seconds > 0
+                else None
+            ),
+            resume_from_checkpoint=bool(args.resume),
         )
         print(
             f"  workflow: tokens={result.tokens_used} steps={result.steps} "
@@ -401,13 +452,20 @@ async def generate(
         )
     finally:
         if not args.keep_container:
-            gp.remove_container(cid)
+            gp.remove_container_and_clear_marker(run_dir, cid)
         else:
             print(f"  (left container {cid} running: {name})")
 
     metrics = _result_metrics(result)
     metrics["patch_produced"] = bool(patch.strip())
     metrics["submitted_patch_chars"] = len(patch)
+    if not metrics.get("workflow_status"):
+        if result.error and patch.strip():
+            metrics["workflow_status"] = "done_with_timeout_patch"
+        elif result.error:
+            metrics["workflow_status"] = "error"
+        elif patch.strip():
+            metrics["workflow_status"] = "done"
     if workflow_allowlist_missing:
         metrics["workflow_allowlist_missing"] = True
     if removed_validation_artifacts:
@@ -444,6 +502,17 @@ def main() -> None:
     ap.add_argument("--budget", type=int, default=DEFAULT_BUDGET,
                     help="Shared token budget across all workflow sessions")
     ap.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    ap.add_argument(
+        "--checkpoint-interval-seconds",
+        type=float,
+        default=DEFAULT_CHECKPOINT_INTERVAL_SECONDS,
+        help="Capture worktree checkpoint patches at this interval; 0 disables it",
+    )
+    ap.add_argument(
+        "--resume",
+        action="store_true",
+        help="Apply the latest checkpoint.worktree.patch before running",
+    )
     ap.add_argument("--keep-container", action="store_true")
     args = ap.parse_args()
 
@@ -478,22 +547,28 @@ def main() -> None:
     print(f"Workflow: {wf_label} (budget={args.budget}, "
           f"max_steps/session={args.max_steps})")
     print(f"Blind validation: {args.blind_validation}")
+    print(
+        "Checkpoint: "
+        f"{args.checkpoint_interval_seconds:g}s"
+        f"{' resume' if args.resume else ''}"
+    )
 
     patch, metrics = asyncio.run(generate(instance, image, cfg, args, workflow_fn, wf_label))
 
     out_path = Path(args.output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    record = {
-        "instance_id": iid,
-        "model_name_or_path": model_name,
-        "model_patch": patch,
-    }
+    record, metric_record = build_output_records(
+        instance_id=iid,
+        model_name=model_name,
+        patch=patch,
+        metrics=metrics,
+    )
     with out_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record) + "\n")
 
     metrics_path = Path(args.metrics or f"{args.output}.metrics.jsonl")
     with metrics_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps({**metrics, "model_name_or_path": model_name}) + "\n")
+        f.write(json.dumps(metric_record) + "\n")
 
     if patch.strip():
         print(f"\nPatch ({len(patch)} chars) written to {out_path}")


### PR DESCRIPTION
这份改动添加 SWE 评测状态层，包含评测记录解析、patch 与 report 配对、状态判定、检查点恢复、自动评测 driver，以及 wave watchdog。

状态层使用 record_id 与 patch_sha256 绑定候选结果，避免复用过期评测报告；检查点恢复路径改为每次运行私有目录，脚本默认保持只读行为。

依赖顺序：请先评审并合入 #8，然后再评审这份 PR。#8 合入后，这份 PR 的差异会自动缩小到评测状态层相关内容。

验证结果：72 个相关测试通过。独立评审 Agent 已通过。