### PR TITLE
fix: close two eval false-green vectors (no-op test command + council probe)

### DIFF
--- a/opencollab/tests/test_swe_v1_prolite_runner.py
+++ b/opencollab/tests/test_swe_v1_prolite_runner.py
@@ -140,6 +140,24 @@ def test_prolite_go_command_uses_package_targets(tmp_path):
     assert command == "go test ./internal/api ./pkg/server"
 
 
+def test_prolite_test_command_never_falls_back_to_a_passing_noop(tmp_path):
+    namespace = _remote_namespace(tmp_path)
+    command = namespace["prolite_test_command"]
+    is_runnable = namespace["_is_runnable_test_command"]
+
+    # An underivable command returns "" — NOT the old "true" no-op that ran zero
+    # target tests yet scored resolved=true (false green; 2026-07-09 review).
+    assert command({"repo_language": "python"}, []) == ""
+    assert command({}, []) == ""
+    assert command({"repo_language": "ruby"}, ["spec/widget_spec.rb"]) == ""
+
+    # The runnable-command gate rejects every no-op form and accepts real commands.
+    assert not is_runnable("")
+    assert not is_runnable("true")
+    assert not is_runnable(" : ")
+    assert is_runnable("python3 -m pytest -q tests/test_x.py::test_y")
+
+
 def test_ensure_image_pulls_missing_image(tmp_path):
     namespace = _remote_namespace(tmp_path)
     existing: set[str] = set()

--- a/opencollab/tests/test_validation_council_toolsets.py
+++ b/opencollab/tests/test_validation_council_toolsets.py
@@ -29,12 +29,15 @@ def test_validation_council_read_tools_are_read_only():
     assert "apply_patch" not in names
 
 
-def test_validation_council_tester_tools_cannot_edit():
+def test_validation_council_tester_tools_can_probe_but_not_author():
+    # Gate roles must be able to run an executable probe (bash) so a PASS is
+    # backed by a real check, not prose alone — removing it caused a silent
+    # false green (2026-07-09 review). They still cannot author the fix.
     tools = _workflow_globals()["_tester_tools"]()
     names = _names(tools)
 
-    assert names == ["file_read", "run_tests", "grep", "git_diff"]
-    assert "bash" not in names
+    assert "bash" in names
+    assert {"file_read", "run_tests", "grep", "git_diff"} <= set(names)
     assert "file_write" not in names
     assert "apply_patch" not in names
     run_tests = next(tool for tool in tools if tool.name == "run_tests")
@@ -42,8 +45,14 @@ def test_validation_council_tester_tools_cannot_edit():
     assert run_tests.allow_extra_args is False
 
 
-def test_validation_council_risk_tools_are_disabled():
-    assert _workflow_globals()["_risk_tools"]() == []
+def test_validation_council_risk_tools_can_read_the_diff():
+    # An auditor with no tools (was []) cannot inspect what it judges — it must
+    # at least read the diff and sources, while staying read-only.
+    names = _names(_workflow_globals()["_risk_tools"]())
+    assert "file_read" in names
+    assert "git_diff" in names
+    assert "bash" not in names
+    assert "file_write" not in names
 
 
 def test_validation_council_coder_tools_keep_edit_path():

--- a/scripts/swe_v1_prolite_runner.py
+++ b/scripts/swe_v1_prolite_runner.py
@@ -577,6 +577,15 @@ def js_runner_command(binary, package_script, target, extra_args=""):
     ])
 
 
+_NOOP_TEST_COMMANDS = {"", "true", ":", "/bin/true"}
+
+
+def _is_runnable_test_command(cmd):
+    # A no-op like `true` "passes" instantly and would score a false green:
+    # resolved=true having executed zero target tests. Treat it as no command.
+    return bool(cmd) and cmd.strip() not in _NOOP_TEST_COMMANDS
+
+
 def prolite_test_command(row, tests):
     language = str(row.get("repo_language") or "").lower()
     repo = str(row.get("repo") or "").lower()
@@ -611,7 +620,7 @@ def prolite_test_command(row, tests):
         if repo == "element-hq/element-web":
             return js_runner_command("jest", "test", target)
         return js_runner_command("jest", "test", target)
