### PR TITLE
fix(core): close mixed-repo false-green and restore cleanup grace

### DIFF
--- a/opencollab/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/opencollab/adapters/tools/run_tests.py
@@ -67,11 +67,16 @@ ESCALATE_AFTER = 3
 # (or when pytest is missing). Each entry: (probe-cmd that exits 0 iff present,
 # base runner command). bin/test is sympy's; manage.py is Django's; tox is the
 # generic multi-env runner. Pytest is always tried first via DEFAULT_RUNNER.
+# go.mod is probed LAST on purpose: the pytest-collected-nothing fallback only
+# trusts a Go runner, so returning "go test" first on a mixed Python+Go repo
+# would green off unrelated Go tests while the intended Python suite never ran.
+# Keeping go.mod last makes _detect_native_runner surface Go only when it is the
+# sole native signal.
 _NATIVE_PROBES: tuple[tuple[str, str], ...] = (
-    ("test -f go.mod", "go test"),
     ("test -x bin/test", "python bin/test"),
     ("test -f manage.py", "python manage.py test"),
     ("test -f tox.ini", "tox"),
+    ("test -f go.mod", "go test"),
 )
 
 # Count tokens pytest prints in its final summary line, e.g.

--- a/opencollab/opencollab/bootstrap/workflow_runtime.py
+++ b/opencollab/opencollab/bootstrap/workflow_runtime.py
@@ -30,6 +30,14 @@ from opencollab.bootstrap._workflow_runtime_state import (
 from opencollab.bootstrap.agent_runtime import revoke_and_abort_environment
 from opencollab.bootstrap.session_factory import build_session
 
+# The integrity runtime's own bounded cleanup can legitimately span several
+# cleanup_timeout phases (session quiesce runs two passes, each bounded by its
+# persistence and environment-abort sub-phases). Give the owner that full
+# envelope to self-finish before escalating to the injected-environment fallback
+# and force-termination, so a slow-but-legitimate teardown is not force-cancelled
+# into a spurious WorkflowLifecycleError.
+_OWNER_CLEANUP_GRACE_PHASES = 4
+
 
 class WorkflowDeadlineExceeded(TimeoutError):
     """The caller-owned workflow wall-clock deadline expired."""
@@ -85,9 +93,12 @@ async def run_workflow(
             owner.cancel(*cancellation.args)
 
         # The integrity runtime already owns session quiescence, persistence,
-        # environment abort, and diagnostic notes. Give that lifecycle enough
-        # time to finish before using the injected-environment fallback.
-        done, _pending = await asyncio.wait({owner}, timeout=cleanup_timeout)
+        # environment abort, and diagnostic notes. Give that lifecycle its full
+        # multi-phase cleanup envelope to finish before using the
+        # injected-environment fallback.
+        done, _pending = await asyncio.wait(
+            {owner}, timeout=cleanup_timeout * _OWNER_CLEANUP_GRACE_PHASES
+        )
         aborted = env is None or bool(getattr(env, "revoked", False))
         if not aborted:
             aborted = await revoke_and_abort_environment(env, cleanup_timeout)

--- a/opencollab/tests/test_run_tests_tool.py
+++ b/opencollab/tests/test_run_tests_tool.py
@@ -426,6 +426,30 @@ def test_run_tests_falls_back_to_go_runner_when_pytest_finds_no_tests():
     assert "Verdict: GREEN" in result
 
 
+def test_run_tests_no_tests_does_not_green_off_go_when_python_suite_present():
+    # Mixed repo: a Python-native suite (bin/test) AND go.mod are both present,
+    # and pytest collected nothing. bin/test is affirmative evidence that a real
+    # Python suite exists that pytest simply did not collect, so falling back to
+    # Go would green off unrelated Go tests while the intended suite never ran.
+    env = ScriptedEnv([
+        ("python -m pytest", 5, "no tests ran in 0.01s"),
+        ("test -x bin/test", 0, ""),
+        ("test -f go.mod", 0, ""),
+        ("go test", 0, '{"Action":"pass","Package":"m","Test":"T"}'),
+    ])
+    runtime = runtime_for(env)
+
+    result = run(
+        RunTestsTool(allow_runner_override=False, allow_extra_args=False).execute_with_runtime(
+            {}, runtime
+        )
+    )
+
+    cmds = [c for c, _ in env.exec_calls]
+    assert not any("go test" in c for c in cmds)
+    assert "Verdict: GREEN" not in result
+
+
 def test_run_tests_native_fallback_quotes_translated_target():
     env = ScriptedEnv([
         ("python -m pytest", 1, "No module named pytest"),


### PR DESCRIPTION
## Summary

Two low-severity follow-ups to #20, surfaced by the post-merge audit. Both are behavior-preserving in the normal case; each closes a narrow edge.

### 1. `run_tests`: mixed-repo false-green (`_NATIVE_PROBES` order)

The "pytest collected nothing → native fallback" branch only trusts a Go runner:

```python
if _pytest_no_tests(returncode, output):
    native = await _detect_native_runner(env)
    if native and _is_go_runner(native):
        return native
```

`_detect_native_runner` returns the **first** matching probe. With `go.mod` probed first, a mixed Python+Go repo (both `bin/test`/`manage.py`/`tox` **and** `go.mod` present) with no pytest-collectable tests returned `"go test"`, ran `go test ./...`, and emitted **Verdict: GREEN** — even though the intended Python suite never ran.

**Fix:** probe `go.mod` **last**, so `_detect_native_runner` surfaces Go to that fallback only when Go is the *sole* native signal. A present `bin/test`/`manage.py`/`tox` is affirmative evidence of a real non-Go suite that pytest simply didn't collect, and now keeps the run RED. Pure-Go repos still fall back to Go unchanged.

### 2. `workflow_runtime`: restore multi-phase cleanup grace

`stop_owned` gave the integrity runtime only a single `cleanup_timeout` to self-quiesce before escalating to the injected-environment fallback + force-termination. But that runtime's own bounded cleanup legitimately spans several phases (session quiesce runs two passes, each with persistence + environment-abort sub-phases). A slow-but-legitimate teardown during a deadline/cancel was therefore force-cancelled into a **spurious `WorkflowLifecycleError`** (instead of the expected `WorkflowDeadlineExceeded`), briefly leaking a self-completing owner task.

**Fix:** give the owner its full multi-phase envelope (`cleanup_timeout * 4`) before escalating. Environment abort (`revoke_and_abort_environment` still runs regardless) and wall-clock deadline enforcement are unchanged; no injected-env leak either way.

## Test plan

- New `test_run_tests_no_tests_does_not_green_off_go_when_python_suite_present`: mixed `bin/test` + `go.mod` repo, pytest collects nothing, empty target → asserts `go test` never runs and the verdict is not GREEN. (Fails against the old probe order.)
- `pytest tests/test_run_tests_tool.py tests/test_workflow_runtime.py` — 91 passed.
- Full framework suite — 1437 passed (2 pre-existing failures unrelated to this change: a machine-timing-sensitive 80ms process test and a repo-ownership test that only fails on a dirty local checkout).
- `ruff check` clean.
