### PR TITLE
ci: add repo-wide lint, PR-title & file-hygiene gates, plus AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --extra dev
-      - name: Lint
-        run: uv run ruff check opencollab/
+      - name: Lint (whole repo)
+        working-directory: .
+        run: uv run --project opencollab ruff check .
       - name: Test
         run: uv run pytest -q

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -1,0 +1,45 @@
+name: Hygiene
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  added-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Block oversized new files and modules
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -u
+          max_bytes=512000     # 500 KB — large binaries/artifacts belong in release assets, not git
+          max_py_lines=800     # keep modules focused (matches the coding-style cap)
+          added=$(git diff --diff-filter=A --name-only "$BASE_SHA" "$HEAD_SHA")
+          if [ -z "$added" ]; then echo "No newly added files."; exit 0; fi
+          fail=0
+          while IFS= read -r f; do
+            [ -n "$f" ] && [ -f "$f" ] || continue
+            bytes=$(wc -c < "$f" | tr -d ' ')
+            if [ "$bytes" -gt "$max_bytes" ]; then
+              echo "::error file=$f::New file is ${bytes} bytes (> ${max_bytes}). Large binaries/artifacts (PDFs, images, datasets) don't belong in git history — use release assets or an external store."
+              fail=1
+            fi
+            case "$f" in
+              *.py)
+                lines=$(wc -l < "$f" | tr -d ' ')
+                if [ "$lines" -gt "$max_py_lines" ]; then
+                  echo "::error file=$f::New Python module is ${lines} lines (> ${max_py_lines}). Split it into focused modules."
+                  fail=1
+                fi
+                ;;
+            esac
+          done < <(printf '%s\n' "$added")
+          exit "$fail"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,25 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce Conventional Commits in the PR title
+        env:
+          # Read via env (never interpolate ${{ }} into the shell) to avoid injection.
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: $TITLE"
+          if printf '%s' "$TITLE" | grep -Eq '^(feat|fix|refactor|docs|test|chore|perf|ci|build|style|revert)(\([a-z0-9._/ -]+\))?!?: .+'; then
+            echo "OK: title follows Conventional Commits."
+          else
+            echo "::error::PR title must follow Conventional Commits — e.g. 'feat: add X', 'fix(tui): handle Y', 'chore!: drop Z'. Squash-merge uses the PR title as the commit subject, so it becomes the message on main."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,14 @@ workflow_logs/
 *.out
 *.synctex.gz
 *.xdv
