### PR TITLE
修复 LLM 用量账本自动审查问题

### DIFF
--- a/opencollab/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/opencollab/adapters/llm/anthropic_provider.py
@@ -22,6 +22,8 @@ def _anthropic_tool_choice(tool_choice: Any) -> dict[str, Any] | None:
     """
     if tool_choice is None:
         return None
+    if tool_choice == "none":
+        return {"type": "none"}
     if tool_choice == "required":
         return {"type": "any"}
     if tool_choice == "auto":

--- a/opencollab/opencollab/adapters/llm/client.py
+++ b/opencollab/opencollab/adapters/llm/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from typing import Any
@@ -13,6 +14,13 @@ from opencollab.adapters.llm.openai_provider import complete_openai
 from opencollab.adapters.llm.providers import is_anthropic, warn_provider_near_miss
 from opencollab.adapters.llm.types import LLMResponse, model_context_window
 from opencollab.adapters.llm.usage_ledger import record_api_usage
+
+
+async def _record_api_usage_async(**kwargs: Any) -> None:
+    try:
+        await asyncio.to_thread(record_api_usage, **kwargs)
+    except Exception:
+        return
 
 
 class LLMClient:
@@ -113,7 +121,7 @@ class LLMClient:
                     tool_choice=tool_choice,
                     top_p=top_p,
                 )
-            record_api_usage(
+            await _record_api_usage_async(
                 provider=self.provider,
                 model=self.model,
                 base_url=self.base_url,
@@ -123,7 +131,7 @@ class LLMClient:
             )
             return response
         except Exception as exc:
-            record_api_usage(
+            await _record_api_usage_async(
                 provider=self.provider,
                 model=self.model,
                 base_url=self.base_url,

--- a/opencollab/opencollab/adapters/llm/client.py
+++ b/opencollab/opencollab/adapters/llm/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 import time
 from typing import Any
 
@@ -15,10 +16,16 @@ from opencollab.adapters.llm.providers import is_anthropic, warn_provider_near_m
 from opencollab.adapters.llm.types import LLMResponse, model_context_window
 from opencollab.adapters.llm.usage_ledger import record_api_usage
 
+_ledger_lock = threading.Lock()
+
 
 async def _record_api_usage_async(**kwargs: Any) -> None:
+    def _locked_record() -> None:
+        with _ledger_lock:
+            record_api_usage(**kwargs)
+
     try:
-        await asyncio.to_thread(record_api_usage, **kwargs)
+        await asyncio.to_thread(_locked_record)
     except Exception:
         return
 

--- a/opencollab/opencollab/adapters/llm/usage_ledger.py
+++ b/opencollab/opencollab/adapters/llm/usage_ledger.py
@@ -24,9 +24,6 @@ SECRET_ASSIGNMENT_RE = re.compile(
     r"((?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token|client[-_ ]?token|token|secret|password)"
     r"\s*[:=]\s*)[^\s,;'\")\]}]+"
 )
-SENSITIVE_TEXT_RE = re.compile(
-    r"(?i)((?:prompt|content|message|messages|input)\s*[:=]\s*)[^\r\n,;}\]]{1,500}"
-)
 
 
 def usage_log_path() -> Path | None:
@@ -52,22 +49,30 @@ def _float_env(name: str, default: float) -> float:
 def pricing_for_model(model: str | None) -> dict[str, float | str]:
     lowered = (model or "").lower()
     if "glm" in lowered:
+        input_price = _float_env("GLM_INPUT_USD_PER_MTOK", DEFAULT_GLM52_INPUT_USD_PER_MTOK)
         return {
             "mode": "glm-5.2-default",
-            "input_usd_per_mtok": _float_env(
-                "GLM_INPUT_USD_PER_MTOK", DEFAULT_GLM52_INPUT_USD_PER_MTOK
-            ),
+            "input_usd_per_mtok": input_price,
             "cached_input_usd_per_mtok": _float_env(
                 "GLM_CACHED_INPUT_USD_PER_MTOK", DEFAULT_GLM52_CACHED_INPUT_USD_PER_MTOK
+            ),
+            "cache_creation_usd_per_mtok": _float_env(
+                "GLM_CACHE_CREATION_USD_PER_MTOK",
+                input_price,
             ),
             "output_usd_per_mtok": _float_env(
                 "GLM_OUTPUT_USD_PER_MTOK", DEFAULT_GLM52_OUTPUT_USD_PER_MTOK
             ),
         }
+    input_price = _float_env("OPENCOLLAB_INPUT_USD_PER_MTOK", 0.0)
     return {
         "mode": "unset",
-        "input_usd_per_mtok": _float_env("OPENCOLLAB_INPUT_USD_PER_MTOK", 0.0),
+        "input_usd_per_mtok": input_price,
         "cached_input_usd_per_mtok": _float_env("OPENCOLLAB_CACHED_INPUT_USD_PER_MTOK", 0.0),
+        "cache_creation_usd_per_mtok": _float_env(
+            "OPENCOLLAB_CACHE_CREATION_USD_PER_MTOK",
+            input_price,
+        ),
         "output_usd_per_mtok": _float_env("OPENCOLLAB_OUTPUT_USD_PER_MTOK", 0.0),
     }
 
@@ -79,10 +84,12 @@ def usage_cost_usd(usage: Usage, model: str | None) -> float:
     uncached_input = max(int(usage.input_tokens or 0) - cached - cache_creation, 0)
     input_price = float(pricing["input_usd_per_mtok"])
     cached_price = float(pricing["cached_input_usd_per_mtok"])
+    cache_creation_price = float(pricing["cache_creation_usd_per_mtok"])
     output_price = float(pricing["output_usd_per_mtok"])
     return (
         uncached_input / 1_000_000 * input_price
         + cached / 1_000_000 * cached_price
+        + cache_creation / 1_000_000 * cache_creation_price
         + int(usage.output_tokens or 0) / 1_000_000 * output_price
     )
 
@@ -107,7 +114,7 @@ def _safe_base_url(base_url: str | None) -> dict[str, str | None]:
 
 def _redact_secrets(text: str) -> str:
     redacted = URL_RE.sub(lambda match: str(_safe_base_url(match.group(0))["base_url"]), text)
-    for name, value in os.environ.items():
+    for name, value in list(os.environ.items()):
         if not value or len(value) < 8:
             continue
         upper = name.upper()
@@ -124,7 +131,6 @@ def _redact_secrets(text: str) -> str:
         redacted,
     )
     redacted = SECRET_ASSIGNMENT_RE.sub(r"\1[redacted]", redacted)
-    redacted = SENSITIVE_TEXT_RE.sub(r"\1[redacted]", redacted)
     return redacted
 
 
@@ -208,17 +214,20 @@ def record_api_usage(
     response: LLMResponse | None = None,
     error: BaseException | None = None,
 ) -> None:
-    append_usage_record(
-        build_usage_record(
-            provider=provider,
-            model=model,
-            base_url=base_url,
-            latency_s=latency_s,
-            status=status,
-            response=response,
-            error=error,
+    try:
+        append_usage_record(
+            build_usage_record(
+                provider=provider,
+                model=model,
+                base_url=base_url,
+                latency_s=latency_s,
+                status=status,
+                response=response,
+                error=error,
+            )
         )
-    )
+    except Exception:
+        return
 
 
 __all__ = [

--- a/opencollab/opencollab/adapters/llm/usage_ledger.py
+++ b/opencollab/opencollab/adapters/llm/usage_ledger.py
@@ -21,8 +21,9 @@ SECRET_ENV_NAME_PARTS = ("API_KEY", "AUTH_TOKEN", "ACCESS_TOKEN", "CLIENT_TOKEN"
 URL_RE = re.compile(r"https?://[^\s'\"<>]+")
 SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)"
-    r"((?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token|client[-_ ]?token|token|secret|password)"
-    r"\s*[:=]\s*)[^\s,;'\")\]}]+"
+    r"(['\"]?(?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token|client[-_ ]?token|"
+    r"token|secret|password)['\"]?\s*[:=]\s*)"
+    r"(?:(['\"])(.*?)\2|([^\s,;'\")\]}]+))"
 )
 
 
@@ -130,8 +131,16 @@ def _redact_secrets(text: str) -> str:
         r"\1[redacted]",
         redacted,
     )
-    redacted = SECRET_ASSIGNMENT_RE.sub(r"\1[redacted]", redacted)
+    redacted = SECRET_ASSIGNMENT_RE.sub(_redact_secret_assignment, redacted)
     return redacted
+
+
+def _redact_secret_assignment(match: re.Match[str]) -> str:
+    prefix = match.group(1)
+    quote = match.group(2)
+    if quote:
+        return f"{prefix}{quote}[redacted]{quote}"
+    return f"{prefix}[redacted]"
 
 
 def _usage_payload(usage: Usage, model: str | None) -> dict[str, Any]:

--- a/opencollab/tests/test_llm_providers.py
+++ b/opencollab/tests/test_llm_providers.py
@@ -297,6 +297,15 @@ def test_anthropic_tool_choice_required_maps_to_any():
     assert "tool_choice" not in default
 
 
+def test_anthropic_tool_choice_none_maps_to_none_type():
+    tools = [{"function": {"name": "f", "parameters": {}}}]
+    msgs = [{"role": "user", "content": "hi"}]
+
+    kwargs = build_anthropic_kwargs("claude", msgs, tools, 0.0, tool_choice="none")
+
+    assert kwargs["tool_choice"] == {"type": "none"}
+
+
 def test_anthropic_tool_choice_named_function_maps_to_named_tool():
     tools = [{"function": {"name": "structured_output", "parameters": {}}}]
     msgs = [{"role": "user", "content": "hi"}]

--- a/opencollab/tests/test_llm_usage_ledger.py
+++ b/opencollab/tests/test_llm_usage_ledger.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from opencollab.adapters.llm import usage_ledger as ledger
 from opencollab.adapters.llm.client import LLMClient
 from opencollab.adapters.llm.types import Usage
 from opencollab.adapters.llm.usage_ledger import (
@@ -23,12 +24,18 @@ def _read_jsonl(path):
 def test_glm_usage_cost_accounts_for_cache_discount(monkeypatch):
     monkeypatch.delenv("GLM_INPUT_USD_PER_MTOK", raising=False)
     monkeypatch.delenv("GLM_CACHED_INPUT_USD_PER_MTOK", raising=False)
+    monkeypatch.delenv("GLM_CACHE_CREATION_USD_PER_MTOK", raising=False)
     monkeypatch.delenv("GLM_OUTPUT_USD_PER_MTOK", raising=False)
-    usage = Usage(input_tokens=1000, output_tokens=50, cache_read_tokens=800)
+    usage = Usage(
+        input_tokens=1000,
+        output_tokens=50,
+        cache_read_tokens=600,
+        cache_creation_tokens=200,
+    )
 
     cost = usage_cost_usd(usage, "glm-5.2")
 
-    expected = (200 * 1.4 + 800 * 0.26 + 50 * 4.4) / 1_000_000
+    expected = (200 * 1.4 + 600 * 0.26 + 200 * 1.4 + 50 * 4.4) / 1_000_000
     assert cost == pytest.approx(expected)
 
 
@@ -78,11 +85,11 @@ def test_usage_record_strips_base_url_userinfo_and_query():
     assert "hidden" not in record_text
 
 
-def test_error_message_redacts_url_token_and_prompt(monkeypatch):
+def test_error_message_redacts_secrets_without_hiding_plain_text(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "local-secret-token")
     error = RuntimeError(
         "failed https://user:secret@example.com:8443/v1?token=hidden "
-        "token=abc123 prompt=very secret prompt content: very secret body "
+        "token=abc123 prompt=ordinary prompt content message=plain input "
         "bearer local-secret-token"
     )
 
@@ -100,8 +107,24 @@ def test_error_message_redacts_url_token_and_prompt(monkeypatch):
     assert "user" not in record_text
     assert "hidden" not in record_text
     assert "abc123" not in record_text
-    assert "very secret" not in record_text
+    assert "ordinary prompt content" in record_text
+    assert "message=plain input" in record_text
     assert "local-secret-token" not in record_text
+
+
+def test_record_api_usage_is_fail_safe(monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError("ledger build failed")
+
+    monkeypatch.setattr(ledger, "build_usage_record", boom)
+
+    ledger.record_api_usage(
+        provider="openai",
+        model="glm-5.2",
+        base_url="http://127.0.0.1:18788/v1",
+        latency_s=0.1,
+        status="success",
+    )
 
 
 class _FakeCompletions:

--- a/opencollab/tests/test_llm_usage_ledger.py
+++ b/opencollab/tests/test_llm_usage_ledger.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from opencollab.adapters.llm import client as client_module
 from opencollab.adapters.llm import usage_ledger as ledger
 from opencollab.adapters.llm.client import LLMClient
 from opencollab.adapters.llm.types import Usage
@@ -112,6 +113,31 @@ def test_error_message_redacts_secrets_without_hiding_plain_text(monkeypatch):
     assert "local-secret-token" not in record_text
 
 
+def test_error_message_redacts_quoted_secret_assignments():
+    error = RuntimeError(
+        "failed password=\"my-secret\" {'token': 'abc123'} "
+        '"secret": "top secret value" prompt=ordinary prompt'
+    )
+
+    record = build_usage_record(
+        provider="openai",
+        model="glm-5.2",
+        base_url="https://safe.example/v1",
+        latency_s=0.25,
+        status="error",
+        error=error,
+    )
+    message = record["error"]["message"]
+
+    assert 'password="[redacted]"' in message
+    assert "'token': '[redacted]'" in message
+    assert '"secret": "[redacted]"' in message
+    assert "ordinary prompt" in message
+    assert "my-secret" not in message
+    assert "abc123" not in message
+    assert "top secret value" not in message
+
+
 def test_record_api_usage_is_fail_safe(monkeypatch):
     def boom(**kwargs):
         raise RuntimeError("ledger build failed")
@@ -125,6 +151,40 @@ def test_record_api_usage_is_fail_safe(monkeypatch):
         latency_s=0.1,
         status="success",
     )
+
+
+def test_async_usage_recording_runs_under_lock(monkeypatch):
+    events = []
+
+    class FakeLock:
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc, tb):
+            events.append("exit")
+
+    async def fake_to_thread(fn):
+        events.append("to_thread")
+        fn()
+
+    def fake_record_api_usage(**kwargs):
+        events.append("record")
+
+    monkeypatch.setattr(client_module, "_ledger_lock", FakeLock())
+    monkeypatch.setattr(client_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(client_module, "record_api_usage", fake_record_api_usage)
+
+    asyncio.run(
+        client_module._record_api_usage_async(
+            provider="openai",
+            model="glm-5.2",
+            base_url="http://127.0.0.1:18788/v1",
+            latency_s=0.1,
+            status="success",
+        )
+    )
+
+    assert events == ["to_thread", "enter", "record", "exit"]
 
 
 class _FakeCompletions:


### PR DESCRIPTION
这个 PR 修复已合并的 LLM 用量账本改动里，自动审查指出的几个问题。

主要调整包括：cache creation token 现在参与成本估算，并支持独立价格配置；API 用量记录失败时直接吞掉账本错误，避免影响真实 LLM 调用；LLM 客户端把账本写入放到线程里执行，减少异步调用中的文件 I/O 阻塞；Anthropic 的 tool_choice="none" 现在会转换成 Anthropic 接受的 {"type":"none"}；错误信息脱敏保留普通 prompt/content/message 文本，只隐藏 URL 凭据、token、secret 等敏感片段。

验证已完成：相关文件通过 compileall；目标行为断言覆盖 cache creation 计费、错误脱敏、record_api_usage 容错、Anthropic none 映射和 LLMClient 成功记录。