### PR TITLE
fix(harness): 修复评测证据与资源清理竞态

### DIFF
--- a/opencollab/opencollab/adapters/_env_local.py
+++ b/opencollab/opencollab/adapters/_env_local.py
@@ -12,6 +12,10 @@ from opencollab.adapters._env_base import Environment, ExecResult
 from opencollab.adapters._env_config import (
     LOCAL_FILE_READ_LIMIT_BYTES,
     LOCAL_FILE_WRITE_LIMIT_BYTES,
+    PROCESS_IO_JOIN_TIMEOUT_SECONDS,
+    PROCESS_KILL_REAP_TIMEOUT_SECONDS,
+    PROCESS_SPAWN_HANDOFF_TIMEOUT_SECONDS,
+    PROCESS_TERM_GRACE_SECONDS,
 )
 from opencollab.adapters._env_file_io import (
     _positive_file_size_limit,
@@ -25,14 +29,130 @@ from opencollab.adapters._env_file_io import (
     _TemporaryFileReplacedError,
 )
 from opencollab.adapters._env_process import (
+    _await_owned_operation,
     _OwnedProcessNotQuiesced,
     _OwnedProcessTimeout,
     _run_thread_owned_process,
+    _ThreadProcessOwner,
 )
 from opencollab.adapters.retirement_registry import (
     registered_retirement_paths,
 )
 from opencollab.application.exception_notes import add_exception_note
+
+
+class _ActiveProcessOperations:
+    """Revoke and observe every command owned by one local environment."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._operations: dict[object, _ThreadProcessOwner | None] = {}
+        self._lingering_owners: set[_ThreadProcessOwner] = set()
+        self._revoked_owners: set[_ThreadProcessOwner] = set()
+        self._revoked = False
+
+    def begin(self) -> object:
+        with self._lock:
+            if self._revoked:
+                raise RuntimeError("process operations have been revoked")
+            self._lingering_owners = {
+                owner for owner in self._lingering_owners if not owner.finished.is_set()
+            }
+            token = object()
+            self._operations[token] = None
+            return token
+
+    def attach(self, token: object, owner: _ThreadProcessOwner) -> None:
+        with self._lock:
+            if token not in self._operations:
+                raise RuntimeError("process operation ownership is unavailable")
+            if self._operations[token] is not None:
+                raise RuntimeError("process operation already has an owner")
+            self._operations[token] = owner
+            revoked = self._revoked
+            if revoked:
+                self._revoked_owners.add(owner)
+        if revoked:
+            owner.cancel()
+
+    def finish(self, token: object) -> None:
+        with self._lock:
+            owner = self._operations.pop(token, None)
+            if owner is not None and not owner.finished.is_set():
+                self._lingering_owners.add(owner)
+            if self._revoked and owner is not None:
+                self._revoked_owners.add(owner)
+
+    async def abort(self) -> None:
+        with self._lock:
+            self._revoked = True
+            owners = {
+                owner for owner in self._operations.values() if owner is not None
+            }
+            owners.update(self._lingering_owners)
+            self._revoked_owners.update(owners)
+        for owner in owners:
+            owner.cancel()
+
+        wait_bound = (
+            _positive_finite_timeout(
+                PROCESS_SPAWN_HANDOFF_TIMEOUT_SECONDS,
+                name="PROCESS_SPAWN_HANDOFF_TIMEOUT_SECONDS",
+            )
+            + _positive_finite_timeout(
+                PROCESS_TERM_GRACE_SECONDS,
+                name="PROCESS_TERM_GRACE_SECONDS",
+            )
+            + _positive_finite_timeout(
+                PROCESS_KILL_REAP_TIMEOUT_SECONDS,
+                name="PROCESS_KILL_REAP_TIMEOUT_SECONDS",
+            )
+            + PROCESS_IO_JOIN_TIMEOUT_SECONDS * 5
+            + 1.0
+        )
+
+        async def wait_for_every_operation() -> bool:
+            deadline = asyncio.get_running_loop().time() + wait_bound
+            while True:
+                with self._lock:
+                    current_owners = {
+                        owner
+                        for owner in self._operations.values()
+                        if owner is not None
+                    }
+                    current_owners.update(self._lingering_owners)
+                    self._revoked_owners.update(current_owners)
+                    operations_pending = bool(self._operations)
+                for current_owner in current_owners:
+                    current_owner.cancel()
+                if not operations_pending and all(
+                    owner.finished.is_set() for owner in current_owners
+                ):
+                    return True
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    return False
+                await asyncio.sleep(min(0.01, remaining))
+
+        completed = await _await_owned_operation(
+            wait_for_every_operation(),
+            propagate_cancellation=True,
+        )
+        if not completed:
+            raise _OwnedProcessNotQuiesced(
+                "environment commands did not finish within the abort bound",
+                cleanup_quiesced=False,
+            )
+        with self._lock:
+            revoked_owners = tuple(self._revoked_owners)
+        if any(
+            not owner.finished.is_set() or not owner.result.cleanup_quiesced
+            for owner in revoked_owners
+        ):
+            raise _OwnedProcessNotQuiesced(
+                "environment command cleanup did not quiesce",
+                cleanup_quiesced=False,
+            )
 
 
 class LocalEnvironment(Environment):
@@ -67,6 +187,7 @@ class LocalEnvironment(Environment):
         self._workspace_lock = threading.Lock()
         self._temp_file_identities: dict[str, _TemporaryFileOwnership] = {}
         self._temp_identity_lock = threading.Lock()
+        self._process_operations = _ActiveProcessOperations()
 
     def _verify_workspace_identity_locked(self) -> None:
         if self._workspace_fd < 0:
@@ -185,46 +306,54 @@ class LocalEnvironment(Environment):
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
         timeout_seconds = _positive_finite_timeout(timeout, name="timeout")
         self._ensure_active()
-        workspace_fd = self._acquire_workspace_handle()
+        operation_token = self._process_operations.begin()
         try:
+            workspace_fd = self._acquire_workspace_handle()
             try:
-                result = await _run_thread_owned_process(
-                    cmd,
-                    shell=True,
-                    cwd=None,
-                    cwd_fd=workspace_fd,
-                    timeout=timeout_seconds,
-                    timeout_name="timeout",
-                )
-                outcome = ExecResult(
-                    returncode=result.returncode or 0,
-                    stdout=result.stdout.decode("utf-8", errors="replace"),
-                    stderr=result.stderr.decode("utf-8", errors="replace"),
-                    stdout_truncated=result.stdout_dropped_bytes > 0,
-                    stderr_truncated=result.stderr_dropped_bytes > 0,
-                    stdout_dropped_bytes=result.stdout_dropped_bytes,
-                    stderr_dropped_bytes=result.stderr_dropped_bytes,
-                )
-            except _OwnedProcessTimeout as exc:
-                if not exc.cleanup_quiesced:
+                try:
+                    result = await _run_thread_owned_process(
+                        cmd,
+                        shell=True,
+                        cwd=None,
+                        cwd_fd=workspace_fd,
+                        timeout=timeout_seconds,
+                        timeout_name="timeout",
+                        owner_started=lambda owner: self._process_operations.attach(
+                            operation_token,
+                            owner,
+                        ),
+                    )
+                    outcome = ExecResult(
+                        returncode=result.returncode or 0,
+                        stdout=result.stdout.decode("utf-8", errors="replace"),
+                        stderr=result.stderr.decode("utf-8", errors="replace"),
+                        stdout_truncated=result.stdout_dropped_bytes > 0,
+                        stderr_truncated=result.stderr_dropped_bytes > 0,
+                        stdout_dropped_bytes=result.stdout_dropped_bytes,
+                        stderr_dropped_bytes=result.stderr_dropped_bytes,
+                    )
+                except _OwnedProcessTimeout as exc:
+                    if not exc.cleanup_quiesced:
+                        self._aborted = True
+                    outcome = ExecResult(
+                        returncode=-1,
+                        stdout="",
+                        stderr=f"Command timed out after {timeout_seconds:g}s",
+                    )
+                except _OwnedProcessNotQuiesced:
                     self._aborted = True
-                outcome = ExecResult(
-                    returncode=-1,
-                    stdout="",
-                    stderr=f"Command timed out after {timeout_seconds:g}s",
-                )
-            except _OwnedProcessNotQuiesced:
-                self._aborted = True
+                    raise
+                except asyncio.CancelledError as exc:
+                    if getattr(exc, "cleanup_quiesced", True) is False:
+                        self._aborted = True
+                    raise
+            except BaseException as original:
+                self._finish_workspace_operation(workspace_fd, original)
                 raise
-            except asyncio.CancelledError as exc:
-                if getattr(exc, "cleanup_quiesced", True) is False:
-                    self._aborted = True
-                raise
-        except BaseException as original:
-            self._finish_workspace_operation(workspace_fd, original)
-            raise
-        self._finish_workspace_operation(workspace_fd)
-        return outcome
+            self._finish_workspace_operation(workspace_fd)
+            return outcome
+        finally:
+            self._process_operations.finish(operation_token)
 
     async def read_file(self, path: str) -> str:
         self._ensure_active()
@@ -361,6 +490,7 @@ class LocalEnvironment(Environment):
                     self._temp_file_identities.pop(full, None)
 
     async def cleanup(self) -> None:
+        await self._process_operations.abort()
         await _run_owned_blocking_io(self._sync_release_owned_resources)
 
     async def abort(self) -> None:

--- a/opencollab/opencollab/adapters/_env_process.py
+++ b/opencollab/opencollab/adapters/_env_process.py
@@ -267,7 +267,12 @@ class _ThreadProcessOwner:
         )
 
     def start(self) -> None:
-        self._thread.start()
+        try:
+            self._thread.start()
+        except BaseException as exc:
+            self.result.error = exc
+            self._finished.set()
+            raise
 
     def cancel(self) -> None:
         self._cancel_requested.set()
@@ -356,6 +361,9 @@ class _ThreadProcessOwner:
         deadline = time.monotonic() + self._timeout
         interrupted = False
         try:
+            if self._cancel_requested.is_set():
+                self.result.returncode = -int(signal.SIGTERM)
+                return
             popen_kwargs = {
                 "shell": self._shell,
                 "cwd": self._cwd,
@@ -505,6 +513,7 @@ async def _run_thread_owned_process(
     timeout_name: str,
     input_data: bytes | None = None,
     late_compensation: Callable[["_ThreadProcessResult"], None] | None = None,
+    owner_started: Callable[[_ThreadProcessOwner], None] | None = None,
 ) -> _ThreadProcessResult:
     timeout_seconds = _positive_finite_timeout(timeout, name=timeout_name)
     owner = _ThreadProcessOwner(
@@ -516,6 +525,8 @@ async def _run_thread_owned_process(
         input_data=input_data,
         late_compensation=late_compensation,
     )
+    if owner_started is not None:
+        owner_started(owner)
     owner.start()
     wait_bound = (
         timeout_seconds

--- a/opencollab/opencollab/adapters/_env_worktree.py
+++ b/opencollab/opencollab/adapters/_env_worktree.py
@@ -50,7 +50,7 @@ class WorktreeEnvironment(Environment):
         self._worktree_dir: str | None = None
         self._worktree_dir_fd = -1
         self._worktree_quarantine_dir: str | None = None
-        self._worktree_directory_removed = False
+        self._worktree_directory_removed = True
         self._local_env: LocalEnvironment | None = None
         self._base_commit: str | None = None
         self._worktree_registered = False
@@ -344,6 +344,7 @@ class WorktreeEnvironment(Environment):
         self._branch_preexisting = False
         self._branch_cleanup_pending = True
         self._worktree_dir = os.path.realpath(tempfile.mkdtemp(prefix="opencollab-wt-"))
+        self._worktree_directory_removed = False
         self._capture_worktree_directory_handle()
         self._worktree_add_attempted = True
         self._add_owner_active = True

--- a/opencollab/opencollab/adapters/_owned_file_cleanup.py
+++ b/opencollab/opencollab/adapters/_owned_file_cleanup.py
@@ -12,7 +12,9 @@ from opencollab.adapters import _atomic_rename
 from opencollab.adapters._posix_file_support import require_posix_file_support
 from opencollab.adapters.retirement_registry import (
     RETIRED_FILE_PREFIX,
+    forget_verified_retirements,
     register_verified_retirement,
+    verified_retirement_identities,
 )
 from opencollab.application.exception_notes import add_exception_note
 
@@ -78,6 +80,114 @@ def _retired_usage(parent_fd: int) -> tuple[int, int]:
     return count, total_bytes
 
 
+def _retirement_identity(
+    parent: os.stat_result,
+    entry: os.stat_result,
+) -> tuple[int, ...]:
+    return (
+        parent.st_dev,
+        parent.st_ino,
+        entry.st_dev,
+        entry.st_ino,
+        stat.S_IFMT(entry.st_mode),
+        entry.st_size,
+        entry.st_mtime_ns,
+        entry.st_ctime_ns,
+        entry.st_nlink,
+    )
+
+
+def reclaim_verified_retirements(
+    parent_fd: int,
+    *,
+    additional_files: int,
+    additional_bytes: int,
+    path_label: str,
+    lock_held: bool = False,
+    excluded_names: frozenset[str] = frozenset(),
+) -> tuple[str, ...]:
+    """Reclaim only unchanged, registry-backed tombstones needed for capacity."""
+    _validate_retirement_reservation(additional_files, additional_bytes)
+
+    def reclaim() -> tuple[str, ...]:
+        retired_count, retired_bytes = _retired_usage(parent_fd)
+        count_excess = max(
+            0,
+            retired_count + additional_files - MAX_RETIRED_FILES_PER_DIRECTORY,
+        )
+        byte_excess = max(
+            0,
+            retired_bytes + additional_bytes - MAX_RETIRED_BYTES_PER_DIRECTORY,
+        )
+        if count_excess == 0 and byte_excess == 0:
+            return ()
+
+        parent = os.fstat(parent_fd)
+        reclaimed: list[str] = []
+        for name, registered_identity in verified_retirement_identities(parent_fd):
+            if count_excess == 0 and byte_excess == 0:
+                break
+            if name in excluded_names:
+                continue
+            try:
+                before = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or _retirement_identity(parent, before) != registered_identity
+            ):
+                continue
+            flags = (
+                os.O_RDONLY
+                | getattr(os, "O_NONBLOCK", 0)
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            owned_fd = os.open(name, flags, dir_fd=parent_fd)
+            try:
+                opened = os.fstat(owned_fd)
+                current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+                if (
+                    _retirement_identity(parent, opened) != registered_identity
+                    or _retirement_identity(parent, current) != registered_identity
+                ):
+                    continue
+                os.unlink(name, dir_fd=parent_fd)
+                detached = os.fstat(owned_fd)
+                if (
+                    (detached.st_dev, detached.st_ino)
+                    != (opened.st_dev, opened.st_ino)
+                    or detached.st_nlink != max(0, opened.st_nlink - 1)
+                ):
+                    raise OSError(
+                        f"verified retirement unlink was not bound to its owned inode: {path_label}"
+                    )
+                reclaimed.append(name)
+                retired_count -= 1
+                retired_bytes -= max(opened.st_size, 0)
+                count_excess = max(
+                    0,
+                    retired_count + additional_files - MAX_RETIRED_FILES_PER_DIRECTORY,
+                )
+                byte_excess = max(
+                    0,
+                    retired_bytes + additional_bytes - MAX_RETIRED_BYTES_PER_DIRECTORY,
+                )
+            finally:
+                os.close(owned_fd)
+
+        if reclaimed:
+            os.fsync(parent_fd)
+            forget_verified_retirements(parent_fd, tuple(reclaimed))
+        return tuple(reclaimed)
+
+    if lock_held:
+        return reclaim()
+    with retirement_lock(parent_fd):
+        return reclaim()
+
+
 def require_retirement_capacity(
     parent_fd: int,
     *,
@@ -87,15 +197,7 @@ def require_retirement_capacity(
 ) -> None:
     """Require room for a complete cooperative retirement transaction."""
     require_posix_file_support()
-    if (
-        isinstance(additional_files, bool)
-        or not isinstance(additional_files, int)
-        or isinstance(additional_bytes, bool)
-        or not isinstance(additional_bytes, int)
-    ):
-        raise TypeError("retirement capacity reservation must use integers")
-    if additional_files < 0 or additional_bytes < 0:
-        raise ValueError("retirement capacity reservation cannot be negative")
+    _validate_retirement_reservation(additional_files, additional_bytes)
     retired_count, retired_bytes = _retired_usage(parent_fd)
     if retired_count + additional_files > MAX_RETIRED_FILES_PER_DIRECTORY:
         raise OSError(
@@ -107,6 +209,21 @@ def require_retirement_capacity(
             f"retired-file byte limit reached for parent of {path_label}: "
             f"{retired_bytes} existing, {additional_bytes} required bytes"
         )
+
+
+def _validate_retirement_reservation(
+    additional_files: object,
+    additional_bytes: object,
+) -> None:
+    if (
+        isinstance(additional_files, bool)
+        or not isinstance(additional_files, int)
+        or isinstance(additional_bytes, bool)
+        or not isinstance(additional_bytes, int)
+    ):
+        raise TypeError("retirement capacity reservation must use integers")
+    if additional_files < 0 or additional_bytes < 0:
+        raise ValueError("retirement capacity reservation cannot be negative")
 
 
 def _check_retirement_capacity(parent_fd: int, size: int, path_label: str) -> None:
@@ -133,6 +250,14 @@ def _retire_entry_locked(
             current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
         except FileNotFoundError:
             return None
+        reclaim_verified_retirements(
+            parent_fd,
+            additional_files=1,
+            additional_bytes=max(current.st_size, 0),
+            path_label=path_label,
+            lock_held=True,
+            excluded_names=frozenset({name}),
+        )
         _check_retirement_capacity(parent_fd, current.st_size, path_label)
         retired = _new_retired_name()
         try:
@@ -199,6 +324,7 @@ def create_owned_retirement_candidate(
         raise TypeError("retirement candidate byte reservation must be an integer")
     if candidate_bytes < 0:
         raise ValueError("retirement candidate byte reservation cannot be negative")
+    _validate_retirement_reservation(required_files, required_bytes)
     flags = (
         os.O_WRONLY
         | os.O_CREAT
@@ -212,6 +338,13 @@ def create_owned_retirement_candidate(
     result: tuple[str, int, tuple[int, int], int] | None = None
     try:
         with retirement_lock(parent_fd):
+            reclaim_verified_retirements(
+                parent_fd,
+                additional_files=required_files,
+                additional_bytes=required_bytes + candidate_bytes,
+                path_label=path_label,
+                lock_held=True,
+            )
             require_retirement_capacity(
                 parent_fd,
                 additional_files=required_files,
@@ -565,6 +698,7 @@ __all__ = [
     "create_owned_retirement_candidate",
     "finalize_owned_retirement_candidate",
     "quarantine_unlink_owned_file",
+    "reclaim_verified_retirements",
     "refresh_verified_retirement_record",
     "require_retirement_capacity",
     "retire_owned_file",

--- a/opencollab/opencollab/adapters/retirement_registry.py
+++ b/opencollab/opencollab/adapters/retirement_registry.py
@@ -113,7 +113,7 @@ def _relative_path(parent_fd: int, name: str) -> str:
         getpath = getattr(fcntl, "F_GETPATH", None)
         if getpath is None:
             raise OSError("descriptor path lookup is unavailable")
-        raw = fcntl.fcntl(parent_fd, getpath, b"\0" * 4096)
+        raw = fcntl.fcntl(parent_fd, getpath, b"\0" * 1024)
         parent = raw.split(b"\0", 1)[0].decode()
     root = os.path.realpath(workspace)
     candidate = os.path.realpath(os.path.join(parent, name))
@@ -143,6 +143,51 @@ def _append_record(path: str, record: _RetirementRecord) -> None:
             os.close(fd)
 
 
+def _records_from_raw(raw: bytes) -> list[_RetirementRecord]:
+    if raw and not raw.endswith(b"\n"):
+        raise OSError("internal retirement log has a partial record")
+    lines = raw.splitlines()
+    if len(lines) > MAX_RETIREMENT_LOG_RECORDS:
+        raise OSError("internal retirement log has too many records")
+    records: list[_RetirementRecord] = []
+    for line in lines:
+        try:
+            payload = json.loads(line, object_pairs_hook=_unique_object)
+            records.append(_RetirementRecord.from_payload(payload))
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            raise OSError("internal retirement log is malformed") from exc
+    return records
+
+
+def _read_locked_records(fd: int) -> list[_RetirementRecord]:
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_size > MAX_RETIREMENT_LOG_BYTES:
+        raise OSError("internal retirement log is invalid")
+    os.lseek(fd, 0, os.SEEK_SET)
+    return _records_from_raw(os.read(fd, MAX_RETIREMENT_LOG_BYTES + 1))
+
+
+def _write_locked_records(fd: int, records: list[_RetirementRecord]) -> None:
+    if len(records) > MAX_RETIREMENT_LOG_RECORDS:
+        raise OSError("internal retirement log has too many records")
+    payload = b"".join(
+        json.dumps(asdict(record), sort_keys=True, separators=(",", ":")).encode()
+        + b"\n"
+        for record in records
+    )
+    if len(payload) > MAX_RETIREMENT_LOG_BYTES:
+        raise OSError("internal retirement log exceeds its bound")
+    os.lseek(fd, 0, os.SEEK_SET)
+    view = memoryview(payload)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("internal retirement log rewrite made no progress")
+        view = view[written:]
+    os.ftruncate(fd, len(payload))
+    os.fsync(fd)
+
+
 def register_verified_retirement(parent_fd: int, retired_name: str) -> None:
     """Record one verified internal tombstone before patch extraction."""
     log = os.environ.get(INTERNAL_RETIREMENT_LOG_ENV, "")
@@ -159,27 +204,12 @@ def _load_records(path: str | os.PathLike[str]) -> list[_RetirementRecord]:
     fd = os.open(path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0))
     try:
         fcntl.flock(fd, fcntl.LOCK_SH)
-        info = os.fstat(fd)
-        if not stat.S_ISREG(info.st_mode) or info.st_size > MAX_RETIREMENT_LOG_BYTES:
-            raise OSError("internal retirement log is invalid")
-        raw = os.read(fd, MAX_RETIREMENT_LOG_BYTES + 1)
+        records = _read_locked_records(fd)
     finally:
         try:
             fcntl.flock(fd, fcntl.LOCK_UN)
         finally:
             os.close(fd)
-    if raw and not raw.endswith(b"\n"):
-        raise OSError("internal retirement log has a partial record")
-    lines = raw.splitlines()
-    if len(lines) > MAX_RETIREMENT_LOG_RECORDS:
-        raise OSError("internal retirement log has too many records")
-    records: list[_RetirementRecord] = []
-    for line in lines:
-        try:
-            payload = json.loads(line, object_pairs_hook=_unique_object)
-            records.append(_RetirementRecord.from_payload(payload))
-        except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
-            raise OSError("internal retirement log is malformed") from exc
     return records
 
 
@@ -190,6 +220,71 @@ def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
             raise ValueError("duplicate retirement log field")
         result[key] = value
     return result
+
+
+def verified_retirement_identities(
+    parent_fd: int,
+) -> tuple[tuple[str, tuple[int, ...]], ...]:
+    """Return the latest registered identity for each tombstone in one parent."""
+    parent = os.fstat(parent_fd)
+    if not stat.S_ISDIR(parent.st_mode):
+        raise OSError("retirement parent descriptor is not a directory")
+    with _lock:
+        records = list(_records)
+    log = os.environ.get(INTERNAL_RETIREMENT_LOG_ENV, "")
+    if log:
+        records.extend(_load_records(log))
+    expected_parent = (parent.st_dev, parent.st_ino)
+    identities: dict[str, tuple[int, ...]] = {}
+    for record in records:
+        if (record.parent_dev, record.parent_ino) == expected_parent:
+            identities[record.name] = record.identity()
+    return tuple(identities.items())
+
+
+def forget_verified_retirements(parent_fd: int, names: tuple[str, ...]) -> None:
+    """Forget tombstones removed after descriptor and registry verification."""
+    if not names:
+        return
+    for name in names:
+        _validate_name(name)
+    parent = os.fstat(parent_fd)
+    if not stat.S_ISDIR(parent.st_mode):
+        raise OSError("retirement parent descriptor is not a directory")
+    expected_parent = (parent.st_dev, parent.st_ino)
+    removed = set(names)
+
+    log = os.environ.get(INTERNAL_RETIREMENT_LOG_ENV, "")
+    if log:
+        flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(log, flags)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            records = _read_locked_records(fd)
+            retained = [
+                record
+                for record in records
+                if not (
+                    (record.parent_dev, record.parent_ino) == expected_parent
+                    and record.name in removed
+                )
+            ]
+            _write_locked_records(fd, retained)
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+    with _lock:
+        _records[:] = [
+            record
+            for record in _records
+            if not (
+                (record.parent_dev, record.parent_ino) == expected_parent
+                and record.name in removed
+            )
+        ]
 
 
 def registered_retirement_paths(
@@ -279,6 +374,8 @@ __all__ = [
     "MAX_RETIREMENT_LOG_BYTES",
     "MAX_RETIREMENT_LOG_RECORDS",
     "RETIRED_FILE_PREFIX",
+    "forget_verified_retirements",
     "register_verified_retirement",
     "registered_retirement_paths",
+    "verified_retirement_identities",
 ]

--- a/opencollab/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/opencollab/adapters/tools/run_tests.py
@@ -135,6 +135,7 @@ class RunTestsTool(Tool):
         self.allow_runner_override = allow_runner_override
         self.allow_extra_args = allow_extra_args
         self.require_process_isolation = require_process_isolation
+        self._verified_targets: set[str] = set()
         # target -> consecutive RED count, for the escalation nudge. The tool
         # instance is shared across a task's workflow sessions (built once in
         # the eval toolset), so this survives across run_tests calls.
@@ -202,6 +203,11 @@ class RunTestsTool(Tool):
             runner=runner,
             target=target,
         )
+        if target:
+            if green:
+                self._verified_targets.add(target)
+            else:
+                self._verified_targets.discard(target)
         streak = self._record(target, green)
         return _format_report(
             cmd,
@@ -241,14 +247,79 @@ class RunTestsTool(Tool):
         self._consecutive_fail[target] = n
         return n
 
+    @property
+    def verified_targets(self) -> frozenset[str]:
+        """Exact requested targets whose latest parser-backed verdict was GREEN."""
+        return frozenset(self._verified_targets)
+
+
+def verification_run_tests_tool() -> RunTestsTool:
+    """Build the model-facing verifier with command overrides disabled."""
+    return RunTestsTool(allow_runner_override=False, allow_extra_args=False)
+
+
+_ENV_ASSIGNMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*", re.DOTALL)
+_PYTHON_EXECUTABLE_RE = re.compile(r"(?:python(?:\d+(?:\.\d+)*)?|pypy\d*)")
+_PYTHON_FLAG_OPTIONS = frozenset({"-B", "-E", "-I", "-O", "-OO", "-P", "-q", "-s", "-S", "-u", "-v"})
+
+
+def _python_invokes_pytest(parts: list[str]) -> bool:
+    executable = parts[0].rsplit("/", 1)[-1]
+    if _PYTHON_EXECUTABLE_RE.fullmatch(executable) is None:
+        return False
+    index = 1
+    while index < len(parts):
+        part = parts[index]
+        if part == "-m":
+            return index + 1 < len(parts) and parts[index + 1] == "pytest"
+        if part in {"-W", "-X", "--check-hash-based-pycs"}:
+            index += 2
+            continue
+        if part.startswith(("-W", "-X")) and len(part) > 2:
+            index += 1
+            continue
+        if part in _PYTHON_FLAG_OPTIONS:
+            index += 1
+            continue
+        return False
+    return False
+
+
+def _parts_invoke_pytest(parts: list[str], *, depth: int = 0) -> bool:
+    """Recognize supported direct wrappers without accepting shell interpreters."""
+    if not parts or depth > 3:
+        return False
+    executable = parts[0].rsplit("/", 1)[-1]
+    if executable == "pytest":
+        return True
+    if _python_invokes_pytest(parts):
+        return True
+    if executable == "env":
+        index = 1
+        while index < len(parts) and _ENV_ASSIGNMENT_RE.fullmatch(parts[index]):
+            index += 1
+        if index < len(parts) and parts[index] == "--":
+            index += 1
+        return _parts_invoke_pytest(parts[index:], depth=depth + 1)
+    if executable in {"uv", "poetry", "pipenv"} and len(parts) >= 3 and parts[1] == "run":
+        index = 3 if parts[2] == "--" else 2
+        return _parts_invoke_pytest(parts[index:], depth=depth + 1)
+    return (
+        executable in {"coverage", "coverage3"}
+        and len(parts) >= 4
+        and parts[1:4] == ["run", "-m", "pytest"]
+    )
+
 
 def _is_pytest_runner(runner: str) -> bool:
-    """Whether ``runner`` invokes pytest (so pytest-only flags are safe)."""
+    """Whether ``runner`` directly invokes pytest (so pytest flags are safe)."""
+    if any(token in runner for token in ("\n", "\r", ";", "&", "|", "<", ">", "`", "$(")):
+        return False
     try:
         parts = shlex.split(runner)
     except ValueError:
         return False
-    return any(part == "pytest" or part.endswith("/pytest") for part in parts)
+    return _parts_invoke_pytest(parts)
 
 
 def _is_go_runner(runner: str) -> bool:
@@ -383,14 +454,20 @@ def _pytest_no_tests(returncode: int, output: str) -> bool:
     return returncode == 5 and "no tests ran" in output.lower()
 
 
-def _summary_line(output: str) -> str | None:
-    """The last complete pytest result summary, with or without ``====``."""
-    summary = None
+def _summary_lines(output: str) -> list[str]:
+    """Return every complete pytest result summary in emission order."""
+    summaries = []
     for line in output.splitlines():
         candidate = line.strip().strip("= ").strip()
         if _PYTEST_SUMMARY_RE.fullmatch(candidate) or _PYTEST_NO_TESTS_RE.fullmatch(candidate):
-            summary = candidate
-    return summary
+            summaries.append(candidate)
+    return summaries
+
+
+def _summary_line(output: str) -> str | None:
+    """The last complete pytest result summary, with or without ``====``."""
+    summaries = _summary_lines(output)
+    return summaries[-1] if summaries else None
 
 
 def _parse_counts(summary: str | None) -> tuple[dict[str, int], int]:
@@ -515,7 +592,13 @@ def _is_green(
     target: str = "",
 ) -> bool:
     """Require positive evidence that at least one requested test executed."""
-    summary = _summary_line(output)
+    summaries = _summary_lines(output)
+    if _is_pytest_runner(runner) and len(summaries) != 1:
+        # One tool invocation represents one pytest session. Multiple result
+        # summaries are ambiguous and let an appended passing summary hide an
+        # earlier failure; no summary proves no pytest session completed.
+        return False
+    summary = summaries[0] if summaries else None
     counts, _ = _parse_counts(summary)
     if counts.get("failed", 0) or counts.get("error", 0):
         return False

--- a/opencollab/opencollab/application/_scheduler_cleanup.py
+++ b/opencollab/opencollab/application/_scheduler_cleanup.py
@@ -19,6 +19,24 @@ from opencollab.domain.pending import PendingRowError, RowStatus
 logger = logging.getLogger(__name__)
 
 
+class _RetryableSchedulerCleanupError(RuntimeError):
+    """A bounded cleanup reached a fully tracked, retry-safe failure state."""
+
+
+def _unique_task_owners(
+    *groups: Any,
+) -> list[tuple[int, asyncio.Task[Any]]]:
+    owners: list[tuple[int, asyncio.Task[Any]]] = []
+    seen: set[asyncio.Task[Any]] = set()
+    for group in groups:
+        for aid, task in group:
+            if task in seen:
+                continue
+            seen.add(task)
+            owners.append((aid, task))
+    return owners
+
+
 class SchedulerCleanupMixin:
     async def cleanup(
         self,
@@ -47,15 +65,16 @@ class SchedulerCleanupMixin:
                     forced_timeout=forced_timeout,
                 )
             )
+        cleanup_task = self._cleanup_task
 
         cancellation: asyncio.CancelledError | None = None
         cleanup_failure: BaseException | None = None
         while True:
             try:
-                await asyncio.shield(self._cleanup_task)
+                await asyncio.shield(cleanup_task)
                 break
             except asyncio.CancelledError as exc:
-                if self._cleanup_task.cancelled():
+                if cleanup_task.cancelled():
                     raise
                 if cancellation is None:
                     cancellation = exc
@@ -66,6 +85,11 @@ class SchedulerCleanupMixin:
             except BaseException as exc:
                 cleanup_failure = exc
                 break
+        if (
+            isinstance(cleanup_failure, _RetryableSchedulerCleanupError)
+            and self._cleanup_task is cleanup_task
+        ):
+            self._cleanup_task = None
         if cancellation is not None:
             if cleanup_failure is not None:
                 add_exception_note(
@@ -93,23 +117,26 @@ class SchedulerCleanupMixin:
             **self._startup_origin,
             **self._spawn_origin,
         }
-        execution_tasks = [
-            *self._tasks.items(),
-            *self._startup_tasks.items(),
-        ]
+        execution_tasks = _unique_task_owners(
+            self._cleanup_execution_tasks,
+            self._tasks.items(),
+            self._startup_tasks.items(),
+        )
         delivery_records = list(self._message_delivery_records.values())
         if self._lead_turn_record is not None:
             self._lead_turn_record["cleanup_terminal"] = True
             delivery_records.append(self._lead_turn_record)
-        delivery_tasks = [
-            *self._message_delivery_tasks.items(),
-            *((0, task) for task in self._active_run_tasks),
-        ]
+        delivery_tasks = _unique_task_owners(
+            self._cleanup_delivery_tasks,
+            self._message_delivery_tasks.items(),
+            ((0, task) for task in self._active_run_tasks),
+        )
         for record in delivery_records:
             add_task = record.get("add_task")
             if isinstance(add_task, asyncio.Task):
                 delivery_tasks.append((int(record["aid"]), add_task))
-        tracked_tasks = [*execution_tasks, *delivery_tasks]
+        delivery_tasks = _unique_task_owners(delivery_tasks)
+        tracked_tasks = _unique_task_owners(execution_tasks, delivery_tasks)
         for task in {task for _, task in tracked_tasks}:
             if not task.done():
                 task.cancel()
@@ -128,7 +155,7 @@ class SchedulerCleanupMixin:
         environment_abort_succeeded = True
         if pending:
             pending_aids = {aid for aid, task in execution_tasks if task in pending}
-            if pending_aids:
+            if pending_aids or self._cleanup_environment_abort_tasks:
                 environment_abort_succeeded = await self._abort_session_environments(
                     pending_aids,
                     timeout=forced_timeout,
@@ -153,6 +180,11 @@ class SchedulerCleanupMixin:
                 for error in termination.errors:
                     logger.error("forced scheduler task termination failed: %s", error)
             pending = still_pending
+        if not pending and self._cleanup_environment_abort_tasks:
+            environment_abort_succeeded = await self._abort_session_environments(
+                set(),
+                timeout=forced_timeout,
+            )
         if execution_required_forced_stop:
             cleanup_failures.append("execution tasks did not quiesce")
         if not environment_abort_succeeded:
@@ -207,6 +239,15 @@ class SchedulerCleanupMixin:
             if record.get("cleanup_terminal", False):
                 self._finalize_cleanup_failure(aid)
         self._active_run_tasks.clear()
+        execution_task_set = {task for _, task in execution_tasks}
+        self._cleanup_execution_tasks = {
+            (aid, task) for aid, task in execution_tasks if not task.done()
+        }
+        self._cleanup_delivery_tasks = {
+            (aid, task)
+            for aid, task in delivery_tasks
+            if task not in execution_task_set and not task.done()
+        }
         # Teardown is terminal for this scheduler instance. Release even a
         # seeded-but-never-run Lead lease and defensively clear any reservation /
         # dedup entry whose owner disappeared before it entered a tracked task.
@@ -276,10 +317,13 @@ class SchedulerCleanupMixin:
                     "worktree pool release skipped because execution ownership was not revoked and quiesced"
                 )
         if cleanup_failures:
-            failure = RuntimeError("technical scheduler cleanup failed: " + "; ".join(cleanup_failures))
+            failure = _RetryableSchedulerCleanupError(
+                "technical scheduler cleanup failed: " + "; ".join(cleanup_failures)
+            )
             if persistence_errors:
                 raise failure from persistence_errors[0]
             raise failure
+        self._cleanup_environment_abort_tasks.clear()
 
     @staticmethod
     async def _wait_for_cleanup_tasks(tasks: set[asyncio.Task[Any]], *, timeout: float) -> set[asyncio.Task[Any]]:
@@ -464,6 +508,10 @@ class SchedulerCleanupMixin:
         seen: set[int] = set()
         abort_tasks: set[asyncio.Task[Any]] = set()
         succeeded = True
+        candidates: list[tuple[int, Any]] = [
+            (-1, env)
+            for env, _task in self._cleanup_environment_abort_tasks.values()
+        ]
         for aid in aids:
             session = self._sessions.get(aid)
             envs = [self._startup_envs.get(aid)]
@@ -472,40 +520,68 @@ class SchedulerCleanupMixin:
                 tool_execution = getattr(session, "tool_execution", None)
                 envs.append(getattr(tool_execution, "environment", None))
             for env in envs:
-                if env is None or id(env) in seen:
+                if env is not None:
+                    candidates.append((aid, env))
+        for aid, env in candidates:
+            env_key = id(env)
+            if env_key in seen:
+                continue
+            seen.add(env_key)
+            existing = self._cleanup_environment_abort_tasks.get(env_key)
+            if existing is not None and existing[0] is env:
+                existing_task = existing[1]
+                if not existing_task.done():
+                    abort_tasks.add(existing_task)
                     continue
-                seen.add(id(env))
+                if not existing_task.cancelled():
+                    try:
+                        existing_error = existing_task.exception()
+                    except asyncio.CancelledError:
+                        existing_error = None
+                    if existing_error is None:
+                        continue
+                    logger.error(
+                        "session environment abort task failed: %s",
+                        existing_error,
+                    )
+                self._cleanup_environment_abort_tasks.pop(env_key, None)
+            try:
+                env._aborted = True
+            except BaseException as exc:
+                succeeded = False
+                logger.error(
+                    "session environment synchronous revoke failed for aid %s: %s",
+                    aid,
+                    exc,
+                )
+            abort = getattr(env, "abort", None)
+            if not callable(abort):
+                continue
+            try:
+                result = abort()
+            except BaseException as exc:
+                succeeded = False
+                logger.error("session environment abort failed for aid %s: %s", aid, exc)
+                continue
+            if inspect.isawaitable(result):
                 try:
-                    env._aborted = True
+                    abort_task = asyncio.ensure_future(result)
                 except BaseException as exc:
                     succeeded = False
                     logger.error(
-                        "session environment synchronous revoke failed for aid %s: %s",
+                        "session environment abort scheduling failed for aid %s: %s",
                         aid,
                         exc,
                     )
-                abort = getattr(env, "abort", None)
-                if not callable(abort):
-                    continue
-                try:
-                    result = abort()
-                except BaseException as exc:
-                    succeeded = False
-                    logger.error("session environment abort failed for aid %s: %s", aid, exc)
-                    continue
-                if inspect.isawaitable(result):
-                    try:
-                        abort_tasks.add(asyncio.ensure_future(result))
-                    except BaseException as exc:
-                        succeeded = False
-                        logger.error(
-                            "session environment abort scheduling failed for aid %s: %s",
-                            aid,
-                            exc,
-                        )
-                        close = getattr(result, "close", None)
-                        if callable(close):
-                            close()
+                    close = getattr(result, "close", None)
+                    if callable(close):
+                        close()
+                else:
+                    self._cleanup_environment_abort_tasks[env_key] = (
+                        env,
+                        abort_task,
+                    )
+                    abort_tasks.add(abort_task)
 
         pending = await self._wait_for_cleanup_tasks(abort_tasks, timeout=timeout)
         if pending:
@@ -534,20 +610,27 @@ class SchedulerCleanupMixin:
                 "%s session environment abort task(s) remained active after cleanup timeout",
                 len(pending),
             )
-        for task in abort_tasks:
+        for env_key, (_env, task) in tuple(
+            self._cleanup_environment_abort_tasks.items()
+        ):
+            if task not in abort_tasks:
+                continue
             if not task.done():
                 task.add_done_callback(self._consume_background_task)
                 continue
             if task.cancelled():
                 succeeded = False
+                self._cleanup_environment_abort_tasks.pop(env_key, None)
                 continue
             try:
                 error = task.exception()
             except asyncio.CancelledError:
                 succeeded = False
+                self._cleanup_environment_abort_tasks.pop(env_key, None)
             else:
                 if error is not None:
                     succeeded = False
+                    self._cleanup_environment_abort_tasks.pop(env_key, None)
                     logger.error("session environment abort task failed: %s", error)
         return succeeded and not pending
 
@@ -557,21 +640,35 @@ class SchedulerCleanupMixin:
         cleanup_timeout: float,
         forced_timeout: float,
     ) -> bool:
-        try:
-            result = self._worktree_pool.release()
-        except BaseException as exc:
-            logger.error("worktree pool release failed: %s", exc)
-            return False
-        if not inspect.isawaitable(result):
-            return True
-        try:
-            task = asyncio.ensure_future(result)
-        except BaseException as exc:
-            logger.error("worktree pool release scheduling failed: %s", exc)
-            close = getattr(result, "close", None)
-            if callable(close):
-                close()
-            return False
+        task = self._cleanup_worktree_release_task
+        if task is not None and task.done():
+            self._cleanup_worktree_release_task = None
+            if not task.cancelled():
+                try:
+                    prior_error = task.exception()
+                except asyncio.CancelledError:
+                    prior_error = None
+                if prior_error is None:
+                    return True
+                logger.error("worktree pool release failed: %s", prior_error)
+            task = None
+        if task is None:
+            try:
+                result = self._worktree_pool.release()
+            except BaseException as exc:
+                logger.error("worktree pool release failed: %s", exc)
+                return False
+            if not inspect.isawaitable(result):
+                return True
+            try:
+                task = asyncio.ensure_future(result)
+            except BaseException as exc:
+                logger.error("worktree pool release scheduling failed: %s", exc)
+                close = getattr(result, "close", None)
+                if callable(close):
+                    close()
+                return False
+            self._cleanup_worktree_release_task = task
         pending = await self._wait_for_cleanup_tasks(
             {task},
             timeout=cleanup_timeout,
@@ -598,12 +695,20 @@ class SchedulerCleanupMixin:
             logger.error("worktree pool release remained active after cleanup timeout")
             return False
         if task.cancelled():
+            if self._cleanup_worktree_release_task is task:
+                self._cleanup_worktree_release_task = None
             return False
         try:
             error = task.exception()
         except asyncio.CancelledError:
+            if self._cleanup_worktree_release_task is task:
+                self._cleanup_worktree_release_task = None
             return False
         if error is not None:
             logger.error("worktree pool release failed: %s", error)
+            if self._cleanup_worktree_release_task is task:
+                self._cleanup_worktree_release_task = None
             return False
+        if succeeded and self._cleanup_worktree_release_task is task:
+            self._cleanup_worktree_release_task = None
         return succeeded

--- a/opencollab/opencollab/application/scheduler.py
+++ b/opencollab/opencollab/application/scheduler.py
@@ -188,6 +188,13 @@ class Scheduler(
         self._manifest_subscriber: AutoSaveSubscriber | None = None
         self._shutting_down = False
         self._cleanup_task: asyncio.Task[None] | None = None
+        self._cleanup_execution_tasks: set[tuple[int, asyncio.Task[Any]]] = set()
+        self._cleanup_delivery_tasks: set[tuple[int, asyncio.Task[Any]]] = set()
+        self._cleanup_environment_abort_tasks: dict[
+            int,
+            tuple[Any, asyncio.Task[Any]],
+        ] = {}
+        self._cleanup_worktree_release_task: asyncio.Task[Any] | None = None
         self._fallback_autosavers: dict[int, AutoSaveSubscriber] = {}
         self._scheduler_persistence_errors: list[Exception] = []
         # A synchronous review loop temporarily yields its caller's turn lease

--- a/opencollab/opencollab/application/scheduler_types.py
+++ b/opencollab/opencollab/application/scheduler_types.py
@@ -65,7 +65,7 @@ class QueuedTeammateMessage:
     summary: str
     content: str
     xml: str
-    sent_at: str
+    sent_at: str = ""
 
 
 __all__ = [

--- a/opencollab/opencollab/application/session.py
+++ b/opencollab/opencollab/application/session.py
@@ -44,7 +44,7 @@ class SessionRuntime:
     tool_execution: ToolExecutionUseCase
     runner: SessionRunUseCase
     auto_save_path: str | None
-    auto_save_subscriber: AutoSaveSubscriber | None
+    auto_save_subscriber: AutoSaveSubscriber | None = None
 
 
 class Session:

--- a/opencollab/opencollab/harness/evaluator_task.py
+++ b/opencollab/opencollab/harness/evaluator_task.py
@@ -5,7 +5,7 @@ import os
 import sys
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +16,383 @@ from opencollab.application.session import Session
 from opencollab.application.workflow import WorkflowContext
 from opencollab.harness.evaluator_patch import cleanup_injected_paths_and_extract_patch
 from opencollab.harness.evaluator_task_setup import prepare_eval_run
+
+
+@dataclass
+class _FinalizationState:
+    error: str | None
+    execution_quiesced: bool
+    checkpoint_result: dict[str, Any] | None
+    injected_paths: list[str]
+    harness_artifact_exclusion_proven: bool
+    checkpoint_restore_integrity_proven: bool
+    test_patch_isolation_failed: bool
+    task_stage_integrity_proven: bool
+    persistence_succeeded: bool = True
+    checkpoint_lingering: set[asyncio.Task[Any]] = field(default_factory=set)
+    final_snapshot_lingering: tuple[asyncio.Task[Any], ...] = ()
+    manifest_lingering: tuple[asyncio.Task[Any], ...] = ()
+    environment_revocation_quiesced: bool = False
+    patch: str = ""
+    patch_extraction_succeeded: bool = False
+    injected_path_cleanup_proven: bool = False
+
+
+def _collect_late_stage_outcomes(
+    facade: Any,
+    state: _FinalizationState,
+    stage_tasks: dict[str, asyncio.Task[Any]],
+    observed_stage_results: set[str],
+) -> None:
+    """Adopt stage results that arrived after their caller-side deadline."""
+    if not state.execution_quiesced:
+        return
+    for stage_name, stage_task in stage_tasks.items():
+        if stage_name in observed_stage_results:
+            continue
+        observed_stage_results.add(stage_name)
+        if stage_task.cancelled():
+            if stage_name == "checkpoint_restore":
+                state.checkpoint_restore_integrity_proven = False
+            elif stage_name == "test_patch_injection":
+                state.test_patch_isolation_failed = True
+            continue
+        try:
+            late_value = stage_task.result()
+        except facade.TestPatchIsolationError as exc:
+            if stage_name == "test_patch_injection":
+                state.injected_paths = list(dict.fromkeys((*state.injected_paths, *exc.touched_paths)))
+                state.test_patch_isolation_failed = True
+            state.error = facade._append_harness_error(state.error, f"late {stage_name} failed", exc)
+        except asyncio.CancelledError:
+            if stage_name == "checkpoint_restore":
+                state.checkpoint_restore_integrity_proven = False
+            elif stage_name == "test_patch_injection":
+                state.test_patch_isolation_failed = True
+        except BaseException as exc:
+            state.error = facade._append_harness_error(state.error, f"late {stage_name} failed", exc)
+            if stage_name == "checkpoint_restore":
+                state.checkpoint_restore_integrity_proven = False
+            elif stage_name == "test_patch_injection":
+                state.test_patch_isolation_failed = True
+        else:
+            if stage_name == "checkpoint_restore":
+                if state.checkpoint_result is None:
+                    state.checkpoint_result = {}
+                state.checkpoint_result["restore"] = late_value.to_dict()
+                state.checkpoint_restore_integrity_proven = False
+            elif stage_name == "test_patch_injection":
+                state.injected_paths = list(dict.fromkeys((*state.injected_paths, *late_value)))
+                state.test_patch_isolation_failed = True
+
+
+async def _finalize_checkpoint_and_patch(
+    facade: Any,
+    state: _FinalizationState,
+    *,
+    env: Any,
+    checkpoint: Any,
+    harness_artifact_paths: list[str],
+    cleanup_timeout: float,
+    await_teardown: Callable[[Awaitable[Any]], Awaitable[Any]],
+) -> None:
+    """Stop or abort checkpointing, then clean injected paths and extract the patch."""
+    if not state.execution_quiesced:
+        failure = TimeoutError("owned execution did not quiesce after cancellation; patch extraction skipped")
+        state.error = facade._append_harness_error(state.error, "execution cleanup timed out", failure)
+        if checkpoint is not None:
+            try:
+                checkpoint_quiesced = await await_teardown(checkpoint.abort(timeout=cleanup_timeout))
+            except Exception as exc:
+                checkpoint_quiesced = False
+                state.error = facade._append_harness_error(state.error, "checkpoint abort failed", exc)
+            if state.checkpoint_result is None:
+                state.checkpoint_result = {}
+            state.checkpoint_result["abort"] = {
+                "status": "aborted_non_quiescent_execution" if checkpoint_quiesced else "checkpoint_abort_timed_out"
+            }
+            if not checkpoint_quiesced:
+                state.error = facade._append_harness_error(
+                    state.error,
+                    "checkpoint abort timed out",
+                    TimeoutError("periodic checkpoint capture remained active"),
+                )
+        if env is not None:
+            env._aborted = True
+
+    unsafe_checkpoint = state.test_patch_isolation_failed or not state.checkpoint_restore_integrity_proven
+    if state.execution_quiesced and env and checkpoint is not None and unsafe_checkpoint:
+        try:
+            checkpoint_quiesced = await await_teardown(checkpoint.abort(timeout=cleanup_timeout))
+        except Exception as exc:
+            checkpoint_quiesced = False
+            state.error = facade._append_harness_error(state.error, "checkpoint abort failed", exc)
+        if state.checkpoint_result is None:
+            state.checkpoint_result = {}
+        skipped_status = (
+            "skipped_test_patch_isolation_failure"
+            if state.test_patch_isolation_failed
+            else "skipped_checkpoint_restore_integrity_failure"
+        )
+        state.checkpoint_result["final"] = {
+            "status": skipped_status if checkpoint_quiesced else "checkpoint_abort_timed_out"
+        }
+        if not checkpoint_quiesced:
+            state.error = facade._append_harness_error(
+                state.error,
+                "checkpoint abort timed out",
+                TimeoutError("periodic checkpoint capture remained active"),
+            )
+            state.execution_quiesced = False
+
+    if state.execution_quiesced and env and checkpoint is not None and not unsafe_checkpoint:
+        try:
+            checkpoint_finalized, final_checkpoint, stop_lingering = await await_teardown(
+                facade._stop_checkpoint_bounded(
+                    checkpoint,
+                    env,
+                    exclude_paths=(*state.injected_paths, *harness_artifact_paths),
+                    cleanup_timeout=cleanup_timeout,
+                )
+            )
+            state.checkpoint_lingering.update(stop_lingering)
+            if state.checkpoint_result is None:
+                state.checkpoint_result = {}
+            if checkpoint_finalized:
+                state.checkpoint_result["final"] = final_checkpoint.to_dict()
+            else:
+                state.checkpoint_result["final"] = {"status": "checkpoint_finalization_timed_out"}
+                state.error = facade._append_harness_error(
+                    state.error,
+                    "checkpoint finalization timed out",
+                    TimeoutError("checkpoint stop remained active"),
+                )
+                try:
+                    checkpoint_quiesced = await await_teardown(checkpoint.abort(timeout=cleanup_timeout))
+                    if not checkpoint_quiesced:
+                        state.error = facade._append_harness_error(
+                            state.error,
+                            "checkpoint abort timed out",
+                            TimeoutError("periodic checkpoint capture remained active"),
+                        )
+                except Exception as exc:
+                    state.error = facade._append_harness_error(state.error, "checkpoint abort failed", exc)
+                env._aborted = True
+                state.execution_quiesced = False
+        except Exception as exc:
+            state.error = facade._append_harness_error(state.error, "checkpoint finalization failed", exc)
+
+    (
+        state.injected_path_cleanup_proven,
+        state.patch,
+        state.patch_extraction_succeeded,
+        state.error,
+    ) = await cleanup_injected_paths_and_extract_patch(
+        facade,
+        env=env,
+        execution_quiesced=state.execution_quiesced,
+        injected_paths=state.injected_paths,
+        harness_artifact_paths=harness_artifact_paths,
+        cleanup_timeout=cleanup_timeout,
+        error=state.error,
+        test_patch_isolation_failed=state.test_patch_isolation_failed,
+        harness_artifact_exclusion_proven=state.harness_artifact_exclusion_proven,
+        checkpoint_restore_integrity_proven=state.checkpoint_restore_integrity_proven,
+        task_stage_integrity_proven=state.task_stage_integrity_proven,
+        await_teardown=await_teardown,
+    )
+
+
+async def _cleanup_resources_and_build_result(
+    facade: Any,
+    state: _FinalizationState,
+    *,
+    task: Any,
+    workflow: Any,
+    run_dir: str | None,
+    workflow_ctx: WorkflowContext | None,
+    session: Session | None,
+    checkpoint: Any,
+    owned_execution_tasks: list[asyncio.Task[Any]],
+    tracer: Any,
+    env: Any,
+    cleanup_timeout: float,
+    start: float,
+    await_teardown: Callable[[Awaitable[Any]], Awaitable[Any]],
+) -> Any:
+    """Persist the manifest, release owned resources, and build the public result."""
+    if state.execution_quiesced and workflow_ctx is not None and workflow is not None and run_dir is not None:
+        try:
+            manifest_quiesced, manifest_error, state.manifest_lingering = await await_teardown(
+                facade._persist_eval_workflow_manifest_owned(
+                    run_dir,
+                    task=task,
+                    workflow=workflow,
+                    ctx=workflow_ctx,
+                    cleanup_timeout=cleanup_timeout,
+                )
+            )
+        except Exception as exc:
+            state.persistence_succeeded = False
+            state.error = facade._append_harness_error(state.error, "workflow manifest failed", exc)
+        else:
+            if manifest_error is not None:
+                state.persistence_succeeded = False
+                state.error = facade._append_harness_error(state.error, "workflow manifest failed", manifest_error)
+            if not manifest_quiesced:
+                state.persistence_succeeded = False
+                state.execution_quiesced = False
+                state.error = facade._append_harness_error(
+                    state.error,
+                    "workflow manifest timed out",
+                    TimeoutError("manifest persistence owner remained active"),
+                )
+
+    live_resource_dependencies = {
+        owned
+        for owned in (
+            *owned_execution_tasks,
+            *state.final_snapshot_lingering,
+            *state.manifest_lingering,
+            *state.checkpoint_lingering,
+        )
+        if not owned.done()
+    }
+    if checkpoint is not None:
+        live_resource_dependencies.update(
+            owned
+            for owned in getattr(checkpoint, "pending_tasks", ())
+            if isinstance(owned, asyncio.Task) and not owned.done()
+        )
+    if workflow_ctx is not None:
+        live_resource_dependencies.update(
+            owned
+            for owned in workflow_ctx.pending_cleanup_tasks
+            if isinstance(owned, asyncio.Task) and not owned.done()
+        )
+    if session is not None:
+        live_resource_dependencies.update(
+            owned
+            for owned in getattr(session, "pending_cleanup_tasks", ())
+            if isinstance(owned, asyncio.Task) and not owned.done()
+        )
+    resources_deferred = bool(live_resource_dependencies)
+    if resources_deferred:
+        state.execution_quiesced = False
+        if env is not None:
+            try:
+                state.environment_revocation_quiesced = await await_teardown(
+                    facade._abort_environment(env, cleanup_timeout=cleanup_timeout)
+                )
+            except Exception as exc:
+                state.error = facade._append_harness_error(state.error, "environment abort failed", exc)
+            if not state.environment_revocation_quiesced:
+                state.error = facade._append_harness_error(
+                    state.error,
+                    "environment abort timed out",
+                    TimeoutError("environment abort hook remained active"),
+                )
+        facade._defer_eval_resource_cleanup(
+            tuple(live_resource_dependencies),
+            tracer=tracer,
+            env=env if not state.environment_revocation_quiesced else None,
+        )
+        state.error = facade._append_harness_error(
+            state.error,
+            "resource cleanup deferred",
+            TimeoutError("owned persistence or execution task remained active"),
+        )
+
+    duration = time.monotonic() - start
+    if not resources_deferred:
+        try:
+            tracer.close()
+        except Exception as exc:
+            state.error = facade._append_harness_error(state.error, "tracer close failed", exc)
+    tracer_write_error = getattr(tracer, "write_error", None)
+    if tracer_write_error:
+        state.error = facade._append_harness_error(
+            state.error,
+            "tracer write failed",
+            RuntimeError(str(tracer_write_error)),
+        )
+
+    if env and (not resources_deferred or state.environment_revocation_quiesced):
+        environment_cleaned = False
+        cleanup_raised = False
+        try:
+            environment_cleaned = await await_teardown(
+                facade._cleanup_environment_bounded(env, cleanup_timeout=cleanup_timeout)
+            )
+        except Exception as exc:
+            cleanup_raised = True
+            state.error = facade._append_harness_error(state.error, "environment cleanup failed", exc)
+        if not environment_cleaned:
+            state.execution_quiesced = False
+            state.patch = ""
+            state.patch_extraction_succeeded = False
+            if not cleanup_raised:
+                state.error = facade._append_harness_error(
+                    state.error,
+                    "environment cleanup timed out",
+                    TimeoutError("environment cleanup hook remained active"),
+                )
+            try:
+                abort_quiesced = await await_teardown(facade._abort_environment(env, cleanup_timeout=cleanup_timeout))
+                if not abort_quiesced:
+                    state.error = facade._append_harness_error(
+                        state.error,
+                        "environment abort timed out",
+                        TimeoutError("environment abort hook remained active"),
+                    )
+            except Exception as exc:
+                state.error = facade._append_harness_error(state.error, "environment abort failed", exc)
+
+    if workflow_ctx is not None:
+        sessions = workflow_ctx.sessions
+        tokens_used = facade._aggregate_tokens(sessions)
+        steps = facade._aggregate_steps(sessions)
+        markup_recovered = facade._aggregate_markup_recovery(sessions)
+        workflow_error = getattr(workflow_ctx, "workflow_error", None)
+        if workflow_error:
+            state.error = f"{workflow_error}; {state.error}" if state.error else workflow_error
+    else:
+        tokens_used = session.used_tokens if session else 0
+        steps = session.step_count if session else 0
+        markup_recovered = getattr(session, "markup_recovered", 0) if session else 0
+
+    result = facade.EvalResult(
+        task_id=task.task_id,
+        patch=state.patch,
+        # Any extracted diff remains submittable even when the run reports an error.
+        patch_produced=bool(state.patch.strip()),
+        tokens_used=tokens_used,
+        steps=steps,
+        duration=duration,
+        error=state.error,
+        trajectory_path=tracer.path,
+        markup_recovered=markup_recovered,
+        workflow_result=getattr(workflow_ctx, "workflow_result", None) if workflow_ctx else None,
+        checkpoint_result=state.checkpoint_result,
+        test_patch_isolation_failed=state.test_patch_isolation_failed,
+        execution_quiesced=state.execution_quiesced,
+        patch_extraction_succeeded=state.patch_extraction_succeeded,
+        injected_path_cleanup_proven=state.injected_path_cleanup_proven,
+        harness_artifact_exclusion_proven=state.harness_artifact_exclusion_proven,
+        checkpoint_restore_integrity_proven=state.checkpoint_restore_integrity_proven,
+        task_stage_integrity_proven=state.task_stage_integrity_proven,
+        submission_eligible=(
+            state.execution_quiesced
+            and state.patch_extraction_succeeded
+            and state.injected_path_cleanup_proven
+            and state.harness_artifact_exclusion_proven
+            and state.checkpoint_restore_integrity_proven
+            and state.task_stage_integrity_proven
+            and state.persistence_succeeded
+            and not state.test_patch_isolation_failed
+        ),
+    )
+    return result
 
 
 async def run_eval_task_impl(
@@ -58,26 +435,17 @@ async def run_eval_task_impl(
     run_dir = prepared.run_dir
     tracer = prepared.tracer
     _EnvironmentSetupOwner = facade._EnvironmentSetupOwner
-    _abort_environment = facade._abort_environment
-    _aggregate_markup_recovery = facade._aggregate_markup_recovery
-    _aggregate_steps = facade._aggregate_steps
-    _aggregate_tokens = facade._aggregate_tokens
     _append_harness_error = facade._append_harness_error
-    _cleanup_environment_bounded = facade._cleanup_environment_bounded
-    _defer_eval_resource_cleanup = facade._defer_eval_resource_cleanup
     _finalize_eval_workflow_sessions = facade._finalize_eval_workflow_sessions
     _legacy_result_temp_paths = facade._legacy_result_temp_paths
     _mapped_artifact_path_bound_error = facade._mapped_artifact_path_bound_error
-    _persist_eval_workflow_manifest_owned = facade._persist_eval_workflow_manifest_owned
     _run_single_session = facade._run_single_session
     _run_workflow_mode = facade._run_workflow_mode
-    _stop_checkpoint_bounded = facade._stop_checkpoint_bounded
     _wait_for_owned_execution = facade._wait_for_owned_execution
     _workspace_relative_artifact_paths = facade._workspace_relative_artifact_paths
     _workspace_relative_host_path = facade._workspace_relative_host_path
     apply_test_patch = facade.apply_test_patch
     build_repo_map_via_env = facade.build_repo_map_via_env
-    EvalResult = facade.EvalResult
     RESULT_TEMP_DIRECTORY = facade.RESULT_TEMP_DIRECTORY
     TestPatchIsolationError = facade.TestPatchIsolationError
     WorktreeCheckpoint = facade.WorktreeCheckpoint
@@ -95,7 +463,6 @@ async def run_eval_task_impl(
     checkpoint_result: dict[str, Any] | None = None
     error: str | None = None
     cancellation: asyncio.CancelledError | None = None
-    patch = ""
     injected_paths: list[str] = []
     harness_artifact_paths: list[str] = []
     harness_artifact_exclusion_proven = True
@@ -104,8 +471,7 @@ async def run_eval_task_impl(
     task_stage_integrity_proven = True
     persistence_succeeded = True
     final_snapshot_lingering: tuple[asyncio.Task[Any], ...] = ()
-    manifest_lingering: tuple[asyncio.Task[Any], ...] = ()
-    environment_revocation_quiesced = False
+    finalization_state: _FinalizationState | None = None
 
     def remaining_task_time() -> float:
         remaining = task_deadline - time.monotonic()
@@ -204,12 +570,8 @@ async def run_eval_task_impl(
                 if not checkpoint_restore_integrity_proven:
                     raise RuntimeError("checkpoint restore left worktree integrity unproven")
 
-        # SWE-bench test injection: apply the real FAIL_TO_PASS test into the
-        # workspace BEFORE the workflow runs so the agent can verify against it.
-        # Guarded on extras so single-session / non-SWE-bench paths are
-        # unaffected. Preflight failures skip injection. An uncertain rollback
-        # stops before agent execution and preserves known paths for final
-        # cleanup and temporary-index exclusion.
+        # Inject the real FAIL_TO_PASS test before the workflow, preserving any
+        # uncertain rollback paths for final cleanup and diff exclusion.
         test_patch = (task.extras or {}).get("test_patch")
         if test_patch:
             try:
@@ -228,8 +590,7 @@ async def run_eval_task_impl(
                 exclude_paths=(*injected_paths, *harness_artifact_paths),
             )
 
-        # Orientation up front: a bounded repo map in the system prompt saves
-        # the model its first N steps of ls/find exploration.
+        # A bounded repo map saves the model its first discovery steps.
         repo_map = await await_task_stage(
             "repo_map",
             build_repo_map_via_env(env),
@@ -282,8 +643,7 @@ async def run_eval_task_impl(
             )
 
     except asyncio.CancelledError as exc:
-        # Finish the same checkpoint/diff/tracer/environment teardown below,
-        # then propagate cancellation after every owned resource is released.
+        # Propagate cancellation after every owned resource is released.
         cancellation = exc
         if getattr(exc, "checkpoint_restore_integrity_proven", True) is False:
             checkpoint_restore_integrity_proven = False
@@ -303,11 +663,18 @@ async def run_eval_task_impl(
             except asyncio.CancelledError as exc:
                 if cancellation is None:
                     cancellation = exc
-                    error = _append_harness_error(
-                        error,
-                        "evaluation task cancelled",
-                        RuntimeError("caller cancelled during teardown"),
-                    )
+                    if finalization_state is None:
+                        error = _append_harness_error(
+                            error,
+                            "evaluation task cancelled",
+                            RuntimeError("caller cancelled during teardown"),
+                        )
+                    else:
+                        finalization_state.error = _append_harness_error(
+                            finalization_state.error,
+                            "evaluation task cancelled",
+                            RuntimeError("caller cancelled during teardown"),
+                        )
                 continue
         if owned_task.cancelled():
             raise RuntimeError("owned teardown operation cancelled itself")
@@ -380,393 +747,48 @@ async def run_eval_task_impl(
                 TimeoutError("session persistence owner remained active"),
             )
 
-    # A stage may consume cancellation and return a resource or mutation record
-    # after its caller-side deadline. Adopt every such result before deciding
-    # what must be cleaned or excluded from the candidate diff.
-    if execution_quiesced:
-        for stage_name, stage_task in stage_tasks.items():
-            if stage_name in observed_stage_results:
-                continue
-            observed_stage_results.add(stage_name)
-            if stage_task.cancelled():
-                if stage_name == "checkpoint_restore":
-                    checkpoint_restore_integrity_proven = False
-                elif stage_name == "test_patch_injection":
-                    test_patch_isolation_failed = True
-                continue
-            try:
-                late_value = stage_task.result()
-            except TestPatchIsolationError as exc:
-                if stage_name == "test_patch_injection":
-                    injected_paths = list(dict.fromkeys((*injected_paths, *exc.touched_paths)))
-                    test_patch_isolation_failed = True
-                error = _append_harness_error(
-                    error,
-                    f"late {stage_name} failed",
-                    exc,
-                )
-            except asyncio.CancelledError:
-                if stage_name == "checkpoint_restore":
-                    checkpoint_restore_integrity_proven = False
-                elif stage_name == "test_patch_injection":
-                    test_patch_isolation_failed = True
-            except BaseException as exc:
-                error = _append_harness_error(
-                    error,
-                    f"late {stage_name} failed",
-                    exc,
-                )
-                if stage_name == "checkpoint_restore":
-                    checkpoint_restore_integrity_proven = False
-                elif stage_name == "test_patch_injection":
-                    test_patch_isolation_failed = True
-            else:
-                if stage_name == "checkpoint_restore":
-                    restore_result = late_value
-                    if checkpoint_result is None:
-                        checkpoint_result = {}
-                    checkpoint_result["restore"] = restore_result.to_dict()
-                    checkpoint_restore_integrity_proven = False
-                elif stage_name == "test_patch_injection":
-                    injected_paths = list(dict.fromkeys((*injected_paths, *late_value)))
-                    test_patch_isolation_failed = True
-
-    if not execution_quiesced:
-        failure = TimeoutError("owned execution did not quiesce after cancellation; patch extraction skipped")
-        error = _append_harness_error(error, "execution cleanup timed out", failure)
-        if checkpoint is not None:
-            try:
-                checkpoint_quiesced = await await_teardown(checkpoint.abort(timeout=cleanup_timeout))
-            except Exception as exc:
-                checkpoint_quiesced = False
-                error = _append_harness_error(
-                    error,
-                    "checkpoint abort failed",
-                    exc,
-                )
-            if checkpoint_result is None:
-                checkpoint_result = {}
-            checkpoint_result["abort"] = {
-                "status": ("aborted_non_quiescent_execution" if checkpoint_quiesced else "checkpoint_abort_timed_out")
-            }
-            if not checkpoint_quiesced:
-                error = _append_harness_error(
-                    error,
-                    "checkpoint abort timed out",
-                    TimeoutError("periodic checkpoint capture remained active"),
-                )
-        if env is not None:
-            # Revoke new public operations immediately. Adapter teardown waits
-            # until the still-owned workflow/checkpoint tasks stop using it.
-            env._aborted = True
-
-    if (
-        execution_quiesced
-        and env
-        and checkpoint is not None
-        and (test_patch_isolation_failed or not checkpoint_restore_integrity_proven)
-    ):
-        try:
-            checkpoint_quiesced = await await_teardown(checkpoint.abort(timeout=cleanup_timeout))
-        except Exception as exc:
-            checkpoint_quiesced = False
-            error = _append_harness_error(error, "checkpoint abort failed", exc)
-        if checkpoint_result is None:
-            checkpoint_result = {}
-        checkpoint_result["final"] = {
-            "status": (
-                (
-                    "skipped_test_patch_isolation_failure"
-                    if test_patch_isolation_failed
-                    else "skipped_checkpoint_restore_integrity_failure"
-                )
-                if checkpoint_quiesced
-                else "checkpoint_abort_timed_out"
-            )
-        }
-        if not checkpoint_quiesced:
-            error = _append_harness_error(
-                error,
-                "checkpoint abort timed out",
-                TimeoutError("periodic checkpoint capture remained active"),
-            )
-            execution_quiesced = False
-
-    if (
-        execution_quiesced
-        and env
-        and checkpoint is not None
-        and not test_patch_isolation_failed
-        and checkpoint_restore_integrity_proven
-    ):
-        try:
-            (
-                checkpoint_finalized,
-                final_checkpoint,
-                stop_lingering,
-            ) = await await_teardown(
-                _stop_checkpoint_bounded(
-                    checkpoint,
-                    env,
-                    exclude_paths=(*injected_paths, *harness_artifact_paths),
-                    cleanup_timeout=cleanup_timeout,
-                )
-            )
-            checkpoint_lingering.update(stop_lingering)
-            if checkpoint_result is None:
-                checkpoint_result = {}
-            if checkpoint_finalized:
-                checkpoint_result["final"] = final_checkpoint.to_dict()
-            else:
-                checkpoint_result["final"] = {"status": "checkpoint_finalization_timed_out"}
-                error = _append_harness_error(
-                    error,
-                    "checkpoint finalization timed out",
-                    TimeoutError("checkpoint stop remained active"),
-                )
-                try:
-                    checkpoint_quiesced = await await_teardown(checkpoint.abort(timeout=cleanup_timeout))
-                    if not checkpoint_quiesced:
-                        error = _append_harness_error(
-                            error,
-                            "checkpoint abort timed out",
-                            TimeoutError("periodic checkpoint capture remained active"),
-                        )
-                except Exception as exc:
-                    error = _append_harness_error(
-                        error,
-                        "checkpoint abort failed",
-                        exc,
-                    )
-                env._aborted = True
-                execution_quiesced = False
-        except Exception as exc:
-            error = _append_harness_error(error, "checkpoint finalization failed", exc)
-
-    (
-        injected_path_cleanup_proven,
-        patch,
-        patch_extraction_succeeded,
-        error,
-    ) = await cleanup_injected_paths_and_extract_patch(
-        facade,
-        env=env,
-        execution_quiesced=execution_quiesced,
-        injected_paths=injected_paths,
-        harness_artifact_paths=harness_artifact_paths,
-        cleanup_timeout=cleanup_timeout,
+    state = _FinalizationState(
         error=error,
-        test_patch_isolation_failed=test_patch_isolation_failed,
+        execution_quiesced=execution_quiesced,
+        checkpoint_result=checkpoint_result,
+        injected_paths=injected_paths,
         harness_artifact_exclusion_proven=harness_artifact_exclusion_proven,
         checkpoint_restore_integrity_proven=checkpoint_restore_integrity_proven,
+        test_patch_isolation_failed=test_patch_isolation_failed,
         task_stage_integrity_proven=task_stage_integrity_proven,
+        persistence_succeeded=persistence_succeeded,
+        checkpoint_lingering=checkpoint_lingering,
+        final_snapshot_lingering=final_snapshot_lingering,
+    )
+    finalization_state = state
+    _collect_late_stage_outcomes(facade, state, stage_tasks, observed_stage_results)
+    await _finalize_checkpoint_and_patch(
+        facade,
+        state,
+        env=env,
+        checkpoint=checkpoint,
+        harness_artifact_paths=harness_artifact_paths,
+        cleanup_timeout=cleanup_timeout,
         await_teardown=await_teardown,
     )
-
-    if execution_quiesced and workflow_ctx is not None and workflow is not None and run_dir is not None:
-        try:
-            (
-                manifest_quiesced,
-                manifest_error,
-                manifest_lingering,
-            ) = await await_teardown(
-                _persist_eval_workflow_manifest_owned(
-                    run_dir,
-                    task=task,
-                    workflow=workflow,
-                    ctx=workflow_ctx,
-                    cleanup_timeout=cleanup_timeout,
-                )
-            )
-        except Exception as exc:
-            persistence_succeeded = False
-            error = _append_harness_error(
-                error,
-                "workflow manifest failed",
-                exc,
-            )
-        else:
-            if manifest_error is not None:
-                persistence_succeeded = False
-                error = _append_harness_error(
-                    error,
-                    "workflow manifest failed",
-                    manifest_error,
-                )
-            if not manifest_quiesced:
-                persistence_succeeded = False
-                execution_quiesced = False
-                error = _append_harness_error(
-                    error,
-                    "workflow manifest timed out",
-                    TimeoutError("manifest persistence owner remained active"),
-                )
-
-    live_resource_dependencies: set[asyncio.Task[Any]] = {
-        task
-        for task in (
-            *owned_execution_tasks,
-            *final_snapshot_lingering,
-            *manifest_lingering,
-            *checkpoint_lingering,
-        )
-        if not task.done()
-    }
-    if checkpoint is not None:
-        live_resource_dependencies.update(
-            task
-            for task in getattr(checkpoint, "pending_tasks", ())
-            if isinstance(task, asyncio.Task) and not task.done()
-        )
-    if workflow_ctx is not None:
-        live_resource_dependencies.update(
-            task for task in workflow_ctx.pending_cleanup_tasks if isinstance(task, asyncio.Task) and not task.done()
-        )
-    if session is not None:
-        live_resource_dependencies.update(
-            task
-            for task in getattr(session, "pending_cleanup_tasks", ())
-            if isinstance(task, asyncio.Task) and not task.done()
-        )
-    resources_deferred = bool(live_resource_dependencies)
-    if resources_deferred:
-        execution_quiesced = False
-        if env is not None:
-            try:
-                environment_revocation_quiesced = await await_teardown(
-                    _abort_environment(
-                        env,
-                        cleanup_timeout=cleanup_timeout,
-                    )
-                )
-            except Exception as exc:
-                error = _append_harness_error(
-                    error,
-                    "environment abort failed",
-                    exc,
-                )
-            if not environment_revocation_quiesced:
-                error = _append_harness_error(
-                    error,
-                    "environment abort timed out",
-                    TimeoutError("environment abort hook remained active"),
-                )
-        _defer_eval_resource_cleanup(
-            tuple(live_resource_dependencies),
-            tracer=tracer,
-            env=(env if not environment_revocation_quiesced else None),
-        )
-        error = _append_harness_error(
-            error,
-            "resource cleanup deferred",
-            TimeoutError("owned persistence or execution task remained active"),
-        )
-
-    duration = time.monotonic() - start
-    if not resources_deferred:
-        try:
-            tracer.close()
-        except Exception as exc:
-            error = _append_harness_error(error, "tracer close failed", exc)
-    tracer_write_error = getattr(tracer, "write_error", None)
-    if tracer_write_error:
-        error = _append_harness_error(
-            error,
-            "tracer write failed",
-            RuntimeError(str(tracer_write_error)),
-        )
-
-    if env and (not resources_deferred or environment_revocation_quiesced):
-        environment_cleaned = False
-        cleanup_raised = False
-        try:
-            environment_cleaned = await await_teardown(
-                _cleanup_environment_bounded(
-                    env,
-                    cleanup_timeout=cleanup_timeout,
-                )
-            )
-        except Exception as exc:
-            cleanup_raised = True
-            error = _append_harness_error(error, "environment cleanup failed", exc)
-        if not environment_cleaned:
-            execution_quiesced = False
-            patch = ""
-            patch_extraction_succeeded = False
-            if not cleanup_raised:
-                error = _append_harness_error(
-                    error,
-                    "environment cleanup timed out",
-                    TimeoutError("environment cleanup hook remained active"),
-                )
-            try:
-                abort_quiesced = await await_teardown(
-                    _abort_environment(
-                        env,
-                        cleanup_timeout=cleanup_timeout,
-                    )
-                )
-                if not abort_quiesced:
-                    error = _append_harness_error(
-                        error,
-                        "environment abort timed out",
-                        TimeoutError("environment abort hook remained active"),
-                    )
-            except Exception as exc:
-                error = _append_harness_error(error, "environment abort failed", exc)
-
-    if workflow_ctx is not None:
-        sessions = workflow_ctx.sessions
-        tokens_used = _aggregate_tokens(sessions)
-        steps = _aggregate_steps(sessions)
-        markup_recovered = _aggregate_markup_recovery(sessions)
-        workflow_error = getattr(workflow_ctx, "workflow_error", None)
-        if workflow_error:
-            error = f"{workflow_error}; {error}" if error else workflow_error
-    else:
-        tokens_used = session.used_tokens if session else 0
-        steps = session.step_count if session else 0
-        markup_recovered = getattr(session, "markup_recovered", 0) if session else 0
-
-    result = EvalResult(
-        task_id=task.task_id,
-        patch=patch,
-        # An on-disk diff is a real, submittable patch regardless of how the run
-        # ended — a budget-floor stop or an outer-wall timeout still produces the
-        # patch we grade (django-11564 was graded RESOLVED yet reported
-        # patch_produced=false under the old ``and error is None`` guard).
-        patch_produced=bool(patch.strip()),
-        tokens_used=tokens_used,
-        steps=steps,
-        duration=duration,
-        error=error,
-        trajectory_path=tracer.path,
-        markup_recovered=markup_recovered,
-        workflow_result=getattr(workflow_ctx, "workflow_result", None) if workflow_ctx else None,
-        checkpoint_result=checkpoint_result,
-        test_patch_isolation_failed=test_patch_isolation_failed,
-        execution_quiesced=execution_quiesced,
-        patch_extraction_succeeded=patch_extraction_succeeded,
-        injected_path_cleanup_proven=injected_path_cleanup_proven,
-        harness_artifact_exclusion_proven=harness_artifact_exclusion_proven,
-        checkpoint_restore_integrity_proven=(checkpoint_restore_integrity_proven),
-        task_stage_integrity_proven=task_stage_integrity_proven,
-        submission_eligible=(
-            execution_quiesced
-            and patch_extraction_succeeded
-            and injected_path_cleanup_proven
-            and harness_artifact_exclusion_proven
-            and checkpoint_restore_integrity_proven
-            and task_stage_integrity_proven
-            and persistence_succeeded
-            and not test_patch_isolation_failed
-        ),
+    result = await _cleanup_resources_and_build_result(
+        facade,
+        state,
+        task=task,
+        workflow=workflow,
+        run_dir=run_dir,
+        workflow_ctx=workflow_ctx,
+        session=session,
+        checkpoint=checkpoint,
+        owned_execution_tasks=owned_execution_tasks,
+        tracer=tracer,
+        env=env,
+        cleanup_timeout=cleanup_timeout,
+        start=start,
+        await_teardown=await_teardown,
     )
     if cancellation is not None:
-        if error:
-            add_exception_note(
-                cancellation,
-                f"evaluation teardown diagnostics: {error}",
-            )
+        if state.error:
+            add_exception_note(cancellation, f"evaluation teardown diagnostics: {state.error}")
         raise cancellation
     return result

--- a/opencollab/opencollab/harness/swe_v1_remote_artifacts.py
+++ b/opencollab/opencollab/harness/swe_v1_remote_artifacts.py
@@ -1,0 +1,240 @@
+"""Bounded Pro-Lite artifact snapshots and pure verdict derivation."""
+
+from __future__ import annotations
+
+import os
+import re
+
+from opencollab.harness.swe_v1_remote_commands import _plan_log_proof_matches
+from opencollab.harness.swe_v1_remote_core import (
+    RecordInputFormatError,
+    RecordInputLimitError,
+)
+from opencollab.harness.swe_v1_remote_generation import eval_log_has_infra_failure
+from opencollab.harness.swe_v1_remote_records import read_tail_text
+from opencollab.harness.swe_v1_remote_state import (
+    MAX_EXIT_STATUS_BYTES,
+    MAX_LOG_TAIL_BYTES,
+    open_regular_binary,
+)
+
+
+def _read_exit(output_dir, errors, name, default=99):
+    path = output_dir / name
+    try:
+        with open_regular_binary(path) as handle:
+            opened = os.fstat(handle.fileno())
+            if opened.st_size > MAX_EXIT_STATUS_BYTES:
+                raise RecordInputLimitError(f"exit status exceeds byte limit: {path}")
+            raw = handle.read(MAX_EXIT_STATUS_BYTES + 1)
+        text = raw.decode("ascii").strip()
+        if not re.fullmatch(r"-?[0-9]+", text):
+            raise RecordInputFormatError(f"invalid exit status: {path}")
+        return int(text)
+    except FileNotFoundError:
+        errors.append(f"missing:{name}")
+        return default
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
+        errors.append(f"unsafe:{name}:{type(exc).__name__}")
+        return default
+
+
+def _read_text(output_dir, errors, name, limit=4000):
+    try:
+        return read_tail_text(output_dir / name, limit)
+    except OSError as exc:
+        errors.append(f"unsafe:{name}:{type(exc).__name__}")
+        return ""
+
+
+def _read_required_text(output_dir, errors, name, limit=4000):
+    path = output_dir / name
+    try:
+        with open_regular_binary(path) as handle:
+            size = os.fstat(handle.fileno()).st_size
+            if size > limit:
+                raise RecordInputLimitError(
+                    f"required output artifact exceeds byte limit: {path}"
+                )
+            return handle.read(limit + 1).decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        errors.append(f"missing:{name}")
+        return ""
+    except (OSError, ValueError) as exc:
+        errors.append(f"unsafe:{name}:{type(exc).__name__}")
+        return ""
+
+
+def _read_plan_evidence(output_dir, errors, prefix, plan, proof_nonce):
+    evidence = []
+    for index, expected_command in enumerate(plan["commands"], 1):
+        stem = f"{prefix}.batch_{index:03d}"
+        error_count = len(errors)
+        status = _read_exit(output_dir, errors, f"{stem}.exit")
+        observed_command = _read_text(
+            output_dir,
+            errors,
+            f"{stem}.command",
+            MAX_LOG_TAIL_BYTES,
+        ).rstrip("\n")
+        log_error_count = len(errors)
+        log_text = _read_required_text(
+            output_dir,
+            errors,
+            f"{stem}.log",
+            MAX_LOG_TAIL_BYTES,
+        )
+        log_artifact_safe = len(errors) == log_error_count
+        proofs = plan.get("proofs") or []
+        proof = proofs[index - 1] if index <= len(proofs) else None
+        proof_text = ""
+        if isinstance(proof, dict) and proof.get("kind") == "pytest_structured_reports":
+            proof_text = _read_required_text(
+                output_dir,
+                errors,
+                f"{stem}.proof.{proof_nonce}.jsonl",
+                MAX_LOG_TAIL_BYTES,
+            )
+        evidence.append(
+            {
+                "batch": index,
+                "status": status,
+                "command_matches_plan": observed_command == expected_command,
+                "log_artifact_safe": log_artifact_safe,
+                "target_proof_matches_plan": _plan_log_proof_matches(
+                    proof,
+                    log_text,
+                    proof_text,
+                ),
+                "artifact_safe": len(errors) == error_count,
+            }
+        )
+    return evidence
+
+
+def _plan_evidence_complete(plan, evidence):
+    return (
+        bool(plan["commands"])
+        and len(evidence) == len(plan["commands"])
+        and all(
+            item["command_matches_plan"]
+            and item["log_artifact_safe"]
+            and item["target_proof_matches_plan"]
+            and item["artifact_safe"]
+            for item in evidence
+        )
+    )
+
+
+def read_eval_output_artifacts(output_dir, f2p_plan, p2p_plan, proof_nonce):
+    """Read every verdict-relevant artifact before returning one snapshot."""
+    errors = []
+    service_status = _read_exit(output_dir, errors, "service_bootstrap.exit", 0)
+    before_status = _read_exit(output_dir, errors, "before_repo.exit")
+    model_status = _read_exit(output_dir, errors, "model_patch.exit")
+    test_status = _read_exit(output_dir, errors, "test_patch.exit")
+    f2p_status = _read_exit(output_dir, errors, "f2p.exit")
+    p2p_status = _read_exit(output_dir, errors, "p2p.exit", 0)
+    f2p_log_tail = _read_text(output_dir, errors, "f2p.log")
+    p2p_log_tail = _read_text(output_dir, errors, "p2p.log")
+    f2p_evidence = _read_plan_evidence(
+        output_dir,
+        errors,
+        "f2p",
+        f2p_plan,
+        proof_nonce,
+    )
+    p2p_evidence = (
+        _read_plan_evidence(
+            output_dir,
+            errors,
+            "p2p",
+            p2p_plan,
+            proof_nonce,
+        )
+        if p2p_plan["commands"]
+        else []
+    )
+    return {
+        "output_artifact_errors": errors,
+        "service_status": service_status,
+        "before_status": before_status,
+        "model_status": model_status,
+        "test_status": test_status,
+        "f2p_status": f2p_status,
+        "p2p_status": p2p_status,
+        "f2p_log_tail": f2p_log_tail,
+        "p2p_log_tail": p2p_log_tail,
+        "f2p_evidence": f2p_evidence,
+        "p2p_evidence": p2p_evidence,
+        "f2p_evidence_complete": _plan_evidence_complete(f2p_plan, f2p_evidence),
+        "p2p_evidence_complete": not p2p_plan["commands"]
+        or _plan_evidence_complete(p2p_plan, p2p_evidence),
+        "f2p_command": _read_text(output_dir, errors, "f2p.command", 1000),
+        "p2p_command": _read_text(output_dir, errors, "p2p.command", 1000),
+        "service_bootstrap_log_tail": _read_text(
+            output_dir,
+            errors,
+            "service_bootstrap.log",
+        ),
+        "model_patch_log_tail": _read_text(output_dir, errors, "model_patch.log"),
+        "test_patch_log_tail": _read_text(output_dir, errors, "test_patch.log"),
+    }
+
+
+def _plan_evidence_mismatch(artifacts, prefix):
+    evidence = artifacts[f"{prefix}_evidence"]
+    status = artifacts[f"{prefix}_status"]
+    aggregate_status = next(
+        (item["status"] for item in evidence if item["status"] != 0),
+        0,
+    )
+    return not artifacts[f"{prefix}_evidence_complete"] or bool(
+        evidence and aggregate_status != status
+    )
+
+
+def derive_eval_verdict(artifacts, *, docker_exit, cleanup_quiesced, container_cleanup):
+    """Derive a verdict only from an already complete artifact snapshot."""
+    f2p_evidence = artifacts["f2p_evidence"]
+    p2p_evidence = artifacts["p2p_evidence"]
+    f2p_status = artifacts["f2p_status"]
+    p2p_status = artifacts["p2p_status"]
+    reason_checks = (
+        ("unsafe_or_missing_output_artifact", bool(artifacts["output_artifact_errors"])),
+        ("fail_to_pass_evidence", _plan_evidence_mismatch(artifacts, "f2p")),
+        ("pass_to_pass_evidence", _plan_evidence_mismatch(artifacts, "p2p")),
+        ("docker_exit", docker_exit != 0),
+        ("process_cleanup", not cleanup_quiesced),
+        ("container_cleanup", not container_cleanup.get("ok")),
+        ("service_bootstrap", artifacts["service_status"] != 0),
+        ("before_repo", artifacts["before_status"] != 0),
+        ("model_patch", artifacts["model_status"] != 0),
+        ("test_patch", artifacts["test_status"] != 0),
+        (
+            "fail_to_pass_infra",
+            eval_log_has_infra_failure(f2p_status, artifacts["f2p_log_tail"]),
+        ),
+        (
+            "pass_to_pass_infra",
+            eval_log_has_infra_failure(p2p_status, artifacts["p2p_log_tail"]),
+        ),
+    )
+    technical_reasons = [reason for reason, active in reason_checks if active]
+    technical_error = bool(technical_reasons)
+    resolved = bool(
+        not technical_error
+        and f2p_status == 0
+        and p2p_status == 0
+        and all(item["status"] == 0 for item in f2p_evidence)
+        and all(item["status"] == 0 for item in p2p_evidence)
+    )
+    return {
+        "technical_reasons": technical_reasons,
+        "technical_error": technical_error,
+        "resolved": resolved,
+        "summary_status": "technical_eval_failed" if technical_error else "done",
+    }
+
+
+__all__ = ["derive_eval_verdict", "read_eval_output_artifacts"]

--- a/opencollab/opencollab/harness/swe_v1_remote_evaluation.py
+++ b/opencollab/opencollab/harness/swe_v1_remote_evaluation.py
@@ -3,6 +3,10 @@
 # ruff: noqa: E501, F403, F405
 
 from opencollab.harness import swe_v1_remote_cleanup as remote_cleanup
+from opencollab.harness.swe_v1_remote_artifacts import (
+    derive_eval_verdict,
+    read_eval_output_artifacts,
+)
 from opencollab.harness.swe_v1_remote_commands import *
 from opencollab.harness.swe_v1_remote_core import *
 from opencollab.harness.swe_v1_remote_generation import *
@@ -375,147 +379,38 @@ exit 0
             container_name,
         )
 
-    output_artifact_errors = []
-
-    def read_exit(name, default=99):
-        path = output_dir / name
-        try:
-            with open_regular_binary(path) as handle:
-                opened = os.fstat(handle.fileno())
-                if opened.st_size > MAX_EXIT_STATUS_BYTES:
-                    raise RecordInputLimitError(f"exit status exceeds byte limit: {path}")
-                raw = handle.read(MAX_EXIT_STATUS_BYTES + 1)
-            text = raw.decode("ascii").strip()
-            if not re.fullmatch(r"-?[0-9]+", text):
-                raise RecordInputFormatError(f"invalid exit status: {path}")
-            return int(text)
-        except FileNotFoundError:
-            output_artifact_errors.append(f"missing:{name}")
-            return default
-        except (OSError, ValueError, UnicodeDecodeError) as exc:
-            output_artifact_errors.append(f"unsafe:{name}:{type(exc).__name__}")
-            return default
-
-    def read_text(name, limit=4000):
-        try:
-            return read_tail_text(output_dir / name, limit)
-        except OSError as exc:
-            output_artifact_errors.append(f"unsafe:{name}:{type(exc).__name__}")
-            return ""
-
-    def read_required_text(name, limit=4000):
-        path = output_dir / name
-        try:
-            with open_regular_binary(path) as handle:
-                size = os.fstat(handle.fileno()).st_size
-                if size > limit:
-                    raise RecordInputLimitError(
-                        f"required output artifact exceeds byte limit: {path}"
-                    )
-                return handle.read(limit + 1).decode("utf-8", errors="replace")
-        except FileNotFoundError:
-            output_artifact_errors.append(f"missing:{name}")
-            return ""
-        except (OSError, ValueError) as exc:
-            output_artifact_errors.append(f"unsafe:{name}:{type(exc).__name__}")
-            return ""
-
-    def read_plan_evidence(prefix, plan):
-        evidence = []
-        for index, expected_command in enumerate(plan["commands"], 1):
-            stem = f"{prefix}.batch_{index:03d}"
-            error_count = len(output_artifact_errors)
-            status = read_exit(f"{stem}.exit")
-            observed_command = read_text(f"{stem}.command", MAX_LOG_TAIL_BYTES).rstrip("\n")
-            log_error_count = len(output_artifact_errors)
-            log_text = read_required_text(f"{stem}.log", MAX_LOG_TAIL_BYTES)
-            log_artifact_safe = len(output_artifact_errors) == log_error_count
-            proofs = plan.get("proofs") or []
-            proof = proofs[index - 1] if index <= len(proofs) else None
-            proof_text = ""
-            if isinstance(proof, dict) and proof.get("kind") == "pytest_structured_reports":
-                proof_text = read_required_text(
-                    f"{stem}.proof.{proof_nonce}.jsonl",
-                    MAX_LOG_TAIL_BYTES,
-                )
-            evidence.append(
-                {
-                    "batch": index,
-                    "status": status,
-                    "command_matches_plan": observed_command == expected_command,
-                    "log_artifact_safe": log_artifact_safe,
-                    "target_proof_matches_plan": _plan_log_proof_matches(
-                        proof,
-                        log_text,
-                        proof_text,
-                    ),
-                    "artifact_safe": len(output_artifact_errors) == error_count,
-                }
-            )
-        return evidence
-
-    def plan_evidence_complete(plan, evidence):
-        return (
-            bool(plan["commands"])
-            and len(evidence) == len(plan["commands"])
-            and all(
-                item["command_matches_plan"]
-                and item["log_artifact_safe"]
-                and item["target_proof_matches_plan"]
-                and item["artifact_safe"]
-                for item in evidence
-            )
-        )
-
-    def aggregate_plan_status(evidence):
-        return next((item["status"] for item in evidence if item["status"] != 0), 0)
-
-    service_status = read_exit("service_bootstrap.exit", 0)
-    before_status = read_exit("before_repo.exit")
-    model_status = read_exit("model_patch.exit")
-    test_status = read_exit("test_patch.exit")
-    f2p_status = read_exit("f2p.exit")
-    p2p_status = read_exit("p2p.exit", 0)
-    f2p_log_tail = read_text("f2p.log")
-    p2p_log_tail = read_text("p2p.log")
-    f2p_evidence = read_plan_evidence("f2p", f2p_plan)
-    p2p_evidence = read_plan_evidence("p2p", p2p_plan) if p2p_plan["commands"] else []
-    f2p_evidence_complete = plan_evidence_complete(f2p_plan, f2p_evidence)
-    p2p_evidence_complete = not p2p_plan["commands"] or plan_evidence_complete(p2p_plan, p2p_evidence)
-    technical_reasons = []
-    if output_artifact_errors:
-        technical_reasons.append("unsafe_or_missing_output_artifact")
-    if not f2p_evidence_complete or aggregate_plan_status(f2p_evidence) != f2p_status:
-        technical_reasons.append("fail_to_pass_evidence")
-    if not p2p_evidence_complete or (p2p_evidence and aggregate_plan_status(p2p_evidence) != p2p_status):
-        technical_reasons.append("pass_to_pass_evidence")
-    if docker_exit != 0:
-        technical_reasons.append("docker_exit")
-    if not cleanup_quiesced:
-        technical_reasons.append("process_cleanup")
-    if not container_cleanup.get("ok"):
-        technical_reasons.append("container_cleanup")
-    if service_status != 0:
-        technical_reasons.append("service_bootstrap")
-    if before_status != 0:
-        technical_reasons.append("before_repo")
-    if model_status != 0:
-        technical_reasons.append("model_patch")
-    if test_status != 0:
-        technical_reasons.append("test_patch")
-    if eval_log_has_infra_failure(f2p_status, f2p_log_tail):
-        technical_reasons.append("fail_to_pass_infra")
-    if eval_log_has_infra_failure(p2p_status, p2p_log_tail):
-        technical_reasons.append("pass_to_pass_infra")
-    technical_error = bool(technical_reasons)
-    resolved = bool(
-        not technical_error
-        and f2p_status == 0
-        and p2p_status == 0
-        and all(item["status"] == 0 for item in f2p_evidence)
-        and all(item["status"] == 0 for item in p2p_evidence)
+    artifacts = read_eval_output_artifacts(
+        output_dir,
+        f2p_plan,
+        p2p_plan,
+        proof_nonce,
     )
-    summary_status = "technical_eval_failed" if technical_error else "done"
+    verdict = derive_eval_verdict(
+        artifacts,
+        docker_exit=docker_exit,
+        cleanup_quiesced=cleanup_quiesced,
+        container_cleanup=container_cleanup,
+    )
+    output_artifact_errors = artifacts["output_artifact_errors"]
+    service_status = artifacts["service_status"]
+    before_status = artifacts["before_status"]
+    model_status = artifacts["model_status"]
+    test_status = artifacts["test_status"]
+    f2p_status = artifacts["f2p_status"]
+    p2p_status = artifacts["p2p_status"]
+    f2p_log_tail = artifacts["f2p_log_tail"]
+    p2p_log_tail = artifacts["p2p_log_tail"]
+    f2p_evidence = artifacts["f2p_evidence"]
+    p2p_evidence = artifacts["p2p_evidence"]
+    f2p_command = artifacts["f2p_command"]
+    p2p_command = artifacts["p2p_command"]
+    service_bootstrap_log_tail = artifacts["service_bootstrap_log_tail"]
+    model_patch_log_tail = artifacts["model_patch_log_tail"]
+    test_patch_log_tail = artifacts["test_patch_log_tail"]
+    technical_reasons = verdict["technical_reasons"]
+    technical_error = verdict["technical_error"]
+    resolved = verdict["resolved"]
+    summary_status = verdict["summary_status"]
     report = {
         "schema": "opencollab.prolite_direct_eval.v2",
         "status": summary_status,
@@ -546,13 +441,13 @@ exit 0
             "pass_to_pass_plan": p2p_plan,
             "fail_to_pass_evidence": f2p_evidence,
             "pass_to_pass_evidence": p2p_evidence,
-            "f2p_command": read_text("f2p.command", 1000),
-            "p2p_command": read_text("p2p.command", 1000),
-            "service_bootstrap_log_tail": read_text("service_bootstrap.log"),
+            "f2p_command": f2p_command,
+            "p2p_command": p2p_command,
+            "service_bootstrap_log_tail": service_bootstrap_log_tail,
             "f2p_log_tail": f2p_log_tail,
             "p2p_log_tail": p2p_log_tail,
-            "model_patch_log_tail": read_text("model_patch.log"),
-            "test_patch_log_tail": read_text("test_patch.log"),
+            "model_patch_log_tail": model_patch_log_tail,
+            "test_patch_log_tail": test_patch_log_tail,
         },
     }
     write_json(report_path, {task: report})

--- a/opencollab/opencollab/harness/swe_v1_remote_records.py
+++ b/opencollab/opencollab/harness/swe_v1_remote_records.py
@@ -191,12 +191,6 @@ def parse_literal_list(value):
     return [text]
 
 
-def prediction_patch(row):
-    if not isinstance(row, dict):
-        return ""
-    return str(row.get("model_patch") or row.get("patch") or "")
-
-
 def is_eval_test_path(path):
     normalized = str(path or "").lstrip("/")
     parts = [part for part in normalized.split("/") if part]
@@ -329,70 +323,6 @@ def filter_model_patch_for_eval(patch):
 
 def eval_model_patch(prediction):
     return filter_model_patch_for_eval(prediction_patch(prediction))
-
-
-def row_task_id(row):
-    if not isinstance(row, dict):
-        return ""
-    return str(row.get("instance_id") or row.get("task_id") or "")
-
-
-def row_record_id(row):
-    if not isinstance(row, dict):
-        return ""
-    return str(row.get("record_id") or row.get("attempt_id") or "")
-
-
-def patch_sha(patch):
-    if not patch:
-        return ""
-    return hashlib.sha256(patch.encode("utf-8", errors="surrogatepass")).hexdigest()
-
-
-def row_patch_sha(row):
-    if not isinstance(row, dict):
-        return ""
-    patch = prediction_patch(row)
-    if patch:
-        return patch_sha(patch)
-    for key in ("patch_sha256", "patch_sha", "model_patch_sha256"):
-        value = row.get(key)
-        if value:
-            return str(value)
-    return ""
-
-
-def row_explicit_patch_sha(row):
-    if not isinstance(row, dict):
-        return ""
-    for key in ("patch_sha256", "patch_sha", "model_patch_sha256"):
-        value = row.get(key)
-        if value:
-            return str(value)
-    return ""
-
-
-def embedded_workflow_metric(row):
-    if not isinstance(row, dict):
-        return None
-    metric = row.get("workflow_metric")
-    if not isinstance(metric, dict):
-        return None
-    if row_task_id(metric) != row_task_id(row):
-        return None
-    if row_record_id(metric) != row_record_id(row):
-        return None
-    prediction_sha = row_patch_sha(row)
-    metric_sha = row_patch_sha(metric)
-    if not prediction_sha or not metric_sha or not patch_sha_matches(prediction_sha, metric_sha):
-        return None
-    return metric
-
-
-def patch_sha_matches(left, right):
-    left = str(left or "")
-    right = str(right or "")
-    return bool(re.fullmatch(r"[0-9a-fA-F]{64}", left) and re.fullmatch(r"[0-9a-fA-F]{64}", right) and left == right)
 
 
 def workflow_status(row):

--- a/opencollab/opencollab/harness/swe_v1_remote_runner.py
+++ b/opencollab/opencollab/harness/swe_v1_remote_runner.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from typing import Any
 
 from opencollab.harness import (
+    swe_v1_remote_artifacts,
     swe_v1_remote_commands,
     swe_v1_remote_core,
     swe_v1_remote_evaluation,
@@ -25,6 +26,7 @@ _RUNTIME_MODULES = (
     swe_v1_remote_records,
     swe_v1_remote_commands,
     swe_v1_remote_generation,
+    swe_v1_remote_artifacts,
     swe_v1_remote_evaluation,
 )
 

--- a/opencollab/opencollab/harness/swe_v1_remote_state.py
+++ b/opencollab/opencollab/harness/swe_v1_remote_state.py
@@ -29,8 +29,16 @@ from typing import Any
 
 from opencollab.harness.swe_eval_records import (
     SUBMISSION_INTEGRITY_INELIGIBLE,
+    embedded_workflow_metric,
     metric_submission_integrity,
     open_regular_binary,
+    patch_sha,
+    patch_sha_matches,
+    prediction_patch,
+    row_explicit_patch_sha,
+    row_patch_sha,
+    row_record_id,
+    row_task_id,
 )
 
 cfg: dict[str, Any] = {}

--- a/opencollab/tests/test_analyst_solve_f2p_gate.py
+++ b/opencollab/tests/test_analyst_solve_f2p_gate.py
@@ -59,7 +59,12 @@ class ScriptedCtx:
         self.agent_calls.append(
             {"prompt": prompt, "label": label, "schema": schema, **kw}
         )
-        return self._replies.pop(0) if self._replies else None
+        reply = self._replies.pop(0) if self._replies else None
+        if isinstance(reply, dict) and tools:
+            for tool in tools:
+                if getattr(tool, "name", "") == "run_tests":
+                    tool._verified_targets.update(reply.get("tests_run") or ())
+        return reply
 
     async def parallel(self, thunks):
         return [await t() for t in thunks]
@@ -115,6 +120,15 @@ async def _run(ctx, args):
 
 def _coder_prompts(ctx) -> list[str]:
     return [c["prompt"] for c in ctx.agent_calls if (c["label"] or "").startswith("coder:")]
+
+
+def test_f2p_gate_rejects_negative_failed_count_and_missing_tool_evidence():
+    verdict = _pass(tests_run=F2P, failed_count=-1)
+    assert _f2p_gate()(verdict, F2P) is not None
+
+    verdict["failed_count"] = 0
+    assert _f2p_gate()(verdict, F2P, executed_tests=set()) is not None
+    assert _f2p_gate()(verdict, F2P, executed_tests=set(F2P)) is None
 
 
 # (a) tester verdict PASS but failed_count=1 -> _run_phase overrides + seeds findings.

--- a/opencollab/tests/test_analyst_solve_target_tests.py
+++ b/opencollab/tests/test_analyst_solve_target_tests.py
@@ -34,7 +34,12 @@ class ScriptedCtx:
 
     async def agent(self, prompt, *, schema=None, label=None, tools=None, **kw):
         self.agent_calls.append({"prompt": prompt, "label": label})
-        return self._replies.pop(0) if self._replies else None
+        reply = self._replies.pop(0) if self._replies else None
+        if isinstance(reply, dict) and tools:
+            for tool in tools:
+                if getattr(tool, "name", "") == "run_tests":
+                    tool._verified_targets.update(reply.get("tests_run") or ())
+        return reply
 
     async def parallel(self, thunks):
         return [await t() for t in thunks]

--- a/opencollab/tests/test_local_env_processes.py
+++ b/opencollab/tests/test_local_env_processes.py
@@ -14,6 +14,8 @@ import threading
 import time
 from pathlib import Path
 
+import opencollab.adapters._env_local as local_mod
+import opencollab.adapters._env_process as process_mod
 import opencollab.adapters.env as env_mod
 import pytest
 from asyncio_test_support import assert_cancel_note, assert_cancel_reason
@@ -767,3 +769,93 @@ async def test_local_cleanup_and_abort_release_workspace_and_temp_descriptors(tm
         os.fstat(abort_workspace_fd)
     with pytest.raises(OSError):
         os.fstat(abort_temp_fd)
+
+
+@pytest.mark.asyncio
+async def test_local_abort_waits_for_active_command_group_before_returning(tmp_path):
+    env = LocalEnvironment(str(tmp_path))
+    started = tmp_path / "started"
+    late = tmp_path / "late"
+    command = f"touch {shlex.quote(str(started))}; sleep 0.5; touch {shlex.quote(str(late))}"
+    command_task = asyncio.create_task(env.exec_cmd(command, timeout=5))
+    await _wait_for_file(started)
+
+    await env.abort()
+    result = await command_task
+
+    assert result.returncode != 0
+    assert not late.exists()
+    await asyncio.sleep(0.6)
+    assert not late.exists()
+    with pytest.raises(RuntimeError, match="aborted"):
+        await env.exec_cmd("touch should-not-run")
+
+
+@pytest.mark.asyncio
+async def test_local_cleanup_waits_for_active_command_group_before_returning(tmp_path):
+    env = LocalEnvironment(str(tmp_path))
+    started = tmp_path / "cleanup-started"
+    late = tmp_path / "cleanup-late"
+    command = f"touch {shlex.quote(str(started))}; sleep 0.5; touch {shlex.quote(str(late))}"
+    command_task = asyncio.create_task(env.exec_cmd(command, timeout=5))
+    await _wait_for_file(started)
+
+    await env.cleanup()
+    result = await command_task
+
+    assert result.returncode != 0
+    await asyncio.sleep(0.6)
+    assert not late.exists()
+
+
+@pytest.mark.asyncio
+async def test_revoked_process_operation_never_spawns_after_registry_attach(monkeypatch):
+    registry = local_mod._ActiveProcessOperations()
+    token = registry.begin()
+    owner = process_mod._ThreadProcessOwner(
+        "touch should-not-run",
+        shell=True,
+        cwd=None,
+        cwd_fd=None,
+        timeout=1.0,
+        input_data=None,
+        late_compensation=None,
+    )
+
+    def forbidden_popen(*args, **kwargs):
+        raise AssertionError("revoked command reached Popen")
+
+    monkeypatch.setattr(process_mod, "_PROCESS_POPEN", forbidden_popen)
+    abort_task = asyncio.create_task(registry.abort())
+    await asyncio.sleep(0)
+    registry.attach(token, owner)
+    owner.start()
+    registry.finish(token)
+
+    await abort_task
+    assert owner.finished.is_set()
+    assert owner.result.returncode == -int(signal.SIGTERM)
+
+
+@pytest.mark.asyncio
+async def test_local_cleanup_recovers_when_process_owner_thread_cannot_start(
+    monkeypatch,
+    tmp_path,
+):
+    original_start = threading.Thread.start
+
+    def fail_process_owner_start(thread):
+        if thread.name.startswith("opencollab-process-owner-"):
+            raise RuntimeError("thread unavailable")
+        return original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", fail_process_owner_start)
+    env = LocalEnvironment(str(tmp_path))
+    workspace_fd = env._workspace_fd
+
+    with pytest.raises(RuntimeError, match="thread unavailable"):
+        await env.exec_cmd("true")
+    await env.cleanup()
+
+    with pytest.raises(OSError):
+        os.fstat(workspace_fd)

--- a/opencollab/tests/test_phase1_toolset_whitelist.py
+++ b/opencollab/tests/test_phase1_toolset_whitelist.py
@@ -178,7 +178,12 @@ class ScriptedCtx:
         self.agent_calls.append(
             {"prompt": prompt, "label": label, "schema": schema, "tools": tools, **kw}
         )
-        return self._replies.pop(0) if self._replies else None
+        reply = self._replies.pop(0) if self._replies else None
+        if isinstance(reply, dict) and reply.get("verdict") == "PASS":
+            for tool in tools or ():
+                if getattr(tool, "name", "") == "run_tests":
+                    tool._verified_targets.update(reply.get("tests_run") or ())
+        return reply
 
     async def parallel(self, thunks):
         return [await t() for t in thunks]

--- a/opencollab/tests/test_phase2_warts.py
+++ b/opencollab/tests/test_phase2_warts.py
@@ -65,7 +65,12 @@ class ScriptedCtx:
 
     async def agent(self, prompt, *, schema=None, label=None, tools=None, **kw):
         self.agent_calls.append({"prompt": prompt, "label": label, "schema": schema, **kw})
-        return self._replies.pop(0) if self._replies else None
+        reply = self._replies.pop(0) if self._replies else None
+        if isinstance(reply, dict) and tools:
+            for tool in tools:
+                if getattr(tool, "name", "") == "run_tests":
+                    tool._verified_targets.update(reply.get("tests_run") or ())
+        return reply
 
     async def parallel(self, thunks):
         return [await t() for t in thunks]

--- a/opencollab/tests/test_public_import_compatibility.py
+++ b/opencollab/tests/test_public_import_compatibility.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import importlib
 
 from opencollab.application.async_timeout import abandon_on_timeout
+from opencollab.application.scheduler_types import QueuedTeammateMessage
+from opencollab.application.session import SessionRuntime
 from opencollab.application.tool_execution import (
     abandon_on_timeout as tool_execution_abandon_on_timeout,
 )
 from opencollab.application.workflow import (
     abandon_on_timeout as workflow_abandon_on_timeout,
 )
+from opencollab.harness import swe_eval_records, swe_v1_remote_records
 from opencollab.harness.evaluator import EvalResult, EvalTask
 from opencollab.harness.evaluator_models import (
     EvalResult as ExtractedEvalResult,
@@ -41,6 +44,21 @@ def test_swe_eval_facades_reexport_patch_digest_helper() -> None:
     assert discovery_row_patch_sha is row_patch_sha
 
 
+def test_remote_runner_reuses_shared_record_identity_helpers() -> None:
+    names = (
+        "prediction_patch",
+        "row_task_id",
+        "row_record_id",
+        "row_explicit_patch_sha",
+        "patch_sha",
+        "row_patch_sha",
+        "embedded_workflow_metric",
+        "patch_sha_matches",
+    )
+    for name in names:
+        assert getattr(swe_v1_remote_records, name) is getattr(swe_eval_records, name)
+
+
 def test_checkpoint_facade_reexports_recovery_prefix() -> None:
     assert ENV_RECOVERY_PATCH_PREFIX == EXTRACTED_ENV_RECOVERY_PATCH_PREFIX
     assert ENV_RECOVERY_PATCH_PREFIX == "/tmp/opencollab-checkpoint-recovery-"
@@ -49,6 +67,28 @@ def test_checkpoint_facade_reexports_recovery_prefix() -> None:
 def test_evaluator_facade_reexports_extracted_models() -> None:
     assert EvalResult is ExtractedEvalResult
     assert EvalTask is ExtractedEvalTask
+
+
+def test_added_runtime_fields_preserve_legacy_construction() -> None:
+    message = QueuedTeammateMessage(
+        from_aid=1,
+        to_aid=2,
+        summary="summary",
+        content="content",
+        xml="<message />",
+    )
+    runtime = SessionRuntime(
+        state=object(),
+        event_bus=object(),
+        llm=object(),
+        store=object(),
+        tool_execution=object(),
+        runner=object(),
+        auto_save_path=None,
+    )
+
+    assert message.sent_at == ""
+    assert runtime.auto_save_subscriber is None
 
 
 def test_split_facades_retain_every_legacy_public_binding() -> None:

--- a/opencollab/tests/test_run_tests_tool.py
+++ b/opencollab/tests/test_run_tests_tool.py
@@ -1,6 +1,7 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
 from opencollab.adapters.tools.run_tests import RunTestsTool
 from opencollab.application.tool_execution import ToolRuntime
 
@@ -501,6 +502,43 @@ def test_build_command_native_runner_quotes_translated_target():
     assert cmd == "python bin/test tests/test_x.py 'test_two; touch pwned'"
 
 
+@pytest.mark.parametrize(
+    "runner",
+    [
+        "uv run pytest",
+        "poetry run pytest",
+        "pipenv run pytest",
+        "coverage run -m pytest",
+        "env PYTHONHASHSEED=0 python -m pytest",
+        "python -X dev -m pytest",
+    ],
+)
+def test_build_command_supports_safe_pytest_wrappers(runner):
+    from opencollab.adapters.tools.run_tests import _build_command, _is_green
+
+    target = "tests/test_x.py::test_two"
+    cmd = _build_command(runner, target, "")
+    output = f"PASSED {target}\n1 passed in 0.01s\n"
+
+    assert cmd.endswith(f"-q {target}")
+    assert _is_green(0, output, runner=runner, target=target)
+
+
+@pytest.mark.parametrize(
+    "runner",
+    [
+        'sh -c "pytest tests/test_x.py"',
+        'python -c "print(\"1 passed in 0.01s\")" -m pytest',
+        "env --ignore-environment pytest",
+        "uv tool run pytest",
+    ],
+)
+def test_pytest_runner_rejects_unsupported_or_shell_wrappers(runner):
+    from opencollab.adapters.tools.run_tests import _is_pytest_runner
+
+    assert not _is_pytest_runner(runner)
+
+
 def test_build_command_go_runner_translates_package_and_test_name():
     from opencollab.adapters.tools.run_tests import _build_command
     cmd = _build_command("go test", "internal/server/evaluator_test.go::TestEvaluate", "")
@@ -604,6 +642,56 @@ def test_run_tests_rejects_noop_runner_green_forgery():
     )
 
     assert "Verdict: RED" in result
+
+
+def test_run_tests_rejects_shell_wrapped_pytest_output_forgery():
+    target = "tests/test_x.py::test_one"
+    forged = f"PASSED {target}\n1 passed in 0.01s\n"
+    runtime = ToolRuntime(
+        environment=FakeEnv(stdout=forged, returncode=0),
+        safety_policy=None,
+        permission_policy=None,
+    )
+
+    tool = RunTestsTool()
+    result = run(
+        tool.execute_with_runtime(
+            {"runner": 'sh -c "printf forged" pytest', "target": target},
+            runtime,
+        )
+    )
+
+    assert "Verdict: RED" in result
+    assert tool.verified_targets == frozenset()
+
+
+def test_run_tests_rejects_multiple_pytest_result_summaries():
+    from opencollab.adapters.tools.run_tests import _is_green
+
+    target = "tests/test_x.py::test_one"
+    output = (
+        f"FAILED {target} - assertion failed\n"
+        "1 failed in 0.01s\n"
+        f"PASSED {target}\n"
+        "1 passed in 0.01s\n"
+    )
+
+    assert not _is_green(0, output, target=target)
+
+
+def test_run_tests_records_only_parser_backed_green_targets():
+    target = "tests/test_x.py::test_one"
+    runtime = ToolRuntime(
+        environment=FakeEnv(stdout=PLAIN_PASS_OUTPUT, returncode=0),
+        safety_policy=None,
+        permission_policy=None,
+    )
+
+    tool = RunTestsTool()
+    result = run(tool.execute_with_runtime({"target": target}, runtime))
+
+    assert "Verdict: GREEN" in result
+    assert tool.verified_targets == frozenset({target})
 
 
 def test_run_tests_requires_named_target_pass_proof():

--- a/opencollab/tests/test_safe_file_ownership.py
+++ b/opencollab/tests/test_safe_file_ownership.py
@@ -13,6 +13,7 @@ import opencollab.adapters._owned_file_cleanup as owned_cleanup_mod
 import opencollab.adapters.retirement_registry as retirement_registry_mod
 import opencollab.adapters.safe_files as safe_files_mod
 import pytest
+from opencollab.adapters.storage import SessionStore
 
 
 def test_atomic_rename_rejects_embedded_nul(tmp_path):
@@ -777,3 +778,73 @@ def test_durable_unlink_refuses_retirement_byte_overflow(tmp_path, monkeypatch):
         safe_files_mod.unlink_regular_file_durable(target)
 
     assert target.read_bytes() == b"owned"
+
+
+def test_session_store_reclaims_verified_tombstones_and_compacts_registry(
+    tmp_path,
+    monkeypatch,
+):
+    retirement_log = tmp_path / "retirements.jsonl"
+    retirement_log.touch()
+    monkeypatch.setenv(
+        retirement_registry_mod.INTERNAL_RETIREMENT_LOG_ENV,
+        str(retirement_log),
+    )
+    monkeypatch.setenv(
+        retirement_registry_mod.INTERNAL_RETIREMENT_WORKSPACE_ENV,
+        str(tmp_path),
+    )
+    monkeypatch.setattr(owned_cleanup_mod, "MAX_RETIRED_FILES_PER_DIRECTORY", 4)
+    target = tmp_path / "session.json"
+    store = SessionStore()
+
+    for index in range(20):
+        store.save(str(target), [{"role": "user", "content": str(index)}])
+
+    assert store.load_messages(str(target), "fallback") == [
+        {"role": "user", "content": "19"}
+    ]
+    retired = list(tmp_path.glob(f"{owned_cleanup_mod.RETIRED_FILE_PREFIX}*"))
+    assert len(retired) <= 3
+    assert len(retirement_log.read_bytes().splitlines()) == len(retired)
+    assert set(retirement_registry_mod.registered_retirement_paths(tmp_path)) == {
+        path.name for path in retired
+    }
+
+
+def test_retirement_reclamation_preserves_unregistered_reserved_entries(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "session.json"
+    store = SessionStore()
+    store.save(str(target), [{"role": "user", "content": "initial"}])
+    foreign = [
+        tmp_path / f"{owned_cleanup_mod.RETIRED_FILE_PREFIX}foreign-{index}"
+        for index in range(2)
+    ]
+    for path in foreign:
+        path.write_text("foreign", encoding="utf-8")
+    monkeypatch.setattr(owned_cleanup_mod, "MAX_RETIRED_FILES_PER_DIRECTORY", 2)
+
+    with pytest.raises(OSError, match="retired-file count limit"):
+        store.save(str(target), [{"role": "user", "content": "replacement"}])
+
+    assert target.exists()
+    assert all(path.read_text(encoding="utf-8") == "foreign" for path in foreign)
+
+
+def test_repeated_durable_unlink_reclaims_verified_tombstones(tmp_path, monkeypatch):
+    monkeypatch.setattr(owned_cleanup_mod, "MAX_RETIRED_FILES_PER_DIRECTORY", 4)
+
+    for index in range(20):
+        target = tmp_path / f"owned-{index}.json"
+        target.write_text(str(index), encoding="utf-8")
+        assert safe_files_mod.unlink_regular_file_durable(target) is True
+        assert not target.exists()
+
+    retired = list(tmp_path.glob(f"{owned_cleanup_mod.RETIRED_FILE_PREFIX}*"))
+    assert len(retired) == 4
+    assert set(retirement_registry_mod.registered_retirement_paths(tmp_path)) == {
+        path.name for path in retired
+    }

--- a/opencollab/tests/test_scheduler_awaiting.py
+++ b/opencollab/tests/test_scheduler_awaiting.py
@@ -1085,18 +1085,30 @@ def test_cleanup_is_bounded_when_worktree_release_ignores_cancellation():
             self.release_gate = asyncio.Event()
             self.finished = asyncio.Event()
             self.cancellations = 0
+            self.release_calls = 0
+            self.active_releases = 0
+            self.max_active_releases = 0
 
         async def acquire(self, role):
             return None
 
         async def release(self):
+            self.release_calls += 1
+            self.active_releases += 1
+            self.max_active_releases = max(
+                self.max_active_releases,
+                self.active_releases,
+            )
             self.started.set()
-            while not self.release_gate.is_set():
-                try:
-                    await self.release_gate.wait()
-                except asyncio.CancelledError:
-                    self.cancellations += 1
-            self.finished.set()
+            try:
+                while not self.release_gate.is_set():
+                    try:
+                        await self.release_gate.wait()
+                    except asyncio.CancelledError:
+                        self.cancellations += 1
+                self.finished.set()
+            finally:
+                self.active_releases -= 1
 
     lead = ScriptedSession("lead", [])
     scheduler, _ = build_scheduler(lead, [])
@@ -1114,8 +1126,20 @@ def test_cleanup_is_bounded_when_worktree_release_ignores_cancellation():
             )
         assert pool.started.is_set()
         assert pool.cancellations >= 1
+        assert pool.release_calls == 1
+        with pytest.raises(
+            RuntimeError,
+            match="technical scheduler cleanup failed: worktree pool release failed or timed out",
+        ):
+            await scheduler.cleanup(cleanup_timeout=0.01)
+        assert pool.release_calls == 1
+        assert pool.active_releases == 1
+        assert pool.max_active_releases == 1
         pool.release_gate.set()
         await asyncio.wait_for(pool.finished.wait(), timeout=0.5)
+        await scheduler.cleanup(cleanup_timeout=0.01)
+        assert pool.release_calls == 1
+        assert pool.active_releases == 0
 
     run(scenario())
 
@@ -1145,21 +1169,67 @@ def test_cleanup_surfaces_synchronous_worktree_release_failure():
     run(scenario())
 
 
+def test_cleanup_retries_worktree_release_after_transient_failure():
+    class FailOnceReleasePool:
+        def __init__(self):
+            self.release_calls = 0
+
+        async def acquire(self, role):
+            return None
+
+        async def release(self):
+            self.release_calls += 1
+            if self.release_calls == 1:
+                raise OSError("transient release failure")
+
+    lead = ScriptedSession("lead", [])
+    scheduler, _ = build_scheduler(lead, [])
+    pool = FailOnceReleasePool()
+    scheduler._worktree_pool = pool
+
+    async def scenario():
+        with pytest.raises(
+            RuntimeError,
+            match="technical scheduler cleanup failed: worktree pool release failed or timed out",
+        ):
+            await scheduler.cleanup(cleanup_timeout=0.01)
+        assert scheduler._cleanup_task is None
+
+        await scheduler.cleanup(cleanup_timeout=0.01)
+        assert pool.release_calls == 2
+        assert scheduler._cleanup_task is not None
+        assert scheduler._cleanup_task.done()
+
+    run(scenario())
+
+
 def test_cleanup_surfaces_environment_abort_timeout_and_late_task_stays_terminal():
     class StubbornAbortEnv:
         def __init__(self):
             self.abort_started = asyncio.Event()
             self.abort_release = asyncio.Event()
             self.abort_finished = asyncio.Event()
+            self.abort_calls = 0
+            self.active_aborts = 0
+            self.max_active_aborts = 0
 
         async def abort(self):
+            self.abort_calls += 1
+            self.active_aborts += 1
+            self.max_active_aborts = max(
+                self.max_active_aborts,
+                self.active_aborts,
+            )
             self.abort_started.set()
-            while not self.abort_release.is_set():
-                try:
-                    await self.abort_release.wait()
-                except asyncio.CancelledError:
-                    continue
-            self.abort_finished.set()
+            try:
+                while not self.abort_release.is_set():
+                    try:
+                        await self.abort_release.wait()
+                    except asyncio.CancelledError:
+                        continue
+                self.abort_finished.set()
+            finally:
+                self.active_aborts -= 1
 
     class StubbornSession:
         def __init__(self, env):
@@ -1186,13 +1256,13 @@ def test_cleanup_surfaces_environment_abort_timeout_and_late_task_stays_terminal
 
     class RecordingPool:
         def __init__(self):
-            self.release_called = False
+            self.release_calls = 0
 
         async def acquire(self, _role):
             return env
 
         async def release(self):
-            self.release_called = True
+            self.release_calls += 1
 
     pool = RecordingPool()
     scheduler._worktree_pool = pool
@@ -1207,13 +1277,25 @@ def test_cleanup_surfaces_environment_abort_timeout_and_late_task_stays_terminal
         assert "session environment abort failed or timed out" in str(caught.value)
         assert env.abort_started.is_set()
         assert env._aborted is True
-        assert pool.release_called is False
+        assert pool.release_calls == 0
         assert scheduler.table.get(aid).state.phase is SessionPhase.CANCELLED
+
+        with pytest.raises(RuntimeError) as retry_caught:
+            await scheduler.cleanup(cleanup_timeout=0.01)
+        assert "execution tasks did not quiesce" in str(retry_caught.value)
+        assert pool.release_calls == 0
+        assert env.abort_calls == 1
+        assert env.active_aborts == 1
+        assert env.max_active_aborts == 1
 
         child.release.set()
         env.abort_release.set()
         await asyncio.wait_for(driver, timeout=0.5)
         await asyncio.wait_for(env.abort_finished.wait(), timeout=0.5)
+        await scheduler.cleanup(cleanup_timeout=0.01)
+        assert pool.release_calls == 1
+        assert env.abort_calls == 1
+        assert env.active_aborts == 0
         assert scheduler.table.get(aid).state.phase is SessionPhase.CANCELLED
         assert scheduler.table.get(aid).result.startswith("Error: scheduler cleanup")
 

--- a/opencollab/tests/test_swe_eval_status_queue.py
+++ b/opencollab/tests/test_swe_eval_status_queue.py
@@ -68,6 +68,31 @@ def test_per_instance_queue_accepts_sidecar_for_exact_candidate(tmp_path):
     assert queue == []
 
 
+@pytest.mark.parametrize("mutation", ["rewrite", "touch"])
+def test_per_instance_report_rejects_preexisting_no_sha_report_after_mutation(
+    tmp_path,
+    mutation,
+):
+    runner = importlib.import_module("scripts.run_swebench_eval_per_instance")
+    report = tmp_path / "report.json"
+    payload = json.dumps({"task-1": {"resolved": True}})
+    report.write_text(payload, encoding="utf-8")
+    identity = {
+        "instance_id": "task-1",
+        "record_id": "current-record",
+        "patch_sha256": "b" * 64,
+    }
+    attempt = runner.write_identity(runner.identity_path(report), identity)
+
+    if mutation == "rewrite":
+        report.write_text(payload, encoding="utf-8")
+    else:
+        changed_ns = max(time.time_ns(), attempt["started_at_ns"] + 1)
+        os.utime(report, ns=(changed_ns, changed_ns))
+
+    assert runner.report_is_done(report, "task-1", identity) is False
+
+
 def test_per_instance_queue_retries_exact_candidate_after_technical_report(tmp_path):
     runner = importlib.import_module("scripts.run_swebench_eval_per_instance")
     dataset_path = tmp_path / "dataset.json"

--- a/opencollab/tests/test_swe_v1_prolite_runner.py
+++ b/opencollab/tests/test_swe_v1_prolite_runner.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import shutil
 import tarfile
+from pathlib import Path
 
 from swe_v1_prolite_runner_test_support import (
     SimpleNamespace,
@@ -10,6 +13,24 @@ from swe_v1_prolite_runner_test_support import (
     subprocess,
     sys,
 )
+
+
+def _run_runtime_sync_command_locally(command, *, timeout=120, input_text=None):
+    if command[0] == "rsync":
+        destination = Path(command[-1].split(":", 1)[1])
+        shutil.copy2(command[-2], destination)
+        return subprocess.CompletedProcess(command, 0, "", "")
+    assert command[:2] == ["ssh", "remote-host"]
+    result = subprocess.run(
+        ["sh", "-c", command[-1]],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr or result.stdout)
+    return result
 
 
 @pytest.mark.parametrize(
@@ -197,6 +218,64 @@ def test_runtime_archive_imports_generation_entrypoints_from_clean_directory(mon
         "gen_prediction_safe_output.py",
     ):
         assert (extracted / "swebench" / name).is_file()
+
+
+def test_runtime_sync_requires_every_declared_input(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner, "SYNC_FILES", ["missing.py"])
+    monkeypatch.setattr(runner, "SYNC_DIRS", ["missing-package"])
+    monkeypatch.setattr(runner, "run_checked", lambda *args, **kwargs: calls.append(args))
+
+    with pytest.raises(RuntimeError, match="missing-package, missing.py"):
+        runner.sync_runtime(
+            ssh_command=["ssh"],
+            host="remote-host",
+            remote_runtime_repo="/remote/runtime",
+        )
+
+    assert calls == []
+
+
+def test_runtime_sync_replaces_reused_directory_with_manifested_snapshot(monkeypatch, tmp_path):
+    remote_runtime = tmp_path / "remote-runtime"
+    remote_runtime.mkdir()
+    (remote_runtime / "runtime.tgz").write_bytes(b"legacy runtime marker")
+    (remote_runtime / "stale_module.py").write_text("STALE = True\n", encoding="utf-8")
+
+    monkeypatch.setattr(runner, "run_checked", _run_runtime_sync_command_locally)
+
+    summary = runner.sync_runtime(
+        ssh_command=["ssh"],
+        host="remote-host",
+        remote_runtime_repo=str(remote_runtime),
+    )
+
+    assert not (remote_runtime / "stale_module.py").exists()
+    manifest = json.loads((remote_runtime / "runtime-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["synced"] == summary["synced"]
+    assert manifest["synced_dirs"] == summary["synced_dirs"]
+    assert "opencollab/opencollab/application/session.py" in manifest["archive_members"]
+    assert not list(tmp_path.glob("remote-runtime.*"))
+
+
+def test_runtime_sync_refuses_to_replace_unmarked_directory(monkeypatch, tmp_path):
+    remote_runtime = tmp_path / "user-directory"
+    remote_runtime.mkdir()
+    user_file = remote_runtime / "notes.txt"
+    user_file.write_text("keep me\n", encoding="utf-8")
+
+    monkeypatch.setattr(runner, "run_checked", _run_runtime_sync_command_locally)
+
+    with pytest.raises(RuntimeError, match="unmarked runtime directory"):
+        runner.sync_runtime(
+            ssh_command=["ssh"],
+            host="remote-host",
+            remote_runtime_repo=str(remote_runtime),
+        )
+
+    assert user_file.read_text(encoding="utf-8") == "keep me\n"
+    assert not list(tmp_path.glob("user-directory.*"))
 
 def test_ensure_remote_proxy_falls_back_when_default_remote_port_is_busy():
     calls: list[list[str]] = []

--- a/opencollab/tests/test_swe_v1_prolite_runner_evidence.py
+++ b/opencollab/tests/test_swe_v1_prolite_runner_evidence.py
@@ -375,7 +375,7 @@ def test_prolite_python_plan_batches_81_exact_node_ids_without_file_fallback(tmp
 
 @pytest.mark.parametrize(
     "evidence_mode",
-    ["matching", "tampered", "missing_log", "go_package_pass_only"],
+    ["matching", "tampered", "missing_log", "unsafe_late_log", "go_package_pass_only"],
 )
 def test_prolite_eval_requires_matching_batch_and_target_evidence(
     monkeypatch,
@@ -416,6 +416,12 @@ def test_prolite_eval_requires_matching_batch_and_target_evidence(
             "p2p.exit",
         ):
             (output_dir / name).write_text("0\n", encoding="ascii")
+        for name in ("service_bootstrap.log", "model_patch.log", "test_patch.log"):
+            (output_dir / name).write_text("", encoding="utf-8")
+        if evidence_mode == "unsafe_late_log":
+            unsafe = output_dir / "service_bootstrap.log"
+            unsafe.unlink()
+            unsafe.symlink_to(output_dir / "attacker.log")
         for prefix in ("f2p", "p2p"):
             (output_dir / f"{prefix}.command").write_bytes((input_dir / f"{prefix}.command").read_bytes())
             (output_dir / f"{prefix}.log").write_text("", encoding="utf-8")
@@ -518,6 +524,14 @@ def test_prolite_eval_requires_matching_batch_and_target_evidence(
         assert result["summary"]["resolved"] is False
         assert "fail_to_pass_evidence" in result["summary"]["technical_reasons"]
         assert evidence[-1]["log_artifact_safe"] is False
+    elif evidence_mode == "unsafe_late_log":
+        assert result["status"] == "technical_eval_failed"
+        assert result["summary"]["resolved"] is False
+        assert "unsafe_or_missing_output_artifact" in result["summary"]["technical_reasons"]
+        assert any(
+            error.startswith("unsafe:service_bootstrap.log")
+            for error in result["summary"]["output_artifact_errors"]
+        )
     else:
         assert result["status"] == "eval_done"
         assert result["summary"]["resolved"] is True

--- a/opencollab/tests/test_workflow_run_tests_controls.py
+++ b/opencollab/tests/test_workflow_run_tests_controls.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_WORKFLOWS = Path(__file__).resolve().parents[2] / "workflows"
+
+
+def _load_workflow(name: str):
+    path = _WORKFLOWS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_run_tests_controls", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    [
+        "analyst_solve",
+        "scout_solve",
+        "self_collab",
+        "split_solve",
+        "swe_committee_v2",
+        "validation_council_solve",
+    ],
+)
+def test_workflow_model_roles_cannot_override_test_commands(workflow_name):
+    module = _load_workflow(workflow_name)
+
+    for factory_name in ("_coder_tools", "_tester_tools"):
+        tools = getattr(module, factory_name)()
+        run_tests = next(tool for tool in tools if tool.name == "run_tests")
+        assert run_tests.allow_runner_override is False
+        assert run_tests.allow_extra_args is False

--- a/opencollab/tests/test_worktree_pool.py
+++ b/opencollab/tests/test_worktree_pool.py
@@ -356,6 +356,27 @@ def test_existing_branch_failure_preserves_branch(tmp_path):
     assert _branch_exists(repo, "existing-review")
 
 
+def test_mkdtemp_failure_after_branch_claim_releases_branch_and_source_handle(
+    tmp_path,
+    monkeypatch,
+):
+    repo = _init_repo(tmp_path / "repo")
+    branch = "mkdtemp-rollback"
+    env = WorktreeEnvironment(str(repo), branch_name=branch)
+
+    def fail_mkdtemp(*args, **kwargs):
+        raise OSError("temporary directory unavailable")
+
+    monkeypatch.setattr(env_module.tempfile, "mkdtemp", fail_mkdtemp)
+    with pytest.raises(OSError, match="temporary directory unavailable"):
+        asyncio.run(env.setup())
+
+    assert not _branch_exists(repo, branch)
+    assert env._branch_cleanup_pending is False
+    assert env._source_handle.fd == -1
+    asyncio.run(env.cleanup())
+
+
 def test_branch_created_after_probe_is_never_deleted_as_ours(tmp_path, monkeypatch):
     repo = _init_repo(tmp_path / "repo")
     branch = "raced-foreign-branch"

--- a/scripts/run_swebench_eval_per_instance.py
+++ b/scripts/run_swebench_eval_per_instance.py
@@ -362,12 +362,17 @@ def run_one(
 
     with print_lock:
         print(f"[{ordinal}/{total}] evaluating {iid}", flush=True)
-    started_at_ns = time.time_ns()
-    prior_report_fingerprint = file_fingerprint(official_report)
     attempt_path = identity_path(official_report)
     try:
         if stop_event is not None and stop_event.is_set():
             return iid, 130
+        # The standard SWE-bench report schema carries no patch identity. Once
+        # this task is exclusively claimed, retire any stale report so a newly
+        # created report can be bound to this attempt by absence-at-start.
+        ensure_directory_no_symlinks(official_report.parent)
+        _unlink_durable(official_report)
+        started_at_ns = time.time_ns()
+        prior_report_fingerprint = ""
         write_identity(
             attempt_path,
             identity,

--- a/scripts/swe_v1_prolite_config.py
+++ b/scripts/swe_v1_prolite_config.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import atexit
+import json
 import os
 import re
+import secrets
 import shlex
 import stat
 import subprocess
@@ -361,11 +363,33 @@ def ensure_remote_proxy(
 
 
 def sync_runtime(*, ssh_command: list[str], host: str, remote_runtime_repo: str) -> dict[str, Any]:
-    synced: list[str] = []
-    synced_dirs: list[str] = []
+    synced = list(SYNC_FILES)
+    synced_dirs = list(SYNC_DIRS)
+    missing = [
+        rel
+        for rel in synced
+        if not (REPO_ROOT / rel).is_file()
+    ]
+    missing.extend(
+        rel
+        for rel in synced_dirs
+        if not (REPO_ROOT / rel).is_dir()
+    )
+    if missing:
+        raise RuntimeError("required runtime inputs are missing: " + ", ".join(sorted(missing)))
+
+    target = remote_runtime_repo.rstrip("/")
+    if not target or target in {".", "..", "/"}:
+        raise ValueError("remote_runtime_repo must identify a dedicated runtime directory")
+    target_parent = str(Path(target).parent)
+    token = secrets.token_hex(8)
+    remote_archive = f"{target}.archive.{token}.tgz"
+    remote_staging = f"{target}.staging.{token}"
+    remote_backup = f"{target}.backup.{token}"
     ssh_part = " ".join(shlex.quote(part) for part in ssh_command)
     with tempfile.TemporaryDirectory(prefix="swe-v1-runtime-") as tmp_dir:
         archive_path = Path(tmp_dir) / "runtime.tgz"
+        manifest_path = Path(tmp_dir) / "runtime-manifest.json"
 
         def archive_filter(tar_info: tarfile.TarInfo) -> tarfile.TarInfo | None:
             parts = Path(tar_info.name).parts
@@ -374,60 +398,93 @@ def sync_runtime(*, ssh_command: list[str], host: str, remote_runtime_repo: str)
             return tar_info
 
         with tarfile.open(archive_path, "w:gz") as archive:
-            for rel in SYNC_FILES:
+            for rel in synced:
                 local_path = REPO_ROOT / rel
-                if not local_path.exists():
-                    continue
                 archive.add(local_path, arcname=rel, filter=archive_filter)
-                synced.append(rel)
-            for rel in SYNC_DIRS:
+            for rel in synced_dirs:
                 local_path = REPO_ROOT / rel
-                if not local_path.exists():
-                    continue
                 archive.add(local_path, arcname=rel, filter=archive_filter)
-                synced_dirs.append(rel)
-        run_checked([*ssh_command, host, "mkdir -p " + shlex.quote(remote_runtime_repo)], timeout=60)
-        remote_archive = remote_runtime_repo.rstrip("/") + "/runtime.tgz"
+            manifest = {
+                "version": 1,
+                "synced": synced,
+                "synced_dirs": synced_dirs,
+                "archive_members": sorted(
+                    member.name
+                    for member in archive.getmembers()
+                    if member.isfile() or member.issym()
+                ),
+            }
+            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            archive.add(manifest_path, arcname="runtime-manifest.json")
+
+        run_checked([*ssh_command, host, "mkdir -p -- " + shlex.quote(target_parent)], timeout=60)
         run_checked(["rsync", "-az", "-e", ssh_part, str(archive_path), f"{host}:{remote_archive}"], timeout=300)
-        run_checked(
-            [*ssh_command, host, "tar -xzf " + shlex.quote(remote_archive) + " -C " + shlex.quote(remote_runtime_repo)],
-            timeout=300,
-        )
     sh_files = [rel for rel in synced if rel.endswith(".sh")]
-    if sh_files:
-        run_checked(
-            [
-                *ssh_command,
-                host,
-                "cd "
-                + shlex.quote(remote_runtime_repo)
-                + " && chmod +x "
-                + " ".join(shlex.quote(rel) for rel in sh_files),
-            ],
-            timeout=60,
-        )
     compile_targets = [
         rel
         for rel in ("scripts", "swebench", "workflows", *SYNC_DIRS)
         if rel in synced_dirs or any(item == rel or item.startswith(rel + "/") for item in synced)
     ]
+    install_lines = [
+        "set -eu",
+        "target=" + shlex.quote(target),
+        "stage=" + shlex.quote(remote_staging),
+        "backup=" + shlex.quote(remote_backup),
+        "archive=" + shlex.quote(remote_archive),
+        "target_moved=0",
+        "installed=0",
+        "cleanup() {",
+        '  if [ "$target_moved" -eq 1 ] && [ "$installed" -eq 0 ] && '
+        '     { [ ! -e "$target" ] && [ ! -L "$target" ]; }; then',
+        '    mv -- "$backup" "$target" || true',
+        "  fi",
+        '  rm -rf -- "$stage"',
+        '  rm -f -- "$archive"',
+        "}",
+        "trap cleanup EXIT HUP INT TERM",
+        'if [ -e "$target" ] || [ -L "$target" ]; then',
+        '  current_manifest="$target/runtime-manifest.json"',
+        '  legacy_archive="$target/runtime.tgz"',
+        '  if { [ ! -f "$current_manifest" ] || [ -L "$current_manifest" ]; } &&',
+        '     { [ ! -f "$legacy_archive" ] || [ -L "$legacy_archive" ]; }; then',
+        '    echo "refusing to replace an unmarked runtime directory: $target" >&2',
+        "    exit 1",
+        "  fi",
+        "fi",
+        'test ! -e "$stage" && test ! -L "$stage"',
+        'test ! -e "$backup" && test ! -L "$backup"',
+        'mkdir -- "$stage"',
+        'tar -xzf "$archive" -C "$stage"',
+    ]
+    prepare_commands: list[str] = []
+    if sh_files:
+        prepare_commands.append("chmod +x " + " ".join(shlex.quote(rel) for rel in sh_files))
     if compile_targets:
-        run_checked(
-            [
-                *ssh_command,
-                host,
-                "cd "
-                + shlex.quote(remote_runtime_repo)
-                + " && python3 -m compileall -q "
-                + " ".join(shlex.quote(rel) for rel in compile_targets),
-            ],
-            timeout=180,
+        prepare_commands.append(
+            "python3 -m compileall -q " + " ".join(shlex.quote(rel) for rel in compile_targets)
         )
+    if prepare_commands:
+        install_lines.append('(cd "$stage" && ' + " && ".join(prepare_commands) + ")")
+    install_lines.extend(
+        [
+            'if [ -e "$target" ] || [ -L "$target" ]; then',
+            '  mv -- "$target" "$backup"',
+            "  target_moved=1",
+            "fi",
+            'mv -- "$stage" "$target"',
+            "installed=1",
+            'if [ "$target_moved" -eq 1 ]; then rm -rf -- "$backup"; fi',
+            'rm -f -- "$archive"',
+            "trap - EXIT HUP INT TERM",
+        ]
+    )
+    run_checked([*ssh_command, host, "\n".join(install_lines)], timeout=300)
     return {
-        "remote_runtime_repo": remote_runtime_repo,
+        "remote_runtime_repo": target,
         "synced": synced,
         "synced_dirs": synced_dirs,
         "compile_targets": compile_targets,
+        "manifest": "runtime-manifest.json",
     }
 
 

--- a/scripts/swebench_eval_records.py
+++ b/scripts/swebench_eval_records.py
@@ -632,7 +632,6 @@ def report_is_done(path: Path, instance_id: str, expected_identity: dict) -> boo
         return False
     attempt, _sidecar_stat = sidecar_document
     report_mtime_ns = report_stat.st_mtime_ns
-    current_report_fingerprint = _runner()._stat_fingerprint(report_stat)
     if not isinstance(attempt, dict) or attempt.get("schema") != "opencollab.swe_eval_attempt.v1":
         return False
     if attempt.get("status") not in {"launching", "started", "completed"}:
@@ -644,7 +643,11 @@ def report_is_done(path: Path, instance_id: str, expected_identity: dict) -> boo
     if str(attempt.get("patch_sha256") or "") != str(expected_identity.get("patch_sha256") or ""):
         return False
     if "prior_report_fingerprint" in attempt:
-        return current_report_fingerprint != str(attempt.get("prior_report_fingerprint") or "")
+        # A report format without an embedded patch identity can only be bound
+        # when the destination was absent at attempt start. Rewriting or merely
+        # touching a pre-existing report does not prove which patch was graded.
+        if str(attempt.get("prior_report_fingerprint") or ""):
+            return False
     try:
         return report_mtime_ns >= int(attempt.get("started_at_ns") or 0) > 0
     except (TypeError, ValueError):

--- a/workflows/analyst_solve.py
+++ b/workflows/analyst_solve.py
@@ -41,7 +41,7 @@ from typing import Any
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool
 from opencollab.adapters.tools.bash import BashTool
 from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
-from opencollab.adapters.tools.run_tests import RunTestsTool
+from opencollab.adapters.tools.run_tests import verification_run_tests_tool
 from opencollab.application.fact_sheet import (
     build_fact_sheet,
     estimate_target_complexity,
@@ -198,6 +198,7 @@ VERDICT_SCHEMA: dict[str, Any] = {
         },
         "failed_count": {
             "type": "integer",
+            "minimum": 0,
             "description": "How many of the tests you ran failed or errored (0 for a clean PASS). "
             "Read it straight off run_tests' Counts line; do not estimate.",
         },
@@ -499,24 +500,36 @@ def _target_tests_block(args: dict[str, Any]) -> str:
     return TARGET_TESTS_BLOCK.format(ids=listed)
 
 
-def _f2p_gate(verdict: Any, fail_to_pass: list[str]) -> str | None:
+def _verified_test_targets(tools: list[Any]) -> set[str]:
+    """Collect parser-backed GREEN targets from this tester call's tool instance."""
+    run_tests = next((tool for tool in tools if getattr(tool, "name", "") == "run_tests"), None)
+    return set(getattr(run_tests, "verified_targets", ()))
+
+
+def _f2p_gate(
+    verdict: Any,
+    fail_to_pass: list[str],
+    *,
+    executed_tests: set[str] | None = None,
+) -> str | None:
     """Hard-gate a tester PASS on the real FAIL_TO_PASS node-ids (D2).
 
     Returns ``None`` when the PASS may stand, or a findings string when it must
     be overridden to not-passed. The gate fires whenever ``fail_to_pass`` is
     non-empty, regardless of whether a test patch was supplied. Defense in
-    depth: even a PASS verdict must carry machine-checkable proof —
-    ``failed_count == 0`` AND every required node-id present in ``tests_run`` —
-    or it does not count.
+    depth: even a PASS verdict must carry ``failed_count == 0``, every required
+    node-id in ``tests_run``, and (when supplied by the workflow) parser-backed
+    GREEN evidence from this tester call's run_tests instance.
     """
     if not fail_to_pass:
         return None  # no benchmark target ids were declared
     if not isinstance(verdict, dict):
         return None  # not a PASS to override; the caller handles dead/FAIL verdicts
     failed = verdict.get("failed_count")
-    if isinstance(failed, int) and failed > 0:
+    if type(failed) is not int or failed != 0:
         return (
-            f"Tester reported {failed} failed/errored test(s). The named FAIL_TO_PASS "
+            f"Tester reported {failed!r} failed/errored test(s), which is invalid. "
+            "The named FAIL_TO_PASS "
             "tests must run green with ZERO failures. Re-run the exact target node-ids "
             "with run_tests and fix the remaining failures."
         )
@@ -530,6 +543,15 @@ def _f2p_gate(verdict: Any, fail_to_pass: list[str]) -> str | None:
             f"verification: {listed}. Run them with run_tests using the EXACT node-ids "
             "and ensure they pass with zero failures before reporting PASS."
         )