+
+# Local team-config variants (per-user runtime, like configs/team.yaml above)
+configs/team.dev.yaml
+configs/team.local.yaml
+
+# Container markers written by tests/runtime — never commit
+container.id
+container.name
+
+# Compiled report artifacts — commit the .tex/.md sources, not the build output
+docs/**/*.pdf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Local guardrails that mirror CI. Install once:
+#   pip install pre-commit && pre-commit install
+# Hooks then run on every commit; bypass a one-off with `git commit --no-verify`.
+# Keep `rev` in sync with the ruff version pinned in opencollab/pyproject.toml.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        name: ruff (lint + autofix)
+        args: [--fix]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md
+
+Guidance for coding agents (OpenAI Codex, Claude Code, and others) contributing to
+**OpenCollab**. Follow it exactly — CI enforces most of it, and a PR that ignores it
+will be blocked. Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for the
+long form.
+
+## Setup & the checks your change must pass
+
+```bash
+cd opencollab && uv sync --extra dev          # create .venv with runtime + dev deps
+uv run --project opencollab ruff check .      # run from the REPO ROOT — lints the whole tree
+cd opencollab && uv run pytest -q             # test suite; must stay green
+```
+
+New behavior needs tests. Do not weaken or delete a test to make CI pass.
+
+## Project structure & the one architecture rule
+
+Strict clean architecture — dependencies point **inward only**:
+
+```
+adapters  →  application  →  domain
+```
+
+- `opencollab/opencollab/domain/` — pure value objects + session FSM. **Stdlib only, no I/O.**
+- `opencollab/opencollab/application/` — use cases, scheduler, ports (`application/ports.py`). Imports `domain` + stdlib only.
+- `opencollab/opencollab/adapters/` — concrete impls (`cli/`, `tui/`, `llm/`, `tools/`, env, tracing, store).
+- `opencollab/opencollab/bootstrap/` — composition root; the only layer that knows concrete types.
+- `opencollab/opencollab/harness/`, `swebench/`, `workflows/`, `scripts/` — headless eval, deterministic workflows, tooling.
+
+Never add an inward → outward import (`tests/test_*_boundaries.py` fail the build on it).
+Need an outer capability inside? Add a **port** in `application/ports.py`, wire the
+concrete type in `bootstrap/`. When splitting a module, keep its public names re-exported.
+
+## Commits & pull requests
+
+- **Conventional Commits**, in **English**: `feat` `fix` `refactor` `docs` `test`
+  `chore` `perf` `ci` `build` `style` `revert`. e.g. `feat: add X`, `fix(tui): handle Y`.
+- **The PR title must itself be a valid Conventional Commit** — merges are squashed, so
+  the PR title becomes the commit subject on `main`.
+- **One focused change per PR.** Don't bundle unrelated work.
+- `refactor:` must be behavior-preserving.
+- Feature branches are squash-merged, so keep review churn out of `main` — don't rely on
+  a merge preserving your intermediate commits.
+
+## Hard gates CI will fail your PR on
+
+1. **Lint** — `ruff check .` over the **whole** repo (package + `scripts/` + `swebench/`
+   + `workflows/` + tests). Config is the repo-root `ruff.toml` (line-length 120, py310).
+2. **PR title** — Conventional Commits (see above).
+3. **File hygiene** — a newly added file over **500 KB**, or a new `.py` module over
+   **800 lines**, fails the build.
+
+## Conventions that keep the repo clean
+
+- **English everywhere public-facing** — code, comments, docs, commit messages, PR text.
+  This repo ships to a public/OSS audience; no Chinese in tracked files.
+- **No hardcoded infrastructure.** Never bake a hostname, NFS path, username, private
+  model name, or personal env-file path in as a default. Read them from env/CLI and
+  fail fast if unset. (These leak topology and are useless to an external clone.)
+- **No compiled artifacts or large binaries in git.** Commit `.tex`/`.md` sources, not
+  the built PDFs; keep images small; put decks/datasets in release assets, not history.
+- **Don't copy-paste or `base64`-embed logic that already exists as a tested module** —
+  import it. Remote runners already sync the package, so `import` from
+  `opencollab/harness/…` instead of inlining a second, drifting copy.
+- **Keep modules focused** (< 800 lines) — split by feature/domain, not by type.
+
+## Eval integrity (load-bearing — read this)
+
+OpenCollab is an evaluation framework. A wrong `resolved: true` / `PASS` is worse than a
+crash: it silently corrupts results and hides a broken fix.
+
+- **Never report a task resolved / a test PASS unless the target `FAIL_TO_PASS` tests
+  actually executed and passed.** No test collected ≠ pass.
+- If a test command cannot be derived or is empty, treat it as a **technical failure
+  (RED)** — never fall back to a no-op passing command (e.g. `true`).
+- A verifier / gate role must retain some way to run an executable probe before it may
+  issue a `PASS`; a verdict on prose alone is not acceptable.
+
+## See also
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — full contributor guide and dev setup.
+- [CLAUDE.md](CLAUDE.md) — repo notes for Claude Code.
+- [SECURITY.md](SECURITY.md) — report vulnerabilities privately; never in a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,22 @@ cp configs/.env.example configs/.env   # then set OPENCOLLAB_API_KEY
 ## Checks (must pass before a PR)
 
 ```bash
-cd opencollab
-uv run pytest -q               # test suite
-uv run ruff check opencollab/  # lint
+uv run --project opencollab ruff check .   # lint the whole repo (root ruff.toml)
+cd opencollab && uv run pytest -q           # test suite
 ```
 
 New behavior needs tests, and the suite must stay green.
+
+### Enforced automatically in CI
+
+- **Lint** — `ruff check .` over the whole repo (package + `scripts/` + `swebench/`
+  + `workflows/` + tests); config lives in the repo-root `ruff.toml`.
+- **PR title** — must follow Conventional Commits; squash-merge uses it as the
+  commit subject on `main`.
+- **File hygiene** — a newly added file over 500 KB, or a new `.py` module over
+  800 lines, fails the build. Commit `.tex`/`.md` sources, not compiled PDFs.
+
+Optionally mirror these locally: `pip install pre-commit && pre-commit install`.
 
 ## The architecture rule (enforced by tests)
 

--- a/opencollab/pyproject.toml
+++ b/opencollab/pyproject.toml
@@ -46,12 +46,8 @@ Homepage = "https://github.com/YihongDong/OpenCollab"
 Repository = "https://github.com/YihongDong/OpenCollab"
 Issues = "https://github.com/YihongDong/OpenCollab/issues"
 