-    return str(row.get("test_cmd") or row.get("eval_cmd") or "true")
+    return str(row.get("test_cmd") or row.get("eval_cmd") or "")
 
 
 def generation_for_task(row):
@@ -899,6 +908,10 @@ exit 0
     f2p_log_tail = read_text("f2p.log")
     p2p_log_tail = read_text("p2p.log")
     technical_reasons = []
+    if not _is_runnable_test_command(f2p_cmd):
+        # No derivable FAIL_TO_PASS command: we cannot prove the fix, so this is a
+        # technical failure (resolved stays False) — never a silent pass.
+        technical_reasons.append("no_fail_to_pass_command")
     if docker_exit != 0:
         technical_reasons.append("docker_exit")
     if before_status != 0:

--- a/workflows/validation_council_solve.py
+++ b/workflows/validation_council_solve.py
@@ -575,7 +575,12 @@ def _coder_tools() -> list[Any]:
 
 
 def _tester_tools() -> list[Any]:
+    # Gate roles (patch-validator, post-triage, final-verifier) need an executable
+    # probe so a PASS is backed by a real run, not prose alone. Blindness holds
+    # because the hidden FAIL_TO_PASS tests are absent from the container, not
+    # because bash is. No file_write/apply_patch: these roles verify, not author.
     return [
+        BashTool(),
         FileReadTool(),
         RunTestsTool(allow_runner_override=False, allow_extra_args=False),
         GrepTool(),
@@ -584,7 +589,9 @@ def _tester_tools() -> list[Any]:
 
 
 def _risk_tools() -> list[Any]:
-    return []
+    # The diff-risk auditor must at least read the diff and the sources it judges;
+    # an empty toolset let it "audit" blind. Read-only — no execution or authoring.
+    return [FileReadTool(), GrepTool(), GitDiffTool()]
 
 
 def _dump(value: Any) -> str:


### PR DESCRIPTION
## Summary

Fixes the two HIGH eval-integrity findings from the 2026-07-09 review — both were
silent false greens (a wrong `resolved` / `PASS` produced with no real test run).

### 1. Runner: no-op `"true"` fallback → false `resolved:true`

`scripts/swe_v1_prolite_runner.py` — `prolite_test_command()` fell back to the shell
command `true` when it couldn't derive a test command (a python row with empty
FAIL_TO_PASS, or a language outside `{python, go, js}`). The eval then ran
`bash -c true` (exit 0), so `resolved = not error and f2p==0 and p2p==0` was True and
the report recorded `resolved:true` having executed **zero** target tests — and the
discovery layer consumes that verbatim as the authoritative resolved signal.

Now an underivable command returns `""`, and a no-op (`""` / `true` / `:`) is treated
as a technical failure (`no_fail_to_pass_command`) that forces `resolved=False`.

### 2. Council: gate roles had no executable probe → PASS on prose

`workflows/validation_council_solve.py` — the gate roles (patch-validator,
post-triage, final-verifier) had lost `BashTool` and the diff-risk auditor had an
empty toolset, so in blind-default mode a `PASS` — which drives workflow status
`done` — could be issued with no executable proof of the fix. Restored a repro probe
(`BashTool`) to the gate roles (still **no** `file_write`/`apply_patch` — they verify,
they don't author) and read tools to the auditor. Blindness is preserved: the hidden
FAIL_TO_PASS tests are absent from the container, not gated by tool removal.

## Tests

- New regression test: `prolite_test_command` never returns a no-op; the
  runnable-command gate rejects `""` / `"true"` / `":"`.
- The council toolset tests **previously asserted the buggy state as correct**
  (`bash` absent, risk tools `== []`) — a test that encoded the false green. They now
  assert the corrected contract.
- Full suite: **1106 passed**.

## Note

Both defects already sit on `main` (merged via PRs #7–#12), so this is a fix-forward.
The runner (`swe_v1_prolite_runner.py`) is still a 1706-line script with an embedded
base64 copy of the tested harness (review finding #3) — a separate refactor if we
want the repo leaner.