+    if executed_tests is not None:
+        unproved = [nid for nid in fail_to_pass if nid not in executed_tests]
+        if unproved:
+            listed = ", ".join(unproved)
+            return (
+                "This tester call contains no parser-backed GREEN run_tests execution for these "
+                f"required node-ids: {listed}. Run each exact target with run_tests; a "
+                "tests_run self-report cannot replace executable evidence."
+            )
     return None
 
 
@@ -651,12 +673,25 @@ def _coder_tools(enforcement_strength: str = ENFORCEMENT_OFF) -> list[Any]:
     habitual edit path plus apply_patch + run_tests + read/grep.
     """
     if enforcement_strength == ENFORCEMENT_OFF:
-        return [BashTool(), FileReadTool(), FileWriteTool(), ApplyPatchTool(), RunTestsTool(), GrepTool()]
-    return [FileReadTool(), GrepTool(), FileWriteTool(allow_create=False), ApplyPatchTool(), RunTestsTool()]
+        return [
+            BashTool(),
+            FileReadTool(),
+            FileWriteTool(),
+            ApplyPatchTool(),
+            verification_run_tests_tool(),
+            GrepTool(),
+        ]
+    return [
+        FileReadTool(),
+        GrepTool(),
+        FileWriteTool(allow_create=False),
+        ApplyPatchTool(),
+        verification_run_tests_tool(),
+    ]
 
 
 def _tester_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), RunTestsTool(), GrepTool()]
+    return [BashTool(), FileReadTool(), verification_run_tests_tool(), GrepTool()]
 
 
 def _static_tester_tools() -> list[Any]:
@@ -1001,6 +1036,7 @@ async def _run_phase(
             coder_summary = "(coder produced empty output; verify the working tree yourself)"
         else:
             coder_summary = summary
+        tester_tools = _tester_tools_for(static_verify)
         verdict = await ctx.agent(
             _tester_prompt(static_verify).format(
                 rules=SHARED_RULES,
@@ -1013,9 +1049,10 @@ async def _run_phase(
             ),
             schema=VERDICT_SCHEMA,
             label=f"tester:p{idx}r{round_no}",
-            tools=_tester_tools_for(static_verify),
+            tools=tester_tools,
             budget=TESTER_BUDGET,
         )
+        executed_tests = _verified_test_targets(tester_tools)
         # Diff guard: a tester PASS must NOT stand if the working tree is
         # verifiably unchanged this round — no edit means nothing to pass. Seed
         # the next round so the coder is told it MUST write; on the final round
@@ -1041,12 +1078,17 @@ async def _run_phase(
             continue
         # F2P gate (the real lever): a tester PASS must NOT stand unless the run
         # carries proof the named FAIL_TO_PASS tests actually went green —
-        # failed_count == 0 AND every required node-id present in tests_run. Only
+        # failed_count == 0, every required node-id present in tests_run, and
+        # matching GREEN evidence from this call's run_tests instance. Only
         # active when ids were injected (f2p non-empty); empty -> bypass,
         # preserving today's behavior. Mirrors the tree-unchanged override: seed
         # the next round's findings and continue, or fail on the final round.
         if passed:
-            gate_findings = _f2p_gate(verdict, f2p)
+            gate_findings = _f2p_gate(
+                verdict,
+                f2p,
+                executed_tests=executed_tests,
+            )
             if gate_findings is not None:
                 await ctx.log(
                     f"phase {idx} round {round_no}: tester PASS overridden — "
@@ -1284,6 +1326,7 @@ async def analyst_solve(ctx: Any, args: dict[str, Any]) -> dict[str, Any]:
     # Phase 5 — one whole-goal verification, with a single repair round if affordable.
     await ctx.phase("verify")
     final_verdict: dict[str, Any] | None = None
+    final_executed_tests: set[str] | None = None
     repaired = False
     # STEP 2B (Phase 2): skip the whole-goal final tester when every phase already
     # passed its own adversarial tester on the current tree and no forced write has
@@ -1302,6 +1345,7 @@ async def analyst_solve(ctx: Any, args: dict[str, Any]) -> dict[str, Any]:
     # wrap-up and FORCED_WRITE_BUDGET caps the forced write, so a verify slice
     # always survives — hence the light ``reserve=0`` gate (any budget + time).
     if _budget_ok(ctx, 0) and not skip_final_verify:
+        final_tester_tools = _tester_tools_for(static_verify)
         final_verdict = await ctx.agent(
             _tester_prompt(static_verify).format(
                 rules=SHARED_RULES,
@@ -1314,9 +1358,10 @@ async def analyst_solve(ctx: Any, args: dict[str, Any]) -> dict[str, Any]:
             ),
             schema=VERDICT_SCHEMA,
             label="tester:final",
-            tools=_tester_tools_for(static_verify),
+            tools=final_tester_tools,
             budget=TESTER_BUDGET,
         )
+        final_executed_tests = _verified_test_targets(final_tester_tools)
         if (
             isinstance(final_verdict, dict)
             and final_verdict.get("verdict") == "FAIL"
@@ -1342,6 +1387,7 @@ async def analyst_solve(ctx: Any, args: dict[str, Any]) -> dict[str, Any]:
                 tools=_coder_tools(enforcement_strength),
                 budget=REPAIR_BUDGET,
             )
+            final_tester_tools = _tester_tools_for(static_verify)
             final_verdict = await ctx.agent(
                 _tester_prompt(static_verify).format(
                     rules=SHARED_RULES,
@@ -1354,19 +1400,25 @@ async def analyst_solve(ctx: Any, args: dict[str, Any]) -> dict[str, Any]:
                 ),
                 schema=VERDICT_SCHEMA,
                 label="tester:final2",
-                tools=_tester_tools_for(static_verify),
+                tools=final_tester_tools,
                 budget=TESTER_BUDGET,
             )
+            final_executed_tests = _verified_test_targets(final_tester_tools)
 
     passed_phases = sum(1 for r in phase_reports if r["status"] == "passed")
     # "verified" requires not just a PASS label but the named FAIL_TO_PASS tests
     # green: when ids were injected, the final verdict must also clear the f2p
-    # gate (failed_count == 0 AND every required node-id in tests_run). With no
-    # declared ids this collapses to the bare verdict == PASS check.
+    # gate, including the current tester tool's GREEN evidence. With no declared
+    # ids this collapses to the bare verdict == PASS check.
     verified = (
         isinstance(final_verdict, dict)
         and final_verdict.get("verdict") == "PASS"
-        and _f2p_gate(final_verdict, fail_to_pass) is None
+        and _f2p_gate(
+            final_verdict,
+            fail_to_pass,
+            executed_tests=final_executed_tests,
+        )
+        is None
     )
     self_reported_done = verified or (not forced and passed_phases == len(phases) and phases)
 

--- a/workflows/scout_solve.py
+++ b/workflows/scout_solve.py
@@ -39,7 +39,7 @@ from typing import Any
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool
 from opencollab.adapters.tools.bash import BashTool
 from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
-from opencollab.adapters.tools.run_tests import RunTestsTool
+from opencollab.adapters.tools.run_tests import verification_run_tests_tool
 from opencollab.application.workflow_registry import workflow
 
 MAX_SOLVE_ROUNDS = 3
@@ -229,11 +229,18 @@ def _read_tools() -> list[Any]:
 
 
 def _coder_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), FileWriteTool(), ApplyPatchTool(), RunTestsTool(), GrepTool()]
+    return [
+        BashTool(),
+        FileReadTool(),
+        FileWriteTool(),
+        ApplyPatchTool(),
+        verification_run_tests_tool(),
+        GrepTool(),
+    ]
 
 
 def _tester_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), RunTestsTool(), GrepTool()]
+    return [BashTool(), FileReadTool(), verification_run_tests_tool(), GrepTool()]
 
 
 async def _explore(ctx: Any, goal: str, dims: list[dict[str, Any]]) -> str:

--- a/workflows/self_collab.py
+++ b/workflows/self_collab.py
@@ -20,7 +20,7 @@ from typing import Any
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool
 from opencollab.adapters.tools.bash import BashTool
 from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
-from opencollab.adapters.tools.run_tests import RunTestsTool
+from opencollab.adapters.tools.run_tests import verification_run_tests_tool
 from opencollab.application.workflow_registry import workflow
 
 MAX_ROUNDS_PER_PHASE = 3
@@ -191,11 +191,18 @@ def _read_tools() -> list[Any]:
 
 
 def _coder_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), FileWriteTool(), ApplyPatchTool(), RunTestsTool(), GrepTool()]
+    return [
+        BashTool(),
+        FileReadTool(),
+        FileWriteTool(),
+        ApplyPatchTool(),
+        verification_run_tests_tool(),
+        GrepTool(),
+    ]
 
 
 def _tester_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), RunTestsTool(), GrepTool()]
+    return [BashTool(), FileReadTool(), verification_run_tests_tool(), GrepTool()]
 
 
 async def _run_phase(ctx: Any, ph: dict[str, Any], idx: int) -> dict[str, Any]:

--- a/workflows/split_solve.py
+++ b/workflows/split_solve.py
@@ -31,7 +31,7 @@ from typing import Any
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool
 from opencollab.adapters.tools.bash import BashTool
 from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
-from opencollab.adapters.tools.run_tests import RunTestsTool
+from opencollab.adapters.tools.run_tests import verification_run_tests_tool
 from opencollab.application.workflow_registry import workflow
 
 MAX_ROUNDS_PER_SUBTASK = 3
@@ -192,11 +192,18 @@ def _read_tools() -> list[Any]:
 
 
 def _coder_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), FileWriteTool(), ApplyPatchTool(), RunTestsTool(), GrepTool()]
+    return [
+        BashTool(),
+        FileReadTool(),
+        FileWriteTool(),
+        ApplyPatchTool(),
+        verification_run_tests_tool(),
+        GrepTool(),
+    ]
 
 
 def _tester_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), RunTestsTool(), GrepTool()]
+    return [BashTool(), FileReadTool(), verification_run_tests_tool(), GrepTool()]
 
 
 async def _run_subtask(ctx: Any, sub: dict[str, Any], idx: int) -> dict[str, Any]:

--- a/workflows/swe_committee_v2.py
+++ b/workflows/swe_committee_v2.py
@@ -15,7 +15,7 @@ from typing import Any
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool
 from opencollab.adapters.tools.bash import BashTool
 from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
-from opencollab.adapters.tools.run_tests import RunTestsTool
+from opencollab.adapters.tools.run_tests import verification_run_tests_tool
 from opencollab.application.workflow_registry import workflow
 
 MAX_PRE_TESTS = 5
@@ -787,11 +787,18 @@ def _read_tools() -> list[Any]:
 
 
 def _coder_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), FileWriteTool(), ApplyPatchTool(), RunTestsTool(), GrepTool()]
+    return [
+        BashTool(),
+        FileReadTool(),
+        FileWriteTool(),
+        ApplyPatchTool(),
+        verification_run_tests_tool(),
+        GrepTool(),
+    ]
 
 
 def _tester_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), RunTestsTool(), GrepTool()]
+    return [BashTool(), FileReadTool(), verification_run_tests_tool(), GrepTool()]
 
 
 def _dump(value: Any) -> str:

--- a/workflows/validation_council_solve.py
+++ b/workflows/validation_council_solve.py
@@ -19,7 +19,7 @@ from opencollab.adapters.tools.apply_patch import ApplyPatchTool
 from opencollab.adapters.tools.bash import BashTool
 from opencollab.adapters.tools.fs import FileReadTool, FileWriteTool, GrepTool
 from opencollab.adapters.tools.git_diff import GitDiffTool
-from opencollab.adapters.tools.run_tests import RunTestsTool
+from opencollab.adapters.tools.run_tests import verification_run_tests_tool
 from opencollab.application.workflow_registry import workflow
 
 MAX_APPROVED_PRE_TESTS = 5
@@ -571,7 +571,14 @@ def _read_tools() -> list[Any]:
 
 
 def _coder_tools() -> list[Any]:
-    return [BashTool(), FileReadTool(), FileWriteTool(), ApplyPatchTool(), RunTestsTool(), GrepTool()]
+    return [
+        BashTool(),
+        FileReadTool(),
+        FileWriteTool(),
+        ApplyPatchTool(),
+        verification_run_tests_tool(),
+        GrepTool(),
+    ]
 
 
 def _tester_tools() -> list[Any]:
@@ -582,7 +589,7 @@ def _tester_tools() -> list[Any]:
     return [
         BashTool(),
         FileReadTool(),
-        RunTestsTool(allow_runner_override=False, allow_extra_args=False),
+        verification_run_tests_tool(),
         GrepTool(),
         GitDiffTool(),
     ]


### PR DESCRIPTION
## 修复范围与结果

这次变更针对上一轮大规模 harness 修复后的回归与审查缺口，覆盖测试证据绑定、Pro-Lite 结果判定、远端运行时替换、retirement 文件容量、LocalEnvironment 进程生命周期、Scheduler 重试所有权、worktree 初始化状态和公开构造兼容性。所有新增行为均带有回归测试。

代码复用方面，六个 workflow 统一使用 `verification_run_tests_tool()`，远端评测删除 70 行重复身份解析并复用共享 records helper。两个核心编排函数完成职责拆分：`run_eval_task_impl` 从 752 行缩至 388 行、圈复杂度从 100 降至 44；`eval_for_task` 从约 580 行缩至 465 行、圈复杂度从 55 降至 27。artifact 读取与 verdict 推导进入 240 行的独立模块，远端评测模块降至 667 行。

## 缺陷具体情况

### 测试命令与执行证据

调用者可以把 shell 包装命令伪装成 pytest，或在一次输出中拼接多个 pytest summary，使失败执行被末尾的通过摘要覆盖；Analyst tester 也能只在 JSON 中声称运行了 FAIL_TO_PASS。结果会把未执行或失败的目标测试记成 GREEN。修复后只识别受限的直接 pytest 包装器，拒绝 shell 控制符和多 summary 输出，并把 PASS 绑定到当前 tester 所持 `RunTestsTool` 的 parser-backed GREEN 目标。合法的 uv、poetry、pipenv、coverage、env 和 Python 解释器选项仍受支持。

### Pro-Lite artifact 与旧报告复用

若命令、bootstrap log 或 patch log 在 verdict 生成后才被读取，晚到的缺失或不安全 artifact 无法进入 `technical_reasons`，评测可能先写出 resolved。无 SHA 的旧官方报告只靠 mtime 变化也可能被新候选复用。修复后先创建完整 artifact snapshot，再通过纯函数派生 verdict；每次独占 claim 后先耐久移除旧报告，仅允许“attempt 开始时目标不存在”的新报告参与绑定。

### 远端运行时目录

增量解压会保留旧版本已经删除的 Python 模块，远端执行可能继续导入陈旧代码；直接覆盖未标记目录还会伤及用户文件。修复后先校验全部输入，生成 manifest，上传同级 archive，在 staging 中解压和 compile，验证 ownership marker 后通过 backup/rename 替换。未标记目录会被保留并返回技术失败。

### retirement 文件容量

失败安全策略会保留 tombstone；持续写入可达到每目录 256 项上限，使后续保存永久失败。修复后只回收 registry 中登记、parent/name/device/inode/type/size/mtime/ctime/nlink 全部匹配的 tombstone，并在目录锁、打开 fd、unlink 后 nlink 复核和 fsync 下更新内存与持久 registry。外来或被替换的对象保持原状。

### LocalEnvironment 进程生命周期

cleanup 与正在启动的 `exec_cmd` 竞态时，命令可能在资源释放后才创建进程；若 owner thread 启动失败，登记项又会永久等待。修复后环境登记每个 active operation，abort/cleanup 先 revoke、取消并等待 owner；取消发生在 Popen 前时直接结束且不会启动子进程。Thread.start 抛错会写入 owner result 并设置 finished，随后 workspace fd 可以正常关闭。

### Scheduler 重试竞态

首次 cleanup 因 stubborn driver、environment abort 或 worktree release 超时后，旧实现会清空 owner 状态。第二次 cleanup 可能并发启动另一个 abort/release，甚至在 driver 仍写 worktree 时释放环境。修复后 execution、delivery、environment abort 和 worktree release 都持久保存单一 owner；重试继续观察同一 task，只有 owner 真正终止后才允许下一阶段或重新调用。

### worktree 与公开构造兼容性

`mkdtemp` 失败前把目录状态记成“尚未删除”，会让 cleanup 操作从未创建的路径；两个 dataclass 新字段缺少默认值也会破坏既有调用者。修复后 worktree 初始状态表示目录不存在，创建成功后才翻转；`QueuedTeammateMessage.sent_at` 与 `SessionRuntime.auto_save_subscriber` 提供兼容默认值。

## 验证

最终全量测试：

```text
2680 passed, 5 skipped in 146.72s
```

高风险定向测试由主流程执行 607 项，独立 correctness Reviewer 执行 405 项，独立质量 Reviewer执行 677 项，均通过。全仓 `ruff check .`、`compileall`、应用层/领域层边界测试、公开导入测试、文件卫生检查和 `git diff --check` 全部通过。

两位独立 Reviewer 均给出 APPROVE，没有可复现的 P0、P1 或 P2 阻断项。