-[tool.ruff]
-line-length = 120
-target-version = "py310"
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "W"]
+# Ruff configuration lives in the repo-root ruff.toml, so a single config governs
+# the whole tree (this package + scripts/ + swebench/ + workflows/).
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/opencollab/tests/test_autosave_subscriber.py
+++ b/opencollab/tests/test_autosave_subscriber.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
-# Reuse the fakes from the characterization test file (same tests/ directory,
-# added to sys.path by pytest's rootdir discovery).
-from test_session_characterization import FakeAgent, FakeLLMClient
-
 from opencollab.application.autosave import SAVE_TRIGGERS, AutoSaveSubscriber
 from opencollab.application.event_bus import EventBus
 from opencollab.bootstrap import build_session as Session
 from opencollab.domain.events import SessionRuntimeEvent as SessionEvent
+
+# Reuse the fakes from the characterization test file (same tests/ directory,
+# added to sys.path by pytest's rootdir discovery).
+from test_session_characterization import FakeAgent, FakeLLMClient
 
 
 @pytest.mark.parametrize("trigger", sorted(SAVE_TRIGGERS))

--- a/opencollab/tests/test_bootstrap.py
+++ b/opencollab/tests/test_bootstrap.py
@@ -2,7 +2,6 @@ import json
 import os
 
 import pytest
