### PR TITLE
fix(core): preserve completed run result on bounded shutdown

### DIFF
--- a/opencollab/opencollab/application/async_timeout.py
+++ b/opencollab/opencollab/application/async_timeout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import warnings
 from collections.abc import Awaitable, Iterable
 from dataclasses import dataclass
 from typing import Callable, TypeVar
@@ -248,14 +249,21 @@ def run_with_bounded_shutdown(
                 break
             loop.run_until_complete(asyncio.wait(pending, timeout=remaining))
         lingering = {task for task in asyncio.all_tasks(loop) if not task.done()}
-        if lingering:
-            raise AsyncRuntimeUnhealthyError(
-                f"{len(lingering)} async task(s) missed the shutdown deadline"
-            )
         for task in observed:
             consume_task_result(task)
         if run_error is not None:
             raise run_error
+        if lingering:
+            # A background task that missed the shutdown deadline must not
+            # discard the completed run's outcome. Surface it as a non-fatal
+            # diagnostic instead of turning a successful run into a
+            # crash-on-exit that loses the result.
+            warnings.warn(
+                f"{len(lingering)} async task(s) missed the shutdown deadline; "
+                "the completed run's result was preserved",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         return result  # type: ignore[return-value]
     finally:
         loop.close()

--- a/opencollab/tests/test_async_timeout.py
+++ b/opencollab/tests/test_async_timeout.py
@@ -141,7 +141,10 @@ def test_bounded_shutdown_runs_pending_task_finalizers():
     assert finalized == [True]
 
 
-def test_bounded_shutdown_reports_cancellation_resistant_task():
+def test_bounded_shutdown_preserves_result_despite_cancellation_resistant_task():
+    # A background task that refuses cancellation must NOT discard the
+    # completed run's result: the run returns normally and the lingering task
+    # is surfaced as a non-fatal diagnostic rather than a crash-on-exit.
     script = r'''
 import asyncio
 from opencollab.application.async_timeout import run_with_bounded_shutdown
@@ -156,8 +159,10 @@ async def stubborn():
 async def main():
     asyncio.create_task(stubborn())
     await asyncio.sleep(0)
+    return "RESULT_OK"
 
-run_with_bounded_shutdown(main(), shutdown_timeout=0.01)
+value = run_with_bounded_shutdown(main(), shutdown_timeout=0.01)
+print("RESULT:" + repr(value))
 '''
     env = dict(os.environ)
     env["PYTHONPATH"] = os.path.dirname(os.path.dirname(__file__))
@@ -170,7 +175,8 @@ run_with_bounded_shutdown(main(), shutdown_timeout=0.01)
         check=False,
     )
 
-    assert completed.returncode != 0
+    assert completed.returncode == 0, completed.stderr
+    assert "RESULT:'RESULT_OK'" in completed.stdout
     assert "missed the shutdown deadline" in completed.stderr
 
 


### PR DESCRIPTION
## Summary

Follow-up to #20. `run_with_bounded_shutdown` could **discard a completed run's result** and crash on exit.

After the main coroutine finished, the function drained pending tasks and then did:

```python
if lingering:
    raise AsyncRuntimeUnhealthyError(...)   # <-- ran BEFORE the lines below
for task in observed:
    consume_task_result(task)
if run_error is not None:
    raise run_error
return result
```

So any background task still non-terminal after `shutdown_timeout` (default `2.0s`) pre-empted **both** `return result` and `raise run_error`. A *successful* run whose fire-and-forget cleanup task (e.g. unwinding a slow provider/LLM coroutine mid stream-close) lingered past the deadline therefore turned into a crash-on-exit that lost its output. Both CLI entrypoints (`adapters/cli/main.py`, `adapters/cli/workflow.py`) call it with the default timeout and do not catch the error.

## Fix

Deliver the run's own outcome first — raise the real `run_error`, otherwise `return result` — and downgrade a lingering-task deadline miss from a fatal `AsyncRuntimeUnhealthyError` to a non-fatal `RuntimeWarning`. The diagnostic is preserved (operators still see the deadline miss on stderr) without ever discarding a completed run. This restores the pre-migration contract that a background task cannot fail an otherwise-successful run, while keeping the new bounded-drain cleanup.

`AsyncRuntimeUnhealthyError` is retained (still exported from `sdk/lifecycle.py`) for API stability; it is simply no longer raised on the happy path.

## Test plan

- Repurposed `test_bounded_shutdown_reports_cancellation_resistant_task` → `test_bounded_shutdown_preserves_result_despite_cancellation_resistant_task`: a run whose `main()` returns `"RESULT_OK"` while a cancellation-resistant task lingers now asserts `returncode == 0`, the result reaches stdout, and the deadline-miss diagnostic still appears on stderr (previously it asserted a non-zero crash).
- `pytest tests/test_async_timeout.py` — 20 passed.
- Full framework suite — 1436 passed (2 pre-existing failures unrelated to this change: a machine-timing-sensitive 80ms process test and a repo-ownership test that only fails on a dirty local checkout).
- `ruff check` clean.

Scope: one behavioral change in `async_timeout.py` + the one test it affects.