-
 from opencollab.adapters.safety import SandboxInterceptor
 from opencollab.bootstrap import (
     build_runtime_context,

--- a/opencollab/tests/test_cli_toolbar.py
+++ b/opencollab/tests/test_cli_toolbar.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from prompt_toolkit.formatted_text import to_formatted_text
-
 from opencollab.adapters.cli.main import _PROMPT_STYLE, _dispatch_repl_command
 from opencollab.adapters.cli.toolbar import format_team_toolbar
+from prompt_toolkit.formatted_text import to_formatted_text
 
 
 class _FakeLead:

--- a/opencollab/tests/test_commit_first.py
+++ b/opencollab/tests/test_commit_first.py
@@ -17,14 +17,12 @@ fact-sheet anchors.
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 from typing import Any
 
 from opencollab.application.session_run import ENFORCEMENT_OFF, ENFORCEMENT_ON
 from opencollab.application.submit_findings import (
     SUBMIT_TOOL_NAME,
-    format_findings_report,
     harvest_findings,
 )
 from opencollab.application.workflow import WorkflowContext

--- a/opencollab/tests/test_config.py
+++ b/opencollab/tests/test_config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from opencollab.bootstrap.config import (
     accepted_api_key_envs,
     api_key_env_precedence,

--- a/opencollab/tests/test_context_builder.py
+++ b/opencollab/tests/test_context_builder.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from opencollab.application.event_bus import EventBus
 from opencollab.bootstrap.container import ContextBuilder, SpawnConfig
 from opencollab.bootstrap.team_config import BASE_TOOL_NAMES, RoleConfig, TeamConfig

--- a/opencollab/tests/test_edit_tool.py
+++ b/opencollab/tests/test_edit_tool.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.safety import SandboxInterceptor
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool

--- a/opencollab/tests/test_gen_prediction_workflow.py
+++ b/opencollab/tests/test_gen_prediction_workflow.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
 from opencollab.harness.evaluator import EvalResult, EvalTask
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/opencollab/tests/test_git_diff_tool.py
+++ b/opencollab/tests/test_git_diff_tool.py
@@ -2,7 +2,6 @@ import asyncio
 import subprocess
 
 import pytest
-
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.tools.git_diff import GitDiffTool
 from opencollab.application.tool_execution import ToolRuntime

--- a/opencollab/tests/test_hooks.py
+++ b/opencollab/tests/test_hooks.py
@@ -11,7 +11,6 @@ import asyncio
 import json
 
 import pytest
-
 from opencollab.adapters.hooks import ShellHookRunner
 from opencollab.application.hooks import HookEventSubscriber
 from opencollab.bootstrap import build_runtime_context, build_scheduler

--- a/opencollab/tests/test_inter_agent_messaging.py
+++ b/opencollab/tests/test_inter_agent_messaging.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 
 import pytest
-
 from opencollab.adapters.worktree_pool import WorktreePool
 from opencollab.application.event_bus import EventBus
 from opencollab.application.scheduler import Scheduler

--- a/opencollab/tests/test_llm_providers.py
+++ b/opencollab/tests/test_llm_providers.py
@@ -8,7 +8,6 @@ import sys
 from types import SimpleNamespace
 
 import pytest
-
 from opencollab.adapters.llm.anthropic_provider import _build_request_kwargs as build_anthropic_kwargs
 from opencollab.adapters.llm.anthropic_provider import _parse_response as parse_anthropic_response
 from opencollab.adapters.llm.anthropic_provider import _parse_usage as parse_anthropic_usage

--- a/opencollab/tests/test_llm_usage_ledger.py
+++ b/opencollab/tests/test_llm_usage_ledger.py
@@ -5,7 +5,6 @@ import json
 from types import SimpleNamespace
 
 import pytest
-
 from opencollab.adapters.llm import client as client_module
 from opencollab.adapters.llm import usage_ledger as ledger
 from opencollab.adapters.llm.client import LLMClient

--- a/opencollab/tests/test_pending_event_table.py
+++ b/opencollab/tests/test_pending_event_table.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from opencollab.domain.pending import (
     PendingEventTable,
     PendingRow,

--- a/opencollab/tests/test_scheduler_awaiting.py
+++ b/opencollab/tests/test_scheduler_awaiting.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
 from opencollab.adapters.worktree_pool import WorktreePool
 from opencollab.application.event_bus import EventBus
 from opencollab.application.scheduler import Scheduler

--- a/opencollab/tests/test_session_adapter.py
+++ b/opencollab/tests/test_session_adapter.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-
 from opencollab.adapters.tui import TuiAskUserPolicy, TuiPermissionPolicy
 
 

--- a/opencollab/tests/test_session_phase_fsm.py
+++ b/opencollab/tests/test_session_phase_fsm.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from opencollab.domain.session import (
     PHASE_TRANSITIONS,
     TERMINAL_PHASES,

--- a/opencollab/tests/test_skill_domain.py
+++ b/opencollab/tests/test_skill_domain.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import dataclasses
 
 import pytest
-
 from opencollab.domain.context import LAYER_PRIORITY, ContextLayer
 from opencollab.domain.skill import SkillManifest
 

--- a/opencollab/tests/test_split_solve_workflow.py
+++ b/opencollab/tests/test_split_solve_workflow.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from opencollab.bootstrap.workflow_runtime import discover_workflows
 
 _WF_DIR = Path(__file__).resolve().parents[2] / "workflows"

--- a/opencollab/tests/test_swe_committee_v2_workflow.py
+++ b/opencollab/tests/test_swe_committee_v2_workflow.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from opencollab.bootstrap.workflow_runtime import discover_workflows
 
 _WF_DIR = Path(__file__).resolve().parents[2] / "workflows"

--- a/opencollab/tests/test_swe_v1_prolite_runner.py
+++ b/opencollab/tests/test_swe_v1_prolite_runner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import io
 import importlib
+import io
 import json
 import subprocess
 import sys

--- a/opencollab/tests/test_team_config.py
+++ b/opencollab/tests/test_team_config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from opencollab.bootstrap.team_config import (
     BASE_TOOL_NAMES,
     DEFAULT_LEAD_PROMPT,

--- a/opencollab/tests/test_tool_call_processor_interceptor.py
+++ b/opencollab/tests/test_tool_call_processor_interceptor.py
@@ -4,7 +4,6 @@ import inspect
 import pkgutil
 
 import pytest
-
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.safety import SandboxInterceptor
 from opencollab.application.event_bus import EventBus

--- a/opencollab/tests/test_tool_limits.py
+++ b/opencollab/tests/test_tool_limits.py
@@ -8,7 +8,6 @@ budgets to its backend's context size. Unknown tools/kwargs fail fast.
 import asyncio
 
 import pytest
-
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.tools.bash import MAX_OUTPUT_CHARS
 from opencollab.application.tool_execution import ToolRuntime

--- a/opencollab/tests/test_tool_registry.py
+++ b/opencollab/tests/test_tool_registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from opencollab.adapters.tools.use_skill import UseSkillTool
 from opencollab.bootstrap.tool_registry import (
     KNOWN_TOOL_NAMES,

--- a/opencollab/tests/test_tool_runtime_contract.py
+++ b/opencollab/tests/test_tool_runtime_contract.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.safety import SandboxInterceptor
 from opencollab.adapters.tools import base, human

--- a/opencollab/tests/test_tui_brand_motion.py
+++ b/opencollab/tests/test_tui_brand_motion.py
@@ -7,15 +7,14 @@ TUI's per-glyph chrome walk stays satisfied.
 
 from __future__ import annotations
 
-from rich.console import Console
-from rich.text import Text
-
 from opencollab.adapters.tui.brand_motion import (
     DOT_GLYPH,
     PulseDot,
     dot_color,
     pulse_brightness,
 )
+from rich.console import Console
+from rich.text import Text
 
 
 def _assert_all_non_white(text: Text) -> None:

--- a/opencollab/tests/test_tui_event_rendering.py
+++ b/opencollab/tests/test_tui_event_rendering.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 
 from io import StringIO
 
-from rich.console import Console
-from rich.text import Text
-
 from opencollab.adapters.tui import TUI
 from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
+from rich.console import Console
+from rich.text import Text
 
 
 def _make_tui() -> TUI:

--- a/opencollab/tests/test_validation_council_workflow.py
+++ b/opencollab/tests/test_validation_council_workflow.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from opencollab.bootstrap.workflow_runtime import discover_workflows
 
 _WF_DIR = Path(__file__).resolve().parents[2] / "workflows"

--- a/opencollab/tests/test_workflow_cli.py
+++ b/opencollab/tests/test_workflow_cli.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from typer.testing import CliRunner
-
 from opencollab.adapters.cli import workflow as workflow_cli
 from opencollab.application.workflow_registry import Registry, workflow
+from typer.testing import CliRunner
 
 runner = CliRunner()
 

--- a/opencollab/tests/test_workflow_context.py
+++ b/opencollab/tests/test_workflow_context.py
@@ -12,7 +12,6 @@ from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 
 import pytest
-
 from opencollab.application.workflow import (
     WorkflowBudgetExceeded,
     WorkflowContext,

--- a/opencollab/tests/test_workflow_registry.py
+++ b/opencollab/tests/test_workflow_registry.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import textwrap
 
 import pytest
-
 from opencollab.application.workflow_registry import (
     Registry,
     WorkflowSpec,

--- a/opencollab/tests/test_workflow_runtime.py
+++ b/opencollab/tests/test_workflow_runtime.py
@@ -13,7 +13,6 @@ import os
 from typing import Any
 
 import pytest
-
 from opencollab.application.workflow import WorkflowBudgetExceeded, WorkflowContext
 from opencollab.bootstrap import workflow_runtime
 

--- a/opencollab/tests/test_workflow_structured_output.py
+++ b/opencollab/tests/test_workflow_structured_output.py
@@ -15,7 +15,6 @@ from collections.abc import Sequence
 from typing import Any
 
 import pytest
-
 from opencollab.application.schema_validate import validate
 from opencollab.application.structured_output import StructuredOutputTool
 from opencollab.application.tool_execution import ToolRuntime

--- a/opencollab/tests/test_working_tree_probe.py
+++ b/opencollab/tests/test_working_tree_probe.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
 from opencollab.adapters.working_tree import EnvWorkingTreeProbe
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,18 @@
+# Single source of truth for linting the WHOLE repository — the opencollab
+# package AND the repo-root tooling (scripts/, swebench/, workflows/).
+# CI runs `ruff check .` from the repo root so nothing escapes the gate.
+line-length = 120
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "I", "W"]
+
+[lint.per-file-ignores]
+# Grandfathered pre-existing debt, so the repo-wide lint gate can land without a
+# large refactor of legacy eval tooling. New code is fully linted; these entries
+# should be deleted as the files are cleaned up.
+# TODO(review-2026-07-09): split the 1706-line runner and clear these ignores.
+"**/swe_v1_prolite_runner.py" = ["E501"]
+"**/glm_token_monitor.py" = ["E501"]
+"**/swe_committee_v2.py" = ["E731"]
+"**/test_predictive_extension.py" = ["E501"]  # long expected-data literals

--- a/scripts/check_dashscope.py
+++ b/scripts/check_dashscope.py
@@ -2,9 +2,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 import requests
-
 from opencollab.bootstrap.config import build_config
-
 
 WORKSPACE = Path(__file__).resolve().parents[1]
 TEST_MODEL_NAME = "kimi-k2.6"

--- a/scripts/glm_token_monitor.py
+++ b/scripts/glm_token_monitor.py
@@ -7,7 +7,6 @@ import os
 import time
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TRAJECTORIES_DIR = REPO_ROOT / ".opencollab" / "logs" / "trajectories"
 DEFAULT_GLM52_INPUT_USD_PER_MTOK = 1.4

--- a/scripts/run_swebench_eval_per_instance.py
+++ b/scripts/run_swebench_eval_per_instance.py
@@ -2,15 +2,14 @@
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 import os
 import signal
 import subprocess
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/scripts/run_swebench_eval_with_docker_timeout.py
+++ b/scripts/run_swebench_eval_with_docker_timeout.py
@@ -6,7 +6,6 @@ import runpy
 
 import docker
 
-
 _original_from_env = docker.from_env
 
 

--- a/scripts/run_swebench_smoke_batch.py
+++ b/scripts/run_swebench_smoke_batch.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from swebench.harness.test_spec.test_spec import make_test_spec
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/scripts/swe_v1_prolite_runner.py
+++ b/scripts/swe_v1_prolite_runner.py
@@ -27,7 +27,6 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_HOST = "jinan-aws"
 DEFAULT_REMOTE_ROOT = "/nfsEDS/dongyh/data/kaka/docker/opencollab"

--- a/scripts/swebench_loop_monitor.py
+++ b/scripts/swebench_loop_monitor.py
@@ -12,7 +12,6 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-
 WRITE_TOOLS = {"file_write", "apply_patch"}
 WARN_LOOP_COUNT = 5
 CRITICAL_LOOP_COUNT = 10

--- a/swebench/gen_prediction_workflow.py
+++ b/swebench/gen_prediction_workflow.py
@@ -49,7 +49,6 @@ if str(_PKG_ROOT) not in sys.path:
     sys.path.insert(0, str(_PKG_ROOT))
 
 import gen_prediction as gp  # noqa: E402 — shared container plumbing
-
 from opencollab.adapters.env import DockerEnvironment  # noqa: E402
 from opencollab.bootstrap.config import get_config  # noqa: E402
 from opencollab.bootstrap.workflow_runtime import discover_workflows  # noqa: E402

--- a/workflows/swe_committee_v2.py
+++ b/workflows/swe_committee_v2.py
@@ -18,7 +18,6 @@ from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
 from opencollab.adapters.tools.run_tests import RunTestsTool
 from opencollab.application.workflow_registry import workflow
 
-
 MAX_PRE_TESTS = 5
 MAX_POST_TESTS = 4
 MAX_CODER_ROUNDS = 3


### PR DESCRIPTION
## Summary

Harden the contribution guardrails so future work stays standardized — CI becomes
the gate, not manual review. Motivated by the 2026-07-09 code review, which found
that `scripts/` (and `tests/`) escaped linting entirely and that non-standard
artifacts (large PDFs, non-conventional commits, hardcoded infra) had reached `main`.

### What lands

- **Repo-wide lint.** Ruff config moves to a single repo-root `ruff.toml`; CI now runs
  `ruff check .` over the whole tree (package + `scripts/` + `swebench/` + `workflows/`
  + tests). The old `ruff check opencollab/` never linted `scripts/` or `tests/`, so
  debt accumulated there. Pre-existing line-length/lambda debt in three legacy files is
  grandfathered via `per-file-ignores` with a TODO.
- **PR-title gate** — `.github/workflows/lint-pr-title.yml` enforces Conventional
  Commits (squash-merge uses the PR title as the commit subject).
- **File-hygiene gate** — `.github/workflows/hygiene.yml` fails a PR that adds a file
  over 500 KB or a new `.py` module over 800 lines (ratchets on newly added files;
  existing debt untouched).
- **`.pre-commit-config.yaml`** — mirrors the gates locally.
- **`.gitignore`** — local `team.*.yaml` variants, `container.id` / `container.name`
  markers, `docs/**/*.pdf`.
- **`AGENTS.md`** — auto-read by OpenAI Codex and other coding agents; restates the
  architecture rule, the setup/lint/test commands, commit & PR conventions, the CI hard
  gates, the clean-repo do/don'ts (no hardcoded infra, no committed build artifacts, no
  base64-embedded copies of tested modules, 800-line cap), and the eval-integrity rule.
- **`style:` commit** — one-time `ruff --fix` import normalization (I001 + 2 F401) across
  45 files so the tree passes the new gate. Mechanical and behavior-preserving.

### Verification

- `ruff check .` — clean, via the exact CI command `uv run --project opencollab ruff check .`.
- Full test suite — **1105 passed**.
- The three workflow YAMLs validate and were logic-reviewed.

### Follow-up (not in this PR)

- Enable branch protection on `main`: require PR + the `test` / `conventional-title` /
  `added-files` checks + squash-merge only. (No approvals / Code-Owner review required —
  avoids a self-approval bottleneck.)
- Clear the grandfathered `per-file-ignores` as the legacy eval scripts are refactored.
