### PR TITLE
feat: 补全 OCE 迁移所需的公共能力

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,28 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added immutable non-secret effective configuration metadata, public stateless
+  tool composition, and caller-owned Local, Worktree, and image-backed Docker
+  environment factories for external integrations. Configuration metadata
+  includes deep-copied thinking parameters and a SHA-256 endpoint fingerprint
+  without exposing the base URL.
+- Expanded the public workflow-authoring contract with the supported agent
+  controls, draft findings, working-tree diff access, and live token
+  observation.
+- Added public agent and workflow step limits, cleanup deadlines, workflow
+  system prompts, aggregate session metrics, and sanitized child-agent failure
+  summaries.
+- Added the narrow `VerificationTool` contract for reading parser-verified test
+  targets without importing a concrete test adapter.
+
 ### Changed
 - Replaced the request-heavy SDK v2 surface with the compact `OpenCollab` facade:
   `agent`, `team`, and `workflow` now share one `RunResult`, central configuration,
   and bootstrap-owned lifecycle wiring.
+- Workflow budget stops now use an explicit runtime reason rather than
+  interpreting caller output, and timeout or execution failures retain finalized
+  session metrics when lifecycle evidence is complete.
 - Reduced the everyday Python API to four root exports and moved optional tool,
   environment, and workflow-authoring contracts into small capability modules.
 - Adopted the Mulan Permissive Software License v2 (`MulanPSL-2.0`) for OpenCollab.

--- a/opencollab/README.md
+++ b/opencollab/README.md
@@ -133,8 +133,16 @@ container = docker_environment("python:3.11-slim", isolated_source)
 ```
 
 These factories construct caller-owned environments without eagerly setting
-them up. The caller retains setup, mount, and cleanup timing. Concrete adapter
-classes stay behind the bootstrap boundary.
+them up. Every public environment supports `await environment.setup()`. Docker
+environments additionally accept `mount_dir`; host and worktree environments
+reject that argument. The caller retains setup, mount, and cleanup timing.
+Concrete adapter classes stay behind the bootstrap boundary.
+
+Run metrics separate OpenCollab-owned session quiescence from environment
+quiescence. `session_quiesced` proves that session and persistence work has
+finished. For a caller-owned environment, `environment_quiesced`,
+`cleanup_quiesced`, and `execution_quiesced` remain `None` until the caller
+performs and verifies its own environment cleanup.
 
 ### Workflow authoring
 

--- a/opencollab/README.md
+++ b/opencollab/README.md
@@ -86,6 +86,56 @@ return `RunResult`. Import optional authoring contracts from
 Treat other package paths as internal. An `artifacts` directory, when supplied,
 must be new or empty because each run claims it for executable evidence.
 
+`OpenCollab.configuration` is a read-only snapshot of effective model,
+provider, budget, timeout, sampling, output-token, and thinking settings.
+`thinking_params` is deep-copied so callers cannot mutate client state. API keys
+and base URLs are excluded. `base_url_sha256` provides a stable endpoint
+fingerprint without exposing credentials embedded in a URL. Agent runs accept
+`max_steps` and `cleanup_timeout`; the older `steps` spelling remains a supported
+alias.
+Workflow runs accept `max_steps`, `system_prompt`, and `cleanup_timeout`.
+Completed, stopped, and failed workflow results report aggregate session,
+step, token, and markup-recovery metrics. Sanitized child-provider failures are
+available through `RunResult.agent_failures`.
+
+Built-in tools can be composed without importing concrete adapters:
+
+```python
+from opencollab.tools import builtin_tools
+
+tools = builtin_tools(
+    "file_read",
+    "file_write",
+    "run_tests",
+    allow_file_creation=False,
+)
+```
+
+The helper returns fresh tools in caller order. Headless shell and test tools
+require process-isolated environments, test-runner overrides stay disabled,
+and limits for unselected tools are rejected. The `run_tests` instance satisfies
+the public `VerificationTool` protocol. Its read-only `verified_targets`
+property contains exact requested targets whose latest parser-backed verdict
+was green.
+
+Environment composition uses the same narrow public module:
+
+```python
+from opencollab.environments import (
+    docker_environment,
+    local_environment,
+    worktree_environment,
+)
+
+host = local_environment(".")
+isolated_source = worktree_environment(".")
+container = docker_environment("python:3.11-slim", isolated_source)
+```
+
+These factories construct caller-owned environments without eagerly setting
+them up. The caller retains setup, mount, and cleanup timing. Concrete adapter
+classes stay behind the bootstrap boundary.
+
 ### Workflow authoring
 
 A workflow is a plain async Python function tagged with `@workflow`. Create
@@ -103,8 +153,16 @@ async def implement_and_review(
     ctx: WorkflowContext,
     inputs: dict[str, Any],
 ) -> str | dict[str, Any] | None:
-    draft = await ctx.agent(f"Implement and verify: {inputs['task']}")
-    return await ctx.agent(f"Review the implementation and fix gaps:\n{draft}")
+    draft = await ctx.agent(
+        f"Implement and verify: {inputs['task']}",
+        tools=inputs.get("tools"),
+        timeout=900,
+    )
+    await ctx.log(f"Tokens spent: {ctx.tokens_spent()}")
+    diff = await ctx.diff()
+    return await ctx.agent(
+        f"Review the implementation and fix gaps:\n{draft}\n\nDiff:\n{diff or ''}"
+    )
 ```
 
 OpenCollab discovers top-level `*.py` modules in `workflows/` by default. Run

--- a/opencollab/adapters/_env_base.py
+++ b/opencollab/adapters/_env_base.py
@@ -39,6 +39,13 @@ class Environment:
         if self._aborted:
             raise RuntimeError("Execution environment has been aborted.")
 
+    async def setup(self, mount_dir: str | None = None) -> str:
+        """Prepare the environment and return its ready workspace identity."""
+        self._ensure_active()
+        if mount_dir is not None:
+            raise ValueError("mount_dir is supported only by container environments")
+        return self.workspace
+
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
         raise NotImplementedError
 

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -52,8 +52,10 @@ class WorktreeEnvironment(Environment):
         )
         return result.to_exec_result()
 
-    async def setup(self) -> str:
+    async def setup(self, mount_dir: str | None = None) -> str:
         self._ensure_active()
+        if mount_dir is not None:
+            raise ValueError("mount_dir is supported only by container environments")
         if self._local_env is not None:
             return self.workspace
         probe = await self._git("rev-parse", "--git-dir")

--- a/opencollab/application/ports.py
+++ b/opencollab/application/ports.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
 
 class EnvironmentPort(Protocol):
     workspace: str
+    host_workspace: str | None
+    source_workspace: str | None
+    local_filesystem: bool
 
     @property
     def revoked(self) -> bool:

--- a/opencollab/application/ports.py
+++ b/opencollab/application/ports.py
@@ -24,6 +24,10 @@ class EnvironmentPort(Protocol):
     def revoke(self) -> None:
         ...
 
+    async def setup(self, mount_dir: str | None = None) -> str:
+        """Prepare the environment and return its ready workspace identity."""
+        ...
+
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> Any:
         ...
 

--- a/opencollab/application/workflow.py
+++ b/opencollab/application/workflow.py
@@ -235,6 +235,24 @@ class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
             await self.log(f"source_changed probe failed: {exc}")
             return None
 
+    async def diff(self) -> str | None:
+        """Return the current working-tree diff when a probe is available."""
+        if self._tree_probe is None:
+            return None
+        try:
+            return await self._tree_probe.diff()
+        except Exception as exc:  # noqa: BLE001 — inspection must never abort the run
+            await self.log(f"diff probe failed: {exc}")
+            return None
+
+    def tokens_spent(self) -> int:
+        """Return live token usage across workflow sessions."""
+        return self.budget.spent()
+
+    def tokens_remaining(self) -> float:
+        """Return unspent and unreserved workflow tokens."""
+        return self.budget.remaining()
+
     @property
     def sessions(self) -> Sequence[Any]:
         """Read-only view of every session created so far (newest last).

--- a/opencollab/bootstrap/_workflow_runtime_cleanup.py
+++ b/opencollab/bootstrap/_workflow_runtime_cleanup.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from opencollab.application.exception_notes import add_exception_note
 from opencollab.application.ports import TracePort
@@ -186,17 +186,25 @@ def _persist_workflow_manifest(
     tracer_failure: BaseException | None,
     tracer_write_error: str | None,
     tracer_dropped_steps: int,
+    status: Literal["completed", "stopped", "failed"],
+    reason: str | None,
+    failure_type: str | None,
+    evidence_complete: bool,
 ) -> Exception | None:
-    manifest = _workflow_manifest_payload(
-        name=name,
-        args=args,
-        ctx=ctx,
-        tracer=tracer,
-        tracer_failure=tracer_failure,
-        tracer_write_error=tracer_write_error,
-        tracer_dropped_steps=tracer_dropped_steps,
-    )
     try:
+        manifest = _workflow_manifest_payload(
+            name=name,
+            args=args,
+            ctx=ctx,
+            tracer=tracer,
+            tracer_failure=tracer_failure,
+            tracer_write_error=tracer_write_error,
+            tracer_dropped_steps=tracer_dropped_steps,
+            status=status,
+            reason=reason,
+            failure_type=failure_type,
+            evidence_complete=evidence_complete,
+        )
         _write_workflow_manifest(
             save_dir,
             name=name,
@@ -206,6 +214,10 @@ def _persist_workflow_manifest(
             tracer_failure=tracer_failure,
             tracer_write_error=tracer_write_error,
             tracer_dropped_steps=tracer_dropped_steps,
+            status=status,
+            reason=reason,
+            failure_type=failure_type,
+            evidence_complete=evidence_complete,
             manifest=manifest,
         )
     except Exception as exc:

--- a/opencollab/bootstrap/_workflow_runtime_execution.py
+++ b/opencollab/bootstrap/_workflow_runtime_execution.py
@@ -165,13 +165,33 @@ async def run_workflow(
         note_prefix="workflow trace also failed",
     )
 
+    if cancellation is not None:
+        terminal_status: Literal["completed", "stopped", "failed"] = "stopped"
+        terminal_reason = "cancelled"
+        failure_type = type(cancellation).__name__
+    elif workflow_failure is not None:
+        terminal_status = "failed"
+        terminal_reason = "workflow_exception"
+        failure_type = type(workflow_failure).__name__
+    elif stop_reason is not None:
+        terminal_status = "stopped"
+        terminal_reason = stop_reason
+        failure_type = None
+    else:
+        terminal_status = "completed"
+        terminal_reason = None
+        failure_type = None
+    requested_manifest = save_dir is not None
+    pre_manifest_evidence_complete = (
+        cleanup_failure is None
+        and cleanup_succeeded
+        and tracer_failure is None
+    )
     manifest_error = None
     if (
-        save_dir is not None
+        requested_manifest
         and cleanup_failure is None
         and cleanup_succeeded
-        and workflow_failure is None
-        and cancellation is None
     ):
         manifest_error = _persist_workflow_manifest(
             save_dir,
@@ -182,14 +202,22 @@ async def run_workflow(
             tracer_failure=tracer_failure,
             tracer_write_error=tracer_write_error,
             tracer_dropped_steps=tracer_dropped_steps,
+            status=terminal_status,
+            reason=terminal_reason,
+            failure_type=failure_type,
+            evidence_complete=pre_manifest_evidence_complete,
         )
 
+    evidence_complete = (
+        pre_manifest_evidence_complete
+        and (not requested_manifest or manifest_error is None)
+    )
     runtime_result = _runtime_result(
         ctx,
         output=result,
         name=name,
         stop_reason=stop_reason,
-        evidence_complete=tracer_failure is None,
+        evidence_complete=evidence_complete,
     )
     _attach_runtime_result(cancellation, runtime_result)
     _attach_runtime_result(workflow_failure, runtime_result)

--- a/opencollab/bootstrap/_workflow_runtime_execution.py
+++ b/opencollab/bootstrap/_workflow_runtime_execution.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, Literal
 
 from opencollab.adapters.trace import Tracer
 from opencollab.application.ports import EventPublisherPort, TracePort
@@ -23,6 +23,7 @@ from opencollab.bootstrap._workflow_runtime_cleanup import (
 from opencollab.bootstrap._workflow_runtime_session import _resolve_spec_fn, build_workflow_context
 from opencollab.bootstrap._workflow_runtime_state import (
     DEFAULT_WORKFLOW_CLEANUP_TIMEOUT_SECONDS,
+    WORKFLOW_AGENT_PROMPT,
     WorkflowRuntimeResult,
 )
 from opencollab.bootstrap.session_factory import ORCHESTRATION_FILENAME
@@ -31,6 +32,39 @@ from opencollab.bootstrap.session_factory import ORCHESTRATION_FILENAME
 def _note_failure(primary: BaseException, label: str, failure: BaseException | None) -> None:
     if failure is not None:
         _add_failure_note(primary, f"{label}: {type(failure).__name__}: {failure}")
+
+
+def _runtime_result(
+    ctx: Any,
+    *,
+    output: Any,
+    name: str,
+    stop_reason: Literal["budget_exceeded"] | None,
+    evidence_complete: bool,
+) -> WorkflowRuntimeResult:
+    sessions = tuple(ctx.sessions)
+    return WorkflowRuntimeResult(
+        output=output,
+        name=name,
+        tokens=ctx.budget.spent(),
+        sessions=len(sessions),
+        steps=sum(int(getattr(session, "step_count", 0)) for session in sessions),
+        markup_recovered=sum(
+            int(getattr(session, "markup_recovered", 0))
+            for session in sessions
+        ),
+        agent_failures=ctx.agent_failures,
+        stop_reason=stop_reason,
+        evidence_complete=evidence_complete,
+    )
+
+
+def _attach_runtime_result(
+    error: BaseException | None,
+    result: WorkflowRuntimeResult,
+) -> None:
+    if error is not None:
+        error.runtime_result = result  # type: ignore[attr-defined]
 
 
 async def run_workflow(
@@ -43,6 +77,8 @@ async def run_workflow(
     event_sink: EventPublisherPort | None = None,
     budget: int | None = None,
     max_concurrency: int = 4,
+    max_steps: int = 100,
+    system_prompt: str = WORKFLOW_AGENT_PROMPT,
     save_dir: str | None = None,
     trace: bool = True,
     cleanup_timeout: float = DEFAULT_WORKFLOW_CLEANUP_TIMEOUT_SECONDS,
@@ -77,6 +113,8 @@ async def run_workflow(
             event_sink=event_sink,
             budget=budget,
             max_concurrency=max_concurrency,
+            max_steps=max_steps,
+            system_prompt=system_prompt,
             save_dir=save_dir,
             env=env,
             source_root=source_root,
@@ -89,11 +127,13 @@ async def run_workflow(
         raise
 
     result: Any = None
+    stop_reason: Literal["budget_exceeded"] | None = None
     workflow_failure: BaseException | None = None
     cancellation: asyncio.CancelledError | None = None
     try:
         result = await fn(ctx, args)
     except WorkflowBudgetExceeded as exc:
+        stop_reason = "budget_exceeded"
         result = {
             "status": "budget_exceeded",
             "error": str(exc),
@@ -144,6 +184,16 @@ async def run_workflow(
             tracer_dropped_steps=tracer_dropped_steps,
         )
 
+    runtime_result = _runtime_result(
+        ctx,
+        output=result,
+        name=name,
+        stop_reason=stop_reason,
+        evidence_complete=tracer_failure is None,
+    )
+    _attach_runtime_result(cancellation, runtime_result)
+    _attach_runtime_result(workflow_failure, runtime_result)
+
     if cancellation is not None:
         _note_failure(cancellation, "workflow cleanup also failed", cleanup_failure)
         if cleanup_failure is None and not cleanup_succeeded:
@@ -176,10 +226,5 @@ async def run_workflow(
     if tracer_failure is not None:
         raise RuntimeError("technical workflow trace failed: orchestration evidence is incomplete") from tracer_failure
     if return_details:
-        return WorkflowRuntimeResult(
-            output=result,
-            name=name,
-            tokens=ctx.budget.spent(),
-            sessions=len(ctx.sessions),
-        )
+        return runtime_result
     return result

--- a/opencollab/bootstrap/_workflow_runtime_manifest.py
+++ b/opencollab/bootstrap/_workflow_runtime_manifest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import os
-from typing import Any
+from typing import Any, Literal
 
 from opencollab.adapters.storage import SessionStore
 from opencollab.application.ports import TracePort
@@ -21,6 +21,10 @@ def _workflow_manifest_payload(
     tracer_failure: BaseException | None,
     tracer_write_error: str | None,
     tracer_dropped_steps: int,
+    status: Literal["completed", "stopped", "failed"],
+    reason: str | None,
+    failure_type: str | None,
+    evidence_complete: bool,
 ) -> dict[str, Any]:
     """Freeze all event-loop-owned values used by the workflow manifest."""
     return copy.deepcopy(
@@ -30,6 +34,10 @@ def _workflow_manifest_payload(
             "sessions": len(ctx.sessions),
             "tokens_spent": ctx.budget.spent(),
             "budget_total": ctx.budget.total,
+            "status": status,
+            "reason": reason,
+            "failure_type": failure_type,
+            "evidence_complete": evidence_complete,
             "trace_enabled": tracer is not None,
             "tracer_write_error": tracer_write_error,
             "tracer_dropped_steps": tracer_dropped_steps,
@@ -50,6 +58,10 @@ def _write_workflow_manifest(
     tracer_failure: BaseException | None,
     tracer_write_error: str | None,
     tracer_dropped_steps: int,
+    status: Literal["completed", "stopped", "failed"],
+    reason: str | None,
+    failure_type: str | None,
+    evidence_complete: bool,
     manifest: dict[str, Any] | None = None,
 ) -> None:
     """Write ``<save_dir>/workflow.json`` summarising the run.
@@ -66,5 +78,9 @@ def _write_workflow_manifest(
             tracer_failure=tracer_failure,
             tracer_write_error=tracer_write_error,
             tracer_dropped_steps=tracer_dropped_steps,
+            status=status,
+            reason=reason,
+            failure_type=failure_type,
+            evidence_complete=evidence_complete,
         )
     SessionStore().save_manifest(os.path.join(save_dir, WORKFLOW_MANIFEST_FILENAME), manifest)

--- a/opencollab/bootstrap/_workflow_runtime_session.py
+++ b/opencollab/bootstrap/_workflow_runtime_session.py
@@ -52,6 +52,8 @@ class WorkflowSessionFactory:
         tracer: TracePort | None = None,
         event_sink: EventPublisherPort | None = None,
         llm_timeout: float = 600.0,
+        max_steps: int = 100,
+        system_prompt: str = WORKFLOW_AGENT_PROMPT,
         temperature: float = DEFAULT_TEMPERATURE,
         top_p: float | None = DEFAULT_TOP_P,
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
@@ -68,6 +70,8 @@ class WorkflowSessionFactory:
         self._tracer = tracer
         self._event_sink = event_sink
         self._llm_timeout = llm_timeout
+        self._max_steps = max_steps
+        self._system_prompt = system_prompt
         self._temperature = temperature
         self._top_p = top_p
         self._max_output_tokens = max_output_tokens
@@ -116,7 +120,7 @@ class WorkflowSessionFactory:
             use_thinking = True
         agent = Agent(
             name="workflow_agent",
-            system_prompt=WORKFLOW_AGENT_PROMPT,
+            system_prompt=self._system_prompt,
             tools=list(tools or []),
             model=self._model,
             provider=self._provider,
@@ -135,6 +139,7 @@ class WorkflowSessionFactory:
             env=env,
             tracer=self._tracer,
             max_budget_tokens=budget,
+            max_steps=self._max_steps,
             event_sink=self._event_sink,
             llm_timeout=self._llm_timeout,
             auto_save_path=self._next_save_path(label),
@@ -149,6 +154,8 @@ def build_workflow_context(
     event_sink: EventPublisherPort | None = None,
     budget: int | None = None,
     max_concurrency: int = 4,
+    max_steps: int = 100,
+    system_prompt: str = WORKFLOW_AGENT_PROMPT,
     save_dir: str | None = None,
     env: Any | None = None,
     source_root: str | None = None,
@@ -176,6 +183,8 @@ def build_workflow_context(
         tracer=tracer,
         event_sink=event_sink,
         llm_timeout=float(cfg.get("llm_timeout", 600.0)),
+        max_steps=max_steps,
+        system_prompt=system_prompt,
         temperature=float(cfg.get("temperature", DEFAULT_TEMPERATURE)),
         top_p=cfg.get("top_p", DEFAULT_TOP_P),
         max_output_tokens=int(cfg.get("max_output_tokens", DEFAULT_MAX_OUTPUT_TOKENS)),

--- a/opencollab/bootstrap/_workflow_runtime_state.py
+++ b/opencollab/bootstrap/_workflow_runtime_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 WORKFLOW_AGENT_PROMPT = (
     "You are an autonomous agent invoked as one step of a larger workflow. "
@@ -24,3 +24,8 @@ class WorkflowRuntimeResult:
     name: str
     tokens: int
     sessions: int
+    steps: int
+    markup_recovered: int
+    agent_failures: tuple[dict[str, Any], ...]
+    stop_reason: Literal["budget_exceeded"] | None = None
+    evidence_complete: bool = True

--- a/opencollab/bootstrap/agent_runtime.py
+++ b/opencollab/bootstrap/agent_runtime.py
@@ -31,6 +31,7 @@ class AgentRuntimeResult:
     terminal_reason: str | None
     tokens_spent: int
     step_count: int
+    markup_recovered: int
     cleanup_quiesced: bool
     persistence_errors: tuple[str, ...]
 
@@ -134,6 +135,7 @@ def _result(
         terminal_reason=session.state.terminal_reason,
         tokens_spent=session.used_tokens,
         step_count=session.step_count,
+        markup_recovered=int(getattr(session, "markup_recovered", 0)),
         cleanup_quiesced=cleanup_quiesced,
         persistence_errors=tuple(str(error) for error in session.persistence_errors),
     )

--- a/opencollab/bootstrap/agent_runtime.py
+++ b/opencollab/bootstrap/agent_runtime.py
@@ -33,6 +33,8 @@ class AgentRuntimeResult:
     step_count: int
     markup_recovered: int
     cleanup_quiesced: bool
+    environment_cleanup_quiesced: bool | None
+    environment_quiesced: bool | None
     persistence_errors: tuple[str, ...]
 
 
@@ -126,6 +128,7 @@ def _result(
     outcome: Literal["completed", "timed_out", "failed"],
     error: Exception | None,
     cleanup_quiesced: bool,
+    cleanup_environment: bool,
 ) -> AgentRuntimeResult:
     return AgentRuntimeResult(
         output=output,
@@ -137,6 +140,8 @@ def _result(
         step_count=session.step_count,
         markup_recovered=int(getattr(session, "markup_recovered", 0)),
         cleanup_quiesced=cleanup_quiesced,
+        environment_cleanup_quiesced=True if cleanup_environment else None,
+        environment_quiesced=True if cleanup_environment else None,
         persistence_errors=tuple(str(error) for error in session.persistence_errors),
     )
 
@@ -216,6 +221,7 @@ async def run_agent(
                 outcome="timed_out",
                 error=TimeoutError(f"agent exceeded {timeout_seconds:g} seconds"),
                 cleanup_quiesced=True,
+                cleanup_environment=cleanup_environment,
             )
         try:
             output = owner.result()
@@ -229,6 +235,7 @@ async def run_agent(
                 outcome="failed",
                 error=exc,
                 cleanup_quiesced=True,
+                cleanup_environment=cleanup_environment,
             )
         finalized = await finalize_once()
         if not finalized:
@@ -239,6 +246,7 @@ async def run_agent(
             outcome="completed",
             error=None,
             cleanup_quiesced=True,
+            cleanup_environment=cleanup_environment,
         )
     except asyncio.CancelledError:
         await stop_once(propagate_cancellation=False)

--- a/opencollab/bootstrap/programmatic.py
+++ b/opencollab/bootstrap/programmatic.py
@@ -250,6 +250,29 @@ def _agent_status(
     return "completed", None
 
 
+def _quiescence_metrics(
+    *,
+    session_quiesced: bool,
+    environment_owned: bool,
+    environment_cleanup_quiesced: bool | None,
+    environment_quiesced: bool | None,
+) -> dict[str, bool | None]:
+    if not session_quiesced or environment_quiesced is False:
+        aggregate: bool | None = False
+    elif environment_quiesced is True:
+        aggregate = True
+    else:
+        aggregate = None
+    return {
+        "session_quiesced": session_quiesced,
+        "environment_owned": environment_owned,
+        "environment_cleanup_quiesced": environment_cleanup_quiesced,
+        "environment_quiesced": environment_quiesced,
+        "cleanup_quiesced": aggregate,
+        "execution_quiesced": aggregate,
+    }
+
+
 async def run_agent(
     *,
     prompt: str,
@@ -317,6 +340,12 @@ async def run_agent(
             raise ProgrammaticLifecycleError(str(exc)) from exc
         _require_agent_evidence(internal, artifacts, transcript_path, tracer)
         status, reason = _agent_status(internal)
+        quiescence = _quiescence_metrics(
+            session_quiesced=internal.cleanup_quiesced,
+            environment_owned=owned_environment,
+            environment_cleanup_quiesced=internal.environment_cleanup_quiesced,
+            environment_quiesced=internal.environment_quiesced,
+        )
         return ProgrammaticResult(
             output=internal.output,
             status=status,
@@ -330,8 +359,7 @@ async def run_agent(
                 "phase": internal.phase,
                 "terminal_reason": internal.terminal_reason,
                 "markup_recovered": internal.markup_recovered,
-                "cleanup_quiesced": True,
-                "execution_quiesced": True,
+                **quiescence,
             },
         )
     except BaseException as exc:
@@ -358,13 +386,27 @@ def _environment_paths(environment: Any, workspace: str) -> tuple[str, str]:
     return str(workdir), str(source_root)
 
 
-def _workflow_metrics(details: WorkflowRuntimeResult | None) -> dict[str, Any]:
-    return {
+def _workflow_metrics(
+    details: WorkflowRuntimeResult | None,
+    *,
+    environment_owned: bool,
+    environment_cleanup_quiesced: bool | None,
+    environment_quiesced: bool | None,
+) -> dict[str, Any]:
+    metrics = {
         "steps": 0 if details is None else details.steps,
         "sessions": 0 if details is None else details.sessions,
         "markup_recovered": 0 if details is None else details.markup_recovered,
-        "execution_quiesced": details is not None,
     }
+    metrics.update(
+        _quiescence_metrics(
+            session_quiesced=details is not None,
+            environment_owned=environment_owned,
+            environment_cleanup_quiesced=environment_cleanup_quiesced,
+            environment_quiesced=environment_quiesced,
+        )
+    )
+    return metrics
 
 
 async def run_workflow(
@@ -397,6 +439,8 @@ async def run_workflow(
     stopped_error: BaseException | None = None
     failed_error: BaseException | None = None
     bootstrap_stopped_environment = False
+    environment_cleanup_quiesced: bool | None = None
+    environment_quiesced: bool | None = None
     try:
         try:
             details = await _run_workflow(
@@ -448,12 +492,22 @@ async def run_workflow(
                 raise ProgrammaticLifecycleError(
                     "workflow-owned environment cleanup failed"
                 )
+            environment_cleanup_quiesced = True
+            environment_quiesced = True
 
     _verify_artifact_claim(artifacts)
     if stopped_error is not None:
         details = stopped_error.result
-        metrics = _workflow_metrics(details)
-        metrics["execution_quiesced"] = True
+        metrics = _workflow_metrics(
+            details,
+            environment_owned=owned_environment,
+            environment_cleanup_quiesced=(
+                True if owned_environment else environment_cleanup_quiesced
+            ),
+            environment_quiesced=(
+                True if owned_environment else environment_quiesced
+            ),
+        )
         return ProgrammaticResult(
             output=None,
             status="stopped",
@@ -473,7 +527,12 @@ async def run_workflow(
             tokens=None if details is None else details.tokens,
             artifacts=artifacts,
             error=failed_error,
-            metrics=_workflow_metrics(details),
+            metrics=_workflow_metrics(
+                details,
+                environment_owned=owned_environment,
+                environment_cleanup_quiesced=environment_cleanup_quiesced,
+                environment_quiesced=environment_quiesced,
+            ),
             agent_failures=() if details is None else details.agent_failures,
         )
     if details is None:
@@ -486,7 +545,12 @@ async def run_workflow(
         reason="budget_exceeded" if budget_stopped else None,
         tokens=details.tokens,
         artifacts=artifacts,
-        metrics=_workflow_metrics(details),
+        metrics=_workflow_metrics(
+            details,
+            environment_owned=owned_environment,
+            environment_cleanup_quiesced=environment_cleanup_quiesced,
+            environment_quiesced=environment_quiesced,
+        ),
         agent_failures=details.agent_failures,
     )
 

--- a/opencollab/bootstrap/programmatic.py
+++ b/opencollab/bootstrap/programmatic.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from opencollab.adapters.env import DockerWorkspaceEnvironment, LocalEnvironment
+from opencollab.adapters.env import (
+    DockerEnvironment,
+    DockerWorkspaceEnvironment,
+    LocalEnvironment,
+    WorktreeEnvironment,
+)
 from opencollab.adapters.safe_files import (
     create_regular_bytes_atomic,
     ensure_directory_no_symlinks,
@@ -38,6 +43,7 @@ from opencollab.bootstrap.runtime_context import build_runtime_context
 from opencollab.bootstrap.scheduler_factory import build_scheduler
 from opencollab.bootstrap.tool_registry import build_tools_for_role
 from opencollab.bootstrap.workflow_runtime import (
+    WORKFLOW_AGENT_PROMPT,
     WorkflowDeadlineExceeded,
     WorkflowLifecycleError,
     WorkflowRuntimeResult,
@@ -83,7 +89,8 @@ class ProgrammaticResult:
     tokens: int | None
     artifacts: Path | None
     error: BaseException | None = None
-    metrics: dict[str, int] = field(default_factory=dict)
+    metrics: dict[str, Any] = field(default_factory=dict)
+    agent_failures: tuple[dict[str, Any], ...] = ()
 
 
 def resolve_tools(value: str | Sequence[Any] | None) -> tuple[Any, ...]:
@@ -135,6 +142,29 @@ def attach_container(
         repo_root=workspace,
         command_prefix=command_prefix,
         timeout_returncode=timeout_returncode,
+    )
+
+
+def local_environment(workspace: str | os.PathLike[str]) -> EnvironmentPort:
+    """Create a host environment rooted at an existing workspace."""
+    return LocalEnvironment(os.fspath(workspace))
+
+
+def worktree_environment(
+    source_workspace: str | os.PathLike[str],
+) -> EnvironmentPort:
+    """Create an uninitialized isolated worktree owned by the caller."""
+    return WorktreeEnvironment(os.fspath(source_workspace))
+
+
+def docker_environment(
+    image: str,
+    backing_environment: EnvironmentPort | None = None,
+) -> EnvironmentPort:
+    """Create an uninitialized image-backed Docker environment."""
+    return DockerEnvironment(
+        image=image,
+        backing_environment=backing_environment,
     )
 
 
@@ -229,6 +259,7 @@ async def run_agent(
     max_tokens: int,
     max_steps: int,
     timeout: float | None,
+    cleanup_timeout: float,
     artifacts: Path | None,
     trace: bool,
     environment: Any | None = None,
@@ -273,7 +304,7 @@ async def run_agent(
                 max_tokens=max_tokens,
                 max_steps=max_steps,
                 timeout_seconds=timeout,
-                cleanup_timeout_seconds=DEFAULT_CLEANUP_TIMEOUT_SECONDS,
+                cleanup_timeout_seconds=cleanup_timeout,
                 transcript_path=(
                     None if transcript_path is None else str(transcript_path)
                 ),
@@ -293,7 +324,15 @@ async def run_agent(
             tokens=internal.tokens_spent,
             artifacts=artifacts,
             error=internal.error,
-            metrics={"steps": internal.step_count},
+            metrics={
+                "steps": internal.step_count,
+                "outcome": internal.outcome,
+                "phase": internal.phase,
+                "terminal_reason": internal.terminal_reason,
+                "markup_recovered": internal.markup_recovered,
+                "cleanup_quiesced": True,
+                "execution_quiesced": True,
+            },
         )
     except BaseException as exc:
         primary_failure = exc
@@ -319,6 +358,15 @@ def _environment_paths(environment: Any, workspace: str) -> tuple[str, str]:
     return str(workdir), str(source_root)
 
 
+def _workflow_metrics(details: WorkflowRuntimeResult | None) -> dict[str, Any]:
+    return {
+        "steps": 0 if details is None else details.steps,
+        "sessions": 0 if details is None else details.sessions,
+        "markup_recovered": 0 if details is None else details.markup_recovered,
+        "execution_quiesced": details is not None,
+    }
+
+
 async def run_workflow(
     *,
     workflow: Any,
@@ -328,6 +376,9 @@ async def run_workflow(
     max_tokens: int | None,
     max_concurrency: int,
     timeout: float | None,
+    max_steps: int,
+    system_prompt: str | None,
+    cleanup_timeout: float,
     artifacts: Path | None,
     trace: bool,
     environment: Any | None = None,
@@ -358,9 +409,11 @@ async def run_workflow(
                 save_dir=None if artifacts is None else str(artifacts),
                 trace=trace,
                 env=resolved_environment,
-                cleanup_timeout=DEFAULT_CLEANUP_TIMEOUT_SECONDS,
+                cleanup_timeout=cleanup_timeout,
                 source_root=source_root,
                 deadline_monotonic=deadline,
+                max_steps=max_steps,
+                system_prompt=system_prompt or WORKFLOW_AGENT_PROMPT,
                 return_details=True,
             )
         except WorkflowDeadlineExceeded as exc:
@@ -371,7 +424,15 @@ async def run_workflow(
         except asyncio.CancelledError:
             bootstrap_stopped_environment = True
             raise
-        except Exception as exc:  # workflow code/provider failures are outcomes
+        except Exception as exc:
+            runtime_result = getattr(exc, "runtime_result", None)
+            if (
+                runtime_result is None
+                or not runtime_result.evidence_complete
+            ):
+                raise ProgrammaticLifecycleError(
+                    "workflow runtime failed without finalized execution evidence"
+                ) from exc
             failed_error = exc
     finally:
         if owned_environment and not bootstrap_stopped_environment:
@@ -379,7 +440,7 @@ async def run_workflow(
                 run_environment_hook(
                     resolved_environment,
                     "cleanup",
-                    timeout=DEFAULT_CLEANUP_TIMEOUT_SECONDS,
+                    timeout=cleanup_timeout,
                 ),
                 propagate_cancellation=True,
             )
@@ -390,34 +451,43 @@ async def run_workflow(
 
     _verify_artifact_claim(artifacts)
     if stopped_error is not None:
+        details = stopped_error.result
+        metrics = _workflow_metrics(details)
+        metrics["execution_quiesced"] = True
         return ProgrammaticResult(
             output=None,
             status="stopped",
             reason="timeout",
-            tokens=None,
+            tokens=0 if details is None else details.tokens,
             artifacts=artifacts,
             error=stopped_error,
+            metrics=metrics,
+            agent_failures=() if details is None else details.agent_failures,
         )
     if failed_error is not None:
+        details = getattr(failed_error, "runtime_result", None)
         return ProgrammaticResult(
             output=None,
             status="failed",
             reason=str(failed_error) or type(failed_error).__name__,
-            tokens=None,
+            tokens=None if details is None else details.tokens,
             artifacts=artifacts,
             error=failed_error,
+            metrics=_workflow_metrics(details),
+            agent_failures=() if details is None else details.agent_failures,
         )
     if details is None:
         raise ProgrammaticLifecycleError("workflow completed without a result")
     output = details.output
-    budget_stopped = isinstance(output, dict) and output.get("status") == "budget_exceeded"
+    budget_stopped = details.stop_reason == "budget_exceeded"
     return ProgrammaticResult(
         output=output,
         status="stopped" if budget_stopped else "completed",
         reason="budget_exceeded" if budget_stopped else None,
         tokens=details.tokens,
         artifacts=artifacts,
-        metrics={"sessions": details.sessions},
+        metrics=_workflow_metrics(details),
+        agent_failures=details.agent_failures,
     )
 
 
@@ -557,8 +627,11 @@ __all__ = [
     "ProgrammaticLifecycleError",
     "ProgrammaticResult",
     "attach_container",
+    "docker_environment",
+    "local_environment",
     "resolve_tools",
     "run_agent",
     "run_team",
     "run_workflow",
+    "worktree_environment",
 ]

--- a/opencollab/bootstrap/tool_registry.py
+++ b/opencollab/bootstrap/tool_registry.py
@@ -117,6 +117,7 @@ def build_tools_for_role(
     scheduler: SchedulerPort | None = None,
     skill_store: SkillStorePort | None = None,
     interactive: bool = False,
+    allow_file_creation: bool = True,
     tool_limits: dict[str, dict[str, int]] | None = None,
 ) -> list[Tool]:
     """Resolve tool names to Tool instances.
@@ -144,6 +145,7 @@ def build_tools_for_role(
                     STATELESS_TOOL_FACTORIES[name],
                     limits,
                     headless=not interactive,
+                    allow_file_creation=allow_file_creation,
                 )
             )
         elif name in SCHEDULER_TOOL_FACTORIES:
@@ -172,6 +174,7 @@ def _instantiate(
     limits: dict[str, dict[str, int]],
     *,
     headless: bool,
+    allow_file_creation: bool,
 ) -> Tool:
     """Build a stateless tool, applying any configured limit kwargs."""
     kwargs: dict[str, object] = dict(limits.get(name, {}))
@@ -183,6 +186,8 @@ def _instantiate(
             allow_extra_args=False,
             require_process_isolation=True,
         )
+    if name == "file_write":
+        kwargs["allow_create"] = allow_file_creation
     try:
         return factory(**kwargs)
     except TypeError as e:

--- a/opencollab/bootstrap/workflow_runtime.py
+++ b/opencollab/bootstrap/workflow_runtime.py
@@ -43,9 +43,26 @@ _OWNER_CLEANUP_GRACE_PHASES = 4
 class WorkflowDeadlineExceeded(TimeoutError):
     """The caller-owned workflow wall-clock deadline expired."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        result: WorkflowRuntimeResult | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.result = result
+
 
 class WorkflowLifecycleError(RuntimeError):
     """Workflow-owned work failed to reach a terminal state."""
+
+
+async def _wait_for_owner(
+    owner: asyncio.Task[Any],
+    *,
+    timeout: float,
+) -> tuple[set[asyncio.Task[Any]], set[asyncio.Task[Any]]]:
+    return await asyncio.wait({owner}, timeout=timeout)
 
 
 async def run_workflow(
@@ -58,6 +75,8 @@ async def run_workflow(
     event_sink: EventPublisherPort | None = None,
     budget: int | None = None,
     max_concurrency: int = 4,
+    max_steps: int = 100,
+    system_prompt: str = WORKFLOW_AGENT_PROMPT,
     save_dir: str | None = None,
     trace: bool = True,
     env: Any | None = None,
@@ -69,26 +88,40 @@ async def run_workflow(
 ) -> Any:
     """Run through one owned lifecycle with an optional wall-clock deadline."""
     token = _WORKFLOW_ENV_OVERRIDE.set(env)
-    owner = asyncio.create_task(
-        _run_workflow_with_integrity(
-            spec_or_fn,
-            args,
-            cfg=cfg,
-            workspace=workspace,
-            tracer=tracer,
-            event_sink=event_sink,
-            budget=budget,
-            max_concurrency=max_concurrency,
-            save_dir=save_dir,
-            trace=trace,
-            cleanup_timeout=cleanup_timeout,
-            env=env,
-            source_root=source_root,
-            deadline_monotonic=deadline_monotonic,
-            deadline_margin_seconds=deadline_margin_seconds,
-            return_details=return_details,
-        )
-    )
+    cancelled_result: WorkflowRuntimeResult | None = None
+    cancelled_notes: tuple[str, ...] = ()
+
+    async def run_owner() -> Any:
+        nonlocal cancelled_result, cancelled_notes
+        try:
+            return await _run_workflow_with_integrity(
+                spec_or_fn,
+                args,
+                cfg=cfg,
+                workspace=workspace,
+                tracer=tracer,
+                event_sink=event_sink,
+                budget=budget,
+                max_concurrency=max_concurrency,
+                max_steps=max_steps,
+                system_prompt=system_prompt,
+                save_dir=save_dir,
+                trace=trace,
+                cleanup_timeout=cleanup_timeout,
+                env=env,
+                source_root=source_root,
+                deadline_monotonic=deadline_monotonic,
+                deadline_margin_seconds=deadline_margin_seconds,
+                return_details=return_details,
+            )
+        except asyncio.CancelledError as cancellation:
+            attached = getattr(cancellation, "runtime_result", None)
+            if isinstance(attached, WorkflowRuntimeResult):
+                cancelled_result = attached
+            cancelled_notes = tuple(getattr(cancellation, "__notes__", ()))
+            raise
+
+    owner = asyncio.create_task(run_owner())
     stop_task: asyncio.Task[tuple[bool, bool]] | None = None
 
     async def stop_owned(cancellation: asyncio.CancelledError) -> tuple[bool, bool]:
@@ -127,7 +160,7 @@ async def run_workflow(
         if deadline_monotonic is None:
             return await asyncio.shield(owner)
         remaining = max(0.0, deadline_monotonic - asyncio.get_running_loop().time())
-        done, pending = await asyncio.wait({owner}, timeout=remaining)
+        done, pending = await _wait_for_owner(owner, timeout=remaining)
         if not pending:
             return owner.result()
         deadline_cancellation = asyncio.CancelledError(
@@ -139,10 +172,16 @@ async def run_workflow(
         )
         if not aborted or not terminated:
             raise WorkflowLifecycleError("timed-out workflow did not reach a quiescent terminal state")
+        deadline_result = cancelled_result
         try:
-            owner.result()
+            late_result = owner.result()
+            if isinstance(late_result, WorkflowRuntimeResult):
+                deadline_result = late_result
         except asyncio.CancelledError as inner:
-            notes = tuple(getattr(inner, "__notes__", ()))
+            attached = getattr(inner, "runtime_result", None)
+            if deadline_result is None and isinstance(attached, WorkflowRuntimeResult):
+                deadline_result = attached
+            notes = cancelled_notes or tuple(getattr(inner, "__notes__", ()))
             if notes:
                 failure = WorkflowLifecycleError(
                     "timed-out workflow reported a cleanup or persistence failure"
@@ -154,7 +193,10 @@ async def run_workflow(
             raise WorkflowLifecycleError(
                 "timed-out workflow failed while reaching its terminal state"
             ) from inner
-        raise WorkflowDeadlineExceeded("workflow wall-clock deadline expired")
+        raise WorkflowDeadlineExceeded(
+            "workflow wall-clock deadline expired",
+            result=deadline_result,
+        )
     except asyncio.CancelledError as cancellation:
         await stop_once(cancellation, propagate_cancellation=False)
         if owner.done():

--- a/opencollab/environments.py
+++ b/opencollab/environments.py
@@ -1,6 +1,17 @@
-"""Public execution-environment contract and container attachment helper."""
+"""Public execution-environment contract and thin composition helpers."""
 
 from opencollab.application.ports import EnvironmentPort as Environment
-from opencollab.bootstrap.programmatic import attach_container
+from opencollab.bootstrap.programmatic import (
+    attach_container,
+    docker_environment,
+    local_environment,
+    worktree_environment,
+)
 
-__all__ = ["Environment", "attach_container"]
+__all__ = [
+    "Environment",
+    "attach_container",
+    "docker_environment",
+    "local_environment",
+    "worktree_environment",
+]

--- a/opencollab/sdk/client.py
+++ b/opencollab/sdk/client.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import math
 import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 from opencollab.bootstrap.config import build_config
@@ -38,6 +41,13 @@ def _positive_timeout(value: object, name: str) -> float | None:
     return parsed
 
 
+def _required_positive_timeout(value: object, name: str) -> float:
+    parsed = _positive_timeout(value, name)
+    if parsed is None:
+        raise ValueError(f"{name} must be a positive finite number")
+    return parsed
+
+
 def _non_empty(value: object, name: str) -> str:
     if not isinstance(value, str) or not value.strip() or "\x00" in value:
         raise ValueError(f"{name} must be non-empty text")
@@ -54,6 +64,15 @@ def _path(value: str | os.PathLike[str] | None, name: str) -> Path | None:
 
 
 def _public_result(result: ProgrammaticResult) -> RunResult[Any]:
+    agent_failures = tuple(
+        {
+            "label": item.get("label"),
+            "exception_type": item.get("exception_type"),
+            "status_code": item.get("status_code"),
+            "provider_error_type": item.get("provider_error_type"),
+        }
+        for item in result.agent_failures
+    )
     return RunResult(
         output=result.output,
         status=result.status,
@@ -62,6 +81,7 @@ def _public_result(result: ProgrammaticResult) -> RunResult[Any]:
         artifacts=result.artifacts,
         error=result.error,
         metrics=dict(result.metrics),
+        agent_failures=agent_failures,
     )
 
 
@@ -104,14 +124,43 @@ class OpenCollab:
         self._config = build_config(self._workspace, overrides=overrides).model_dump()
         self._environment = environment
 
+    @property
+    def configuration(self) -> Mapping[str, Any]:
+        """Return read-only non-secret metadata with isolated nested values."""
+        public_keys = (
+            "model",
+            "provider",
+            "budget",
+            "llm_timeout",
+            "temperature",
+            "top_p",
+            "max_output_tokens",
+            "thinking",
+            "thinking_params",
+        )
+        public = {
+            key: copy.deepcopy(self._config[key])
+            for key in public_keys
+            if key in self._config
+        }
+        base_url = self._config.get("base_url")
+        public["base_url_sha256"] = (
+            hashlib.sha256(base_url.encode("utf-8")).hexdigest()
+            if isinstance(base_url, str) and base_url
+            else None
+        )
+        return MappingProxyType(public)
+
     async def agent(
         self,
         prompt: str,
         *,
         tools: str | Sequence[Any] | None = "coding",
         budget: int | None = None,
-        steps: int = 100,
+        max_steps: int | None = None,
+        steps: int | None = None,
         timeout: float | None = None,
+        cleanup_timeout: float = 2.0,
         artifacts: str | os.PathLike[str] | None = None,
         trace: bool = True,
         name: str = "agent",
@@ -125,6 +174,16 @@ class OpenCollab:
             _non_empty(system_prompt, "system_prompt")
         if not isinstance(trace, bool):
             raise ValueError("trace must be a boolean")
+        if max_steps is not None and steps is not None:
+            raise ValueError("max_steps and steps cannot both be set")
+        resolved_max_steps = (
+            100
+            if max_steps is None and steps is None
+            else _positive_int(
+                max_steps if max_steps is not None else steps,
+                "max_steps" if max_steps is not None else "steps",
+            )
+        )
         try:
             result = await run_agent(
                 prompt=prompt,
@@ -135,8 +194,12 @@ class OpenCollab:
                     self._config["budget"] if budget is None else budget,
                     "budget",
                 ),
-                max_steps=_positive_int(steps, "steps"),
+                max_steps=resolved_max_steps,
                 timeout=_positive_timeout(timeout, "timeout"),
+                cleanup_timeout=_required_positive_timeout(
+                    cleanup_timeout,
+                    "cleanup_timeout",
+                ),
                 artifacts=_path(artifacts, "artifacts"),
                 trace=trace,
                 environment=self._environment,
@@ -193,6 +256,9 @@ class OpenCollab:
         budget: int | None = None,
         concurrency: int = 4,
         timeout: float | None = None,
+        max_steps: int = 100,
+        system_prompt: str | None = None,
+        cleanup_timeout: float = 2.0,
         artifacts: str | os.PathLike[str] | None = None,
         trace: bool = True,
     ) -> RunResult[Any]:
@@ -204,6 +270,8 @@ class OpenCollab:
         normalized_inputs = dict(inputs or {})
         if any(not isinstance(key, str) for key in normalized_inputs):
             raise ValueError("workflow input keys must be strings")
+        if system_prompt is not None:
+            _non_empty(system_prompt, "system_prompt")
         if not isinstance(trace, bool):
             raise ValueError("trace must be a boolean")
         try:
@@ -219,6 +287,12 @@ class OpenCollab:
                 ),
                 max_concurrency=_positive_int(concurrency, "concurrency"),
                 timeout=_positive_timeout(timeout, "timeout"),
+                max_steps=_positive_int(max_steps, "max_steps"),
+                system_prompt=system_prompt,
+                cleanup_timeout=_required_positive_timeout(
+                    cleanup_timeout,
+                    "cleanup_timeout",
+                ),
                 artifacts=_path(artifacts, "artifacts"),
                 trace=trace,
                 environment=self._environment,

--- a/opencollab/sdk/result.py
+++ b/opencollab/sdk/result.py
@@ -27,7 +27,8 @@ class RunResult(Generic[T]):
     tokens: int | None = None
     artifacts: Path | None = None
     error: BaseException | None = field(default=None, repr=False, compare=False)
-    metrics: dict[str, int] = field(default_factory=dict)
+    metrics: dict[str, Any] = field(default_factory=dict)
+    agent_failures: tuple[dict[str, Any], ...] = ()
 
     @property
     def ok(self) -> bool:

--- a/opencollab/tools.py
+++ b/opencollab/tools.py
@@ -1,9 +1,91 @@
-"""Public structural tool contract.
+"""Public structural tool contract and built-in tool composition.
 
 Pass custom implementations directly to ``OpenCollab.agent``; built-in tools
-are selected by the ``"coding"`` and ``"read"`` preset names.
+can be selected by preset name or composed explicitly for workflow roles.
 """
 
-from opencollab.application.ports import ToolPort as Tool
+from __future__ import annotations
 
-__all__ = ["Tool"]
+from collections.abc import Mapping
+from typing import Literal, Protocol, TypeAlias, runtime_checkable
+
+from opencollab.application.ports import ToolPort as Tool
+from opencollab.bootstrap.tool_registry import build_tools_for_role
+
+BuiltinToolName: TypeAlias = Literal[
+    "bash",
+    "file_read",
+    "file_write",
+    "apply_patch",
+    "run_tests",
+    "git_diff",
+    "grep",
+]
+
+_BUILTIN_TOOL_NAMES = frozenset(
+    {
+        "bash",
+        "file_read",
+        "file_write",
+        "apply_patch",
+        "run_tests",
+        "git_diff",
+        "grep",
+    }
+)
+
+
+@runtime_checkable
+class VerificationTool(Tool, Protocol):
+    """A test tool exposing targets with a latest parser-backed green verdict."""
+
+    @property
+    def verified_targets(self) -> frozenset[str]: ...
+
+
+def builtin_tools(
+    *names: BuiltinToolName,
+    headless: bool = True,
+    allow_file_creation: bool = True,
+    limits: Mapping[str, Mapping[str, int]] | None = None,
+) -> tuple[Tool, ...]:
+    """Build a fresh ordered set of public, stateless tools.
+
+    Headless composition requires process isolation for shell and test
+    execution, and disables model-supplied test runner overrides. Coordination
+    and human-interaction tools remain scheduler-owned and are not available
+    through this helper.
+    """
+    if not isinstance(headless, bool):
+        raise ValueError("headless must be a boolean")
+    if not isinstance(allow_file_creation, bool):
+        raise ValueError("allow_file_creation must be a boolean")
+    unsupported = sorted({name for name in names if name not in _BUILTIN_TOOL_NAMES})
+    if unsupported:
+        raise ValueError(f"unsupported built-in tools: {unsupported}")
+    if len(set(names)) != len(names):
+        raise ValueError("built-in tool names must be unique")
+    if limits is not None and not isinstance(limits, Mapping):
+        raise ValueError("limits must be a mapping")
+    unselected_limits = sorted(set(limits or {}) - set(names))
+    if unselected_limits:
+        raise ValueError(
+            f"limits reference unselected built-in tools: {unselected_limits}"
+        )
+    for name, values in (limits or {}).items():
+        if not isinstance(values, Mapping):
+            raise ValueError(f"limits for {name!r} must be a mapping")
+    normalized_limits = {
+        name: dict(values) for name, values in (limits or {}).items()
+    }
+    return tuple(
+        build_tools_for_role(
+            list(names),
+            interactive=not headless,
+            allow_file_creation=allow_file_creation,
+            tool_limits=normalized_limits,
+        )
+    )
+
+
+__all__ = ["BuiltinToolName", "Tool", "VerificationTool", "builtin_tools"]

--- a/opencollab/workflows.py
+++ b/opencollab/workflows.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, Literal, Protocol
+from typing import Any, Protocol
 
 from opencollab.application.workflow_registry import workflow
 from opencollab.tools import Tool
@@ -26,9 +26,6 @@ class WorkflowContext(Protocol):
         tool_choice: str | None = None,
         thinking: bool | None = None,
         over_budget_ok: bool = False,
-        enforcement_strength: Literal["off", "needs-enforcement"] = "off",
-        commit_reserve: int = 25_000,
-        harvest_fallback: str | None = None,
     ) -> str | dict[str, Any] | None: ...
 
     async def draft_findings(

--- a/opencollab/workflows.py
+++ b/opencollab/workflows.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from opencollab.application.workflow_registry import workflow
+from opencollab.tools import Tool
 
 
 class WorkflowContext(Protocol):
@@ -19,9 +20,24 @@ class WorkflowContext(Protocol):
         *,
         schema: dict[str, Any] | None = None,
         label: str | None = None,
-        tools: Sequence[Any] | None = None,
+        tools: Sequence[Tool] | None = None,
         budget: int | None = None,
+        timeout: float | None = None,
+        tool_choice: str | None = None,
+        thinking: bool | None = None,
+        over_budget_ok: bool = False,
+        enforcement_strength: Literal["off", "needs-enforcement"] = "off",
+        commit_reserve: int = 25_000,
+        harvest_fallback: str | None = None,
     ) -> str | dict[str, Any] | None: ...
+
+    async def draft_findings(
+        self,
+        prompt: str,
+        *,
+        label: str | None = None,
+        budget: int | None = None,
+    ) -> dict[str, Any] | None: ...
 
     async def parallel(
         self,
@@ -36,6 +52,12 @@ class WorkflowContext(Protocol):
         self,
         exclude_paths: Sequence[str] = (),
     ) -> bool | None: ...
+
+    async def diff(self) -> str | None: ...
+
+    def tokens_spent(self) -> int: ...
+
+    def tokens_remaining(self) -> float: ...
 
     def seconds_left(self) -> float: ...
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -108,6 +108,8 @@ async def test_agent_runtime_returns_metrics_after_final_save(monkeypatch) -> No
     assert result.tokens_spent == 7
     assert result.step_count == 2
     assert result.cleanup_quiesced
+    assert result.environment_cleanup_quiesced is True
+    assert result.environment_quiesced is True
     assert environment.cleanup_calls == 1
 
 
@@ -127,6 +129,8 @@ async def test_agent_runtime_returns_quiescent_execution_failure(monkeypatch) ->
     assert result.outcome == "failed"
     assert isinstance(result.error, RuntimeError)
     assert result.phase == "error"
+    assert result.environment_cleanup_quiesced is None
+    assert result.environment_quiesced is None
 
 
 async def test_agent_runtime_timeout_revokes_aborts_and_quiesces(monkeypatch) -> None:

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 from dataclasses import fields
 from pathlib import Path
@@ -10,8 +11,14 @@ import pytest
 
 import opencollab
 import opencollab.sdk as sdk
-from opencollab.environments import Environment, attach_container
-from opencollab.tools import Tool
+from opencollab.environments import (
+    Environment,
+    attach_container,
+    docker_environment,
+    local_environment,
+    worktree_environment,
+)
+from opencollab.tools import Tool, VerificationTool, builtin_tools
 from opencollab.workflows import WorkflowContext
 
 
@@ -48,8 +55,10 @@ def test_public_class_and_method_shapes_stay_lean() -> None:
             "prompt",
             "tools",
             "budget",
+            "max_steps",
             "steps",
             "timeout",
+            "cleanup_timeout",
             "artifacts",
             "trace",
             "name",
@@ -73,6 +82,9 @@ def test_public_class_and_method_shapes_stay_lean() -> None:
             "budget",
             "concurrency",
             "timeout",
+            "max_steps",
+            "system_prompt",
+            "cleanup_timeout",
             "artifacts",
             "trace",
         ),
@@ -88,6 +100,7 @@ def test_public_class_and_method_shapes_stay_lean() -> None:
         "artifacts",
         "error",
         "metrics",
+        "agent_failures",
     )
 
 
@@ -134,12 +147,42 @@ def test_advanced_capabilities_live_in_small_opt_in_modules() -> None:
     import opencollab.tools as tools
     import opencollab.workflows as workflows
 
-    assert tools.__all__ == ["Tool"]
-    assert environments.__all__ == ["Environment", "attach_container"]
+    assert tools.__all__ == [
+        "BuiltinToolName",
+        "Tool",
+        "VerificationTool",
+        "builtin_tools",
+    ]
+    assert environments.__all__ == [
+        "Environment",
+        "attach_container",
+        "docker_environment",
+        "local_environment",
+        "worktree_environment",
+    ]
     assert workflows.__all__ == ["WorkflowContext", "workflow"]
     assert Tool is not None
+    assert VerificationTool is not None
+    assert builtin_tools is not None
     assert Environment is not None
     assert WorkflowContext is not None
+    assert not hasattr(environments, "LocalEnvironment")
+    assert not hasattr(environments, "WorktreeEnvironment")
+    assert not hasattr(environments, "DockerEnvironment")
+
+
+def test_environment_factories_preserve_caller_owned_lifecycle(tmp_path: Path) -> None:
+    local = local_environment(tmp_path)
+    worktree = worktree_environment(tmp_path)
+    container = docker_environment("python:3.11-slim", worktree)
+
+    assert local.workspace == str(tmp_path.resolve())
+    assert worktree.source_workspace == str(tmp_path.resolve())
+    assert container.source_workspace == str(tmp_path.resolve())
+    assert container.process_isolated is True
+    assert not local.revoked
+    assert not worktree.revoked
+    assert not container.revoked
 
 
 def test_attach_container_validates_non_owning_workspace() -> None:
@@ -157,8 +200,98 @@ def test_attach_container_validates_non_owning_workspace() -> None:
         attach_container(container_id=" container-1 ", workspace="/testbed")
 
 
+def test_builtin_tools_are_fresh_ordered_and_headless_safe() -> None:
+    first = builtin_tools(
+        "bash",
+        "file_write",
+        "run_tests",
+        allow_file_creation=False,
+    )
+    second = builtin_tools("bash", "file_write", "run_tests")
+
+    assert tuple(tool.name for tool in first) == (
+        "bash",
+        "file_write",
+        "run_tests",
+    )
+    assert all(left is not right for left, right in zip(first, second, strict=True))
+    assert first[0].require_process_isolation is True
+    assert first[1].allow_create is False
+    assert first[2].require_process_isolation is True
+    assert first[2].allow_runner_override is False
+    assert first[2].allow_extra_args is False
+    assert isinstance(first[2], VerificationTool)
+    assert first[2].verified_targets == frozenset()
+
+
+def test_builtin_tools_reject_unsupported_or_ambiguous_requests() -> None:
+    with pytest.raises(ValueError, match="unsupported"):
+        builtin_tools("spawn_agent")
+    with pytest.raises(ValueError, match="unique"):
+        builtin_tools("grep", "grep")
+    with pytest.raises(ValueError, match="headless"):
+        builtin_tools("grep", headless="yes")
+    with pytest.raises(ValueError, match="allow_file_creation"):
+        builtin_tools("file_write", allow_file_creation=1)
+    with pytest.raises(ValueError, match="mapping"):
+        builtin_tools("grep", limits=[])
+    with pytest.raises(ValueError, match="unselected"):
+        builtin_tools("grep", limits={"bash": {"max_output_chars": 10}})
+    with pytest.raises(ValueError, match="mapping"):
+        builtin_tools("grep", limits={"grep": []})
+    with pytest.raises(ValueError, match="unsupported keys"):
+        builtin_tools("grep", limits={"grep": {"unknown": 10}})
+
+
 def test_client_rejects_invalid_workspace_or_config(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="not a directory"):
         sdk.OpenCollab(tmp_path / "missing")
     with pytest.raises(TypeError, match="mapping"):
         sdk.OpenCollab(tmp_path, config=object())
+
+
+def test_client_exposes_immutable_non_secret_configuration(tmp_path: Path) -> None:
+    client = sdk.OpenCollab(
+        tmp_path,
+        model="public-model",
+        provider="openai",
+        api_key="private-key",  # pragma: allowlist secret
+        base_url="https://private.example",
+        config={
+            "temperature": 0.7,
+            "top_p": 0.8,
+            "max_output_tokens": 4096,
+            "thinking": True,
+            "thinking_params": {
+                "thinking": {
+                    "type": "enabled",
+                    "keep": ["all"],
+                }
+            },
+        },
+    )
+
+    assert client.configuration["model"] == "public-model"
+    assert client.configuration["provider"] == "openai"
+    assert client.configuration["temperature"] == 0.7
+    assert client.configuration["top_p"] == 0.8
+    assert client.configuration["max_output_tokens"] == 4096
+    assert client.configuration["thinking"] is True
+    assert client.configuration["thinking_params"] == {
+        "thinking": {
+            "type": "enabled",
+            "keep": ["all"],
+        }
+    }
+    assert client.configuration["base_url_sha256"] == hashlib.sha256(
+        b"https://private.example"
+    ).hexdigest()
+    assert "api_key" not in client.configuration
+    assert "base_url" not in client.configuration
+    assert "private-key" not in repr(client.configuration)
+    assert "https://private.example" not in repr(client.configuration)
+    copied_params = client.configuration["thinking_params"]
+    copied_params["thinking"]["keep"].append("mutated")
+    assert client.configuration["thinking_params"]["thinking"]["keep"] == ["all"]
+    with pytest.raises(TypeError):
+        client.configuration["model"] = "changed"

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -178,6 +178,14 @@ def test_public_environment_contract_exposes_workspace_mapping_metadata() -> Non
         "source_workspace",
         "local_filesystem",
     } <= set(Environment.__annotations__)
+    assert callable(getattr(Environment, "setup"))
+
+
+def test_public_workflow_context_keeps_research_strategy_private() -> None:
+    parameters = inspect.signature(WorkflowContext.agent).parameters
+    assert "enforcement_strength" not in parameters
+    assert "commit_reserve" not in parameters
+    assert "harvest_fallback" not in parameters
 
 
 def test_environment_factories_preserve_caller_owned_lifecycle(tmp_path: Path) -> None:
@@ -192,6 +200,17 @@ def test_environment_factories_preserve_caller_owned_lifecycle(tmp_path: Path) -
     assert not local.revoked
     assert not worktree.revoked
     assert not container.revoked
+
+
+async def test_public_environment_setup_has_one_shared_contract(tmp_path: Path) -> None:
+    local = local_environment(tmp_path)
+    worktree = worktree_environment(tmp_path)
+
+    assert await local.setup() == str(tmp_path.resolve())
+    with pytest.raises(ValueError, match="mount_dir"):
+        await local.setup(str(tmp_path))
+    with pytest.raises(ValueError, match="mount_dir"):
+        await worktree.setup(str(tmp_path))
 
 
 def test_attach_container_validates_non_owning_workspace() -> None:

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -171,6 +171,15 @@ def test_advanced_capabilities_live_in_small_opt_in_modules() -> None:
     assert not hasattr(environments, "DockerEnvironment")
 
 
+def test_public_environment_contract_exposes_workspace_mapping_metadata() -> None:
+    assert {
+        "workspace",
+        "host_workspace",
+        "source_workspace",
+        "local_filesystem",
+    } <= set(Environment.__annotations__)
+
+
 def test_environment_factories_preserve_caller_owned_lifecycle(tmp_path: Path) -> None:
     local = local_environment(tmp_path)
     worktree = worktree_environment(tmp_path)

--- a/tests/test_sdk_runtime.py
+++ b/tests/test_sdk_runtime.py
@@ -11,11 +11,13 @@ import pytest
 
 from opencollab import OpenCollab, RunError, workflow
 from opencollab.adapters.llm.types import LLMResponse, Usage
-from opencollab.bootstrap import programmatic
-from opencollab.bootstrap.programmatic import (
-    ProgrammaticLifecycleError,
-    ProgrammaticResult,
+from opencollab.bootstrap import (
+    _workflow_runtime_execution as workflow_execution,
 )
+from opencollab.bootstrap import (
+    programmatic,
+)
+from opencollab.bootstrap.programmatic import ProgrammaticLifecycleError, ProgrammaticResult
 from opencollab.sdk import client as sdk_client
 
 
@@ -33,9 +35,7 @@ async def test_agent_uses_real_hardened_runtime_and_persists_evidence(
 ) -> None:
     artifacts = tmp_path / "agent-run"
     result = await OpenCollab(
-        tmp_path,
-        model="model",
-        provider="openai",
+        tmp_path, model="model", provider="openai"
     ).agent(
         "finish once",
         tools=(),
@@ -48,7 +48,7 @@ async def test_agent_uses_real_hardened_runtime_and_persists_evidence(
     assert result.output == "finished"
     assert result.reason is None
     assert result.tokens == 6
-    assert result.metrics == {"steps": 1}
+    assert result.metrics == _completed_agent_metrics()
     assert result.artifacts == artifacts.resolve()
     assert (artifacts / ".opencollab-run").read_text() == "claimed\n"
     transcript = json.loads((artifacts / "agent.json").read_text())
@@ -83,7 +83,8 @@ async def test_client_resolves_config_once_and_delegates_plain_arguments(
     result = await client.agent(
         "do it",
         tools="read",
-        steps=3,
+        max_steps=3,
+        cleanup_timeout=4.0,
         artifacts=tmp_path / "evidence",
         trace=False,
     )
@@ -95,9 +96,25 @@ async def test_client_resolves_config_once_and_delegates_plain_arguments(
     assert captured["config"]["api_key"] == "private-key"
     assert captured["max_tokens"] == 123
     assert captured["max_steps"] == 3
+    assert captured["cleanup_timeout"] == 4.0
     assert captured["tools"] == "read"
     assert captured["artifacts"] == (tmp_path / "evidence").resolve()
     assert "private-key" not in repr(client)
+
+    await client.agent("legacy", steps=4)
+    assert captured["max_steps"] == 4
+
+
+def _completed_agent_metrics() -> dict[str, object]:
+    return {
+        "steps": 1,
+        "outcome": "completed",
+        "phase": "done",
+        "terminal_reason": "completed",
+        "markup_recovered": 0,
+        "cleanup_quiesced": True,
+        "execution_quiesced": True,
+    }
 
 
 async def test_agent_validates_controls_before_delegating(
@@ -118,6 +135,116 @@ async def test_agent_validates_controls_before_delegating(
         await client.agent("run", budget=True)
     with pytest.raises(ValueError, match="timeout"):
         await client.agent("run", timeout=float("inf"))
+    with pytest.raises(ValueError, match="cleanup_timeout"):
+        await client.agent("run", cleanup_timeout=0)
+    with pytest.raises(ValueError, match="cannot both"):
+        await client.agent("run", max_steps=3, steps=3)
+    assert not called
+
+
+async def test_workflow_delegates_evaluation_controls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured = {}
+
+    async def fake_run_workflow(**kwargs):
+        captured.update(kwargs)
+        return ProgrammaticResult(
+            output="done",
+            status="completed",
+            reason=None,
+            tokens=9,
+            artifacts=None,
+            metrics={
+                "steps": 3,
+                "sessions": 2,
+                "markup_recovered": 1,
+                "execution_quiesced": True,
+            },
+        )
+
+    monkeypatch.setattr(sdk_client, "run_workflow", fake_run_workflow)
+
+    async def plain(_ctx, _inputs):
+        return None
+
+    result = await OpenCollab(tmp_path).workflow(
+        plain,
+        max_steps=60,
+        system_prompt="Evaluation system prompt",
+        cleanup_timeout=10.0,
+    )
+
+    assert result.output == "done"
+    assert captured["max_steps"] == 60
+    assert captured["system_prompt"] == "Evaluation system prompt"
+    assert captured["cleanup_timeout"] == 10.0
+
+
+async def test_workflow_exposes_sanitized_agent_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def fake_run_workflow(**_kwargs):
+        return ProgrammaticResult(
+            output="partial",
+            status="completed",
+            reason=None,
+            tokens=9,
+            artifacts=None,
+            agent_failures=(
+                {
+                    "label": "reviewer",
+                    "exception_type": "ProviderFailure",
+                    "status_code": 403,
+                    "provider_error_type": "access_terminated_error",
+                    "message": "private provider detail",
+                },
+            ),
+        )
+
+    monkeypatch.setattr(sdk_client, "run_workflow", fake_run_workflow)
+
+    async def plain(_ctx, _inputs):
+        return None
+
+    result = await OpenCollab(tmp_path).workflow(plain)
+
+    assert result.agent_failures == (
+        {
+            "label": "reviewer",
+            "exception_type": "ProviderFailure",
+            "status_code": 403,
+            "provider_error_type": "access_terminated_error",
+        },
+    )
+    assert "message" not in result.agent_failures[0]
+    assert "private provider detail" not in repr(result)
+
+
+async def test_workflow_rejects_invalid_evaluation_controls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    called = False
+
+    async def should_not_run(**_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(sdk_client, "run_workflow", should_not_run)
+
+    async def plain(_ctx, _inputs):
+        return None
+
+    client = OpenCollab(tmp_path)
+    with pytest.raises(ValueError, match="max_steps"):
+        await client.workflow(plain, max_steps=0)
+    with pytest.raises(ValueError, match="system_prompt"):
+        await client.workflow(plain, system_prompt=" ")
+    with pytest.raises(ValueError, match="cleanup_timeout"):
+        await client.workflow(plain, cleanup_timeout=float("nan"))
     assert not called
 
 
@@ -139,7 +266,12 @@ async def test_workflow_uses_real_runtime_and_returns_live_metrics(
     assert result.ok
     assert result.output == {"answer": 4}
     assert result.tokens == 0
-    assert result.metrics == {"sessions": 0}
+    assert result.metrics == {
+        "steps": 0,
+        "sessions": 0,
+        "markup_recovered": 0,
+        "execution_quiesced": True,
+    }
     manifest = json.loads((artifacts / "workflow.json").read_text())
     assert manifest["workflow"] == "echo-flow"
     assert manifest["args"] == {"value": 3}
@@ -153,7 +285,8 @@ async def test_workflow_execution_failure_is_a_result(tmp_path: Path) -> None:
     result = await OpenCollab(tmp_path).workflow(broken, trace=False)
     assert result.status == "failed"
     assert result.reason == "bad workflow"
-    assert result.tokens is None
+    assert result.tokens == 0
+    assert result.metrics["execution_quiesced"] is True
     assert isinstance(result.error, ValueError)
     with pytest.raises(RunError, match="bad workflow"):
         result.raise_for_status()
@@ -171,8 +304,28 @@ async def test_workflow_timeout_is_a_stopped_result(tmp_path: Path) -> None:
     )
     assert result.status == "stopped"
     assert result.reason == "timeout"
-    assert result.tokens is None
+    assert result.tokens == 0
+    assert result.metrics == {
+        "steps": 0,
+        "sessions": 0,
+        "markup_recovered": 0,
+        "execution_quiesced": True,
+    }
     assert isinstance(result.error, TimeoutError)
+
+
+async def test_user_workflow_status_payload_does_not_fake_a_budget_stop(
+    tmp_path: Path,
+) -> None:
+    @workflow
+    async def ordinary(_ctx, _inputs):
+        return {"status": "budget_exceeded", "source": "user"}
+
+    result = await OpenCollab(tmp_path).workflow(ordinary, trace=False)
+
+    assert result.status == "completed"
+    assert result.reason is None
+    assert result.output == {"status": "budget_exceeded", "source": "user"}
 
 
 async def test_lifecycle_failure_raises_the_single_public_error(
@@ -189,6 +342,72 @@ async def test_lifecycle_failure_raises_the_single_public_error(
 
     with pytest.raises(RunError, match="quiesce"):
         await OpenCollab(tmp_path).workflow(plain)
+
+
+@pytest.mark.parametrize(
+    "failure_point",
+    ("cleanup", "manifest", "trace"),
+)
+async def test_real_workflow_technical_failures_raise_public_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_point: str,
+) -> None:
+    async def plain(_ctx, _inputs):
+        return "done"
+
+    artifacts = tmp_path / failure_point
+    if failure_point == "cleanup":
+        async def fail_cleanup(*_args, **_kwargs):
+            raise RuntimeError("cleanup evidence failed")
+
+        monkeypatch.setattr(
+            workflow_execution,
+            "_quiesce_and_finalize_workflow_context",
+            fail_cleanup,
+        )
+    elif failure_point == "manifest":
+        monkeypatch.setattr(
+            workflow_execution,
+            "_persist_workflow_manifest",
+            lambda *_args, **_kwargs: RuntimeError("manifest evidence failed"),
+        )
+    else:
+        monkeypatch.setattr(
+            workflow_execution,
+            "_close_tracer_capture",
+            lambda _tracer: RuntimeError("trace evidence failed"),
+        )
+
+    with pytest.raises(RunError, match="finalized execution evidence"):
+        await OpenCollab(tmp_path).workflow(
+            plain,
+            artifacts=artifacts,
+            trace=failure_point == "trace",
+        )
+
+
+async def test_incomplete_trace_upgrades_workflow_error_to_public_lifecycle_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def broken(_ctx, _inputs):
+        raise ValueError("workflow failed first")
+
+    monkeypatch.setattr(
+        workflow_execution,
+        "_close_tracer_capture",
+        lambda _tracer: RuntimeError("trace evidence failed"),
+    )
+
+    with pytest.raises(RunError, match="finalized execution evidence") as caught:
+        await OpenCollab(tmp_path).workflow(
+            broken,
+            artifacts=tmp_path / "combined-failure",
+            trace=True,
+        )
+
+    assert isinstance(caught.value.__cause__.__cause__, ValueError)
 
 
 async def test_artifact_directory_must_be_new_or_empty(tmp_path: Path) -> None:

--- a/tests/test_sdk_runtime.py
+++ b/tests/test_sdk_runtime.py
@@ -10,7 +10,9 @@ from types import SimpleNamespace
 import pytest
 
 from opencollab import OpenCollab, RunError, workflow
+from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.llm.types import LLMResponse, Usage
+from opencollab.application.workflow import WorkflowBudgetExceeded
 from opencollab.bootstrap import (
     _workflow_runtime_execution as workflow_execution,
 )
@@ -34,9 +36,7 @@ async def test_agent_uses_real_hardened_runtime_and_persists_evidence(
     tmp_path: Path,
 ) -> None:
     artifacts = tmp_path / "agent-run"
-    result = await OpenCollab(
-        tmp_path, model="model", provider="openai"
-    ).agent(
+    result = await OpenCollab(tmp_path, model="model", provider="openai").agent(
         "finish once",
         tools=(),
         llm=ReplyLLM(),
@@ -112,9 +112,39 @@ def _completed_agent_metrics() -> dict[str, object]:
         "phase": "done",
         "terminal_reason": "completed",
         "markup_recovered": 0,
+        "session_quiesced": True,
+        "environment_owned": True,
+        "environment_cleanup_quiesced": True,
+        "environment_quiesced": True,
         "cleanup_quiesced": True,
         "execution_quiesced": True,
     }
+
+
+async def test_agent_does_not_claim_caller_owned_environment_quiescence(
+    tmp_path: Path,
+) -> None:
+    environment = LocalEnvironment(str(tmp_path))
+    result = await OpenCollab(
+        tmp_path,
+        model="model",
+        provider="openai",
+        environment=environment,
+    ).agent(
+        "finish once",
+        tools=(),
+        llm=ReplyLLM(),
+        trace=False,
+    )
+
+    assert result.status == "completed"
+    assert result.metrics["session_quiesced"] is True
+    assert result.metrics["environment_owned"] is False
+    assert result.metrics["environment_cleanup_quiesced"] is None
+    assert result.metrics["environment_quiesced"] is None
+    assert result.metrics["cleanup_quiesced"] is None
+    assert result.metrics["execution_quiesced"] is None
+    assert environment.revoked is False
 
 
 async def test_agent_validates_controls_before_delegating(
@@ -270,11 +300,20 @@ async def test_workflow_uses_real_runtime_and_returns_live_metrics(
         "steps": 0,
         "sessions": 0,
         "markup_recovered": 0,
+        "session_quiesced": True,
+        "environment_owned": True,
+        "environment_cleanup_quiesced": True,
+        "environment_quiesced": True,
+        "cleanup_quiesced": True,
         "execution_quiesced": True,
     }
     manifest = json.loads((artifacts / "workflow.json").read_text())
     assert manifest["workflow"] == "echo-flow"
     assert manifest["args"] == {"value": 3}
+    assert manifest["status"] == "completed"
+    assert manifest["reason"] is None
+    assert manifest["failure_type"] is None
+    assert manifest["evidence_complete"] is True
 
 
 async def test_workflow_execution_failure_is_a_result(tmp_path: Path) -> None:
@@ -282,12 +321,22 @@ async def test_workflow_execution_failure_is_a_result(tmp_path: Path) -> None:
     async def broken(_ctx, _inputs):
         raise ValueError("bad workflow")
 
-    result = await OpenCollab(tmp_path).workflow(broken, trace=False)
+    artifacts = tmp_path / "failed-workflow"
+    result = await OpenCollab(tmp_path).workflow(
+        broken,
+        artifacts=artifacts,
+        trace=False,
+    )
     assert result.status == "failed"
     assert result.reason == "bad workflow"
     assert result.tokens == 0
     assert result.metrics["execution_quiesced"] is True
     assert isinstance(result.error, ValueError)
+    manifest = json.loads((artifacts / "workflow.json").read_text())
+    assert manifest["status"] == "failed"
+    assert manifest["reason"] == "workflow_exception"
+    assert manifest["failure_type"] == "ValueError"
+    assert manifest["evidence_complete"] is True
     with pytest.raises(RunError, match="bad workflow"):
         result.raise_for_status()
 
@@ -297,9 +346,11 @@ async def test_workflow_timeout_is_a_stopped_result(tmp_path: Path) -> None:
     async def blocked(_ctx, _inputs):
         await asyncio.Event().wait()
 
+    artifacts = tmp_path / "timed-out-workflow"
     result = await OpenCollab(tmp_path).workflow(
         blocked,
         timeout=0.01,
+        artifacts=artifacts,
         trace=False,
     )
     assert result.status == "stopped"
@@ -309,9 +360,41 @@ async def test_workflow_timeout_is_a_stopped_result(tmp_path: Path) -> None:
         "steps": 0,
         "sessions": 0,
         "markup_recovered": 0,
+        "session_quiesced": True,
+        "environment_owned": True,
+        "environment_cleanup_quiesced": True,
+        "environment_quiesced": True,
+        "cleanup_quiesced": True,
         "execution_quiesced": True,
     }
     assert isinstance(result.error, TimeoutError)
+    manifest = json.loads((artifacts / "workflow.json").read_text())
+    assert manifest["status"] == "stopped"
+    assert manifest["reason"] == "cancelled"
+    assert manifest["failure_type"] == "CancelledError"
+    assert manifest["evidence_complete"] is True
+
+
+async def test_workflow_budget_stop_persists_terminal_manifest(
+    tmp_path: Path,
+) -> None:
+    async def exhausted(_ctx, _inputs):
+        raise WorkflowBudgetExceeded("budget exhausted")
+
+    artifacts = tmp_path / "budget-workflow"
+    result = await OpenCollab(tmp_path).workflow(
+        exhausted,
+        artifacts=artifacts,
+        trace=False,
+    )
+
+    assert result.status == "stopped"
+    assert result.reason == "budget_exceeded"
+    manifest = json.loads((artifacts / "workflow.json").read_text())
+    assert manifest["status"] == "stopped"
+    assert manifest["reason"] == "budget_exceeded"
+    assert manifest["failure_type"] is None
+    assert manifest["evidence_complete"] is True
 
 
 async def test_user_workflow_status_payload_does_not_fake_a_budget_stop(
@@ -326,6 +409,29 @@ async def test_user_workflow_status_payload_does_not_fake_a_budget_stop(
     assert result.status == "completed"
     assert result.reason is None
     assert result.output == {"status": "budget_exceeded", "source": "user"}
+
+
+async def test_workflow_does_not_claim_caller_owned_environment_quiescence(
+    tmp_path: Path,
+) -> None:
+    environment = LocalEnvironment(str(tmp_path))
+
+    async def plain(_ctx, _inputs):
+        return "done"
+
+    result = await OpenCollab(tmp_path, environment=environment).workflow(
+        plain,
+        trace=False,
+    )
+
+    assert result.status == "completed"
+    assert result.metrics["session_quiesced"] is True
+    assert result.metrics["environment_owned"] is False
+    assert result.metrics["environment_cleanup_quiesced"] is None
+    assert result.metrics["environment_quiesced"] is None
+    assert result.metrics["cleanup_quiesced"] is None
+    assert result.metrics["execution_quiesced"] is None
+    assert environment.revoked is False
 
 
 async def test_lifecycle_failure_raises_the_single_public_error(
@@ -358,6 +464,7 @@ async def test_real_workflow_technical_failures_raise_public_error(
 
     artifacts = tmp_path / failure_point
     if failure_point == "cleanup":
+
         async def fail_cleanup(*_args, **_kwargs):
             raise RuntimeError("cleanup evidence failed")
 

--- a/tests/test_workflow_context_observation.py
+++ b/tests/test_workflow_context_observation.py
@@ -8,6 +8,7 @@ import pytest
 from workflow_context_test_support import (
     FakeFactory,
     FakeProbe,
+    FakeSession,
     RecordingSink,
 )
 
@@ -92,3 +93,36 @@ async def test_source_changed_swallows_probe_error_to_none():
     # A flaky git call must never abort the run: probe error -> None.
     ctx = WorkflowContext(FakeFactory([]), tree_probe=FakeProbe(boom=True))
     assert await ctx.source_changed(["t/test_x.py"]) is None
+
+
+@pytest.mark.asyncio
+async def test_diff_reports_probe_output_or_unknown() -> None:
+    assert await WorkflowContext(FakeFactory([])).diff() is None
+    assert (
+        await WorkflowContext(
+            FakeFactory([]),
+            tree_probe=FakeProbe(),
+        ).diff()
+        == "diff"
+    )
+    assert (
+        await WorkflowContext(
+            FakeFactory([]),
+            tree_probe=FakeProbe(boom=True),
+        ).diff()
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_observation_reports_live_session_usage() -> None:
+    ctx = WorkflowContext(
+        FakeFactory([FakeSession(tokens=12)]),
+        budget_total=100,
+    )
+
+    assert ctx.tokens_spent() == 0
+    assert ctx.tokens_remaining() == 100
+    await ctx.agent("measure usage")
+    assert ctx.tokens_spent() == 12
+    assert ctx.tokens_remaining() == 88

--- a/tests/test_workflow_runtime.py
+++ b/tests/test_workflow_runtime.py
@@ -67,6 +67,25 @@ async def test_built_context_injects_sampling_and_output_limits(monkeypatch):
     assert agent.top_p == 1.0
     assert agent.max_tokens_per_step == 32_768
 
+
+@pytest.mark.asyncio
+async def test_built_context_threads_session_limits_and_system_prompt(monkeypatch):
+    calls = _patch_build_session(monkeypatch)
+    ctx = workflow_runtime.build_workflow_context(
+        cfg=_cfg(),
+        max_steps=60,
+        system_prompt="Evaluation system prompt",
+    )
+
+    await ctx.agent("first")
+    await ctx.agent("second")
+
+    assert [call["max_steps"] for call in calls] == [60, 60]
+    assert [call["agent"].system_prompt for call in calls] == [
+        "Evaluation system prompt",
+        "Evaluation system prompt",
+    ]
+
 @pytest.mark.asyncio
 async def test_kimi_global_thinking_applies_to_fast_structured_roles(monkeypatch):
     calls = _patch_build_session(monkeypatch)
@@ -115,6 +134,42 @@ async def test_run_workflow_invokes_fn_with_context_and_args(monkeypatch):
     assert result == {"echo": 42}
     assert isinstance(seen["ctx"], WorkflowContext)
     assert seen["args"] == {"x": 42}
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_aggregates_session_metrics(monkeypatch):
+    from workflow_runtime_test_support import _FakeSession
+
+    values = ((5, 2, 1), (7, 3, 2))
+
+    def fake_build_session(*, agent, **_kwargs):
+        session = _FakeSession(agent, agent.tools)
+        session.used_tokens, session.step_count, session.markup_recovered = values[
+            fake_build_session.calls
+        ]
+        fake_build_session.calls += 1
+        return session
+
+    fake_build_session.calls = 0
+    monkeypatch.setattr(workflow_session, "build_session", fake_build_session)
+
+    async def fn(ctx, _args):
+        await ctx.agent("first")
+        await ctx.agent("second")
+        return "done"
+
+    details = await workflow_runtime.run_workflow(
+        fn,
+        {},
+        cfg=_cfg(),
+        return_details=True,
+    )
+
+    assert details.output == "done"
+    assert details.tokens == 12
+    assert details.sessions == 2
+    assert details.steps == 5
+    assert details.markup_recovered == 3
 
 @pytest.mark.asyncio
 async def test_run_workflow_accepts_a_workflow_spec(monkeypatch):

--- a/tests/test_workflow_runtime_artifacts.py
+++ b/tests/test_workflow_runtime_artifacts.py
@@ -257,6 +257,7 @@ async def test_run_workflow_projects_sticky_trace_failure_and_fails_closed(
     assert manifest["tracer_write_error"] == FailingTracer.write_error
     assert manifest["tracer_dropped_steps"] == 3
     assert "trajectory write failed" in manifest["tracer_failure"]
+    assert manifest["evidence_complete"] is False
 
 @pytest.mark.asyncio
 async def test_run_workflow_trace_close_failure_does_not_mask_workflow_error(
@@ -333,6 +334,7 @@ async def test_run_workflow_fails_closed_when_custom_tracer_diagnostics_raise(
     assert manifest["tracer_write_error"] is None
     assert manifest["tracer_dropped_steps"] == 0
     assert "diagnostics could not be inspected" in manifest["tracer_failure"]
+    assert manifest["evidence_complete"] is False
 
 @pytest.mark.asyncio
 async def test_run_workflow_trace_false_skips_orchestration(monkeypatch, tmp_path):

--- a/tests/test_workflow_runtime_deadline.py
+++ b/tests/test_workflow_runtime_deadline.py
@@ -7,9 +7,13 @@ import asyncio
 import pytest
 from workflow_runtime_test_support import (
     _cfg,
+    _FakeSession,
     _InjectedEnvironment,
 )
 
+from opencollab.bootstrap import (
+    _workflow_runtime_session as workflow_session,
+)
 from opencollab.bootstrap import (
     workflow_runtime,
 )
@@ -108,3 +112,49 @@ async def test_bootstrap_preserves_inner_timeout(monkeypatch):
             deadline_monotonic=asyncio.get_running_loop().time() + 1,
         )
     assert captured.value is inner
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_deadline_preserves_finalized_session_metrics(
+    monkeypatch,
+    tmp_path,
+):
+    session_finished = asyncio.Event()
+
+    async def wait_after_session(owner, *, timeout):
+        await asyncio.wait_for(session_finished.wait(), timeout=1)
+        return set(), {owner}
+
+    monkeypatch.setattr(workflow_runtime, "_wait_for_owner", wait_after_session)
+
+    def fake_build_session(*, agent, **_kwargs):
+        session = _FakeSession(agent, agent.tools)
+        session.used_tokens = 8
+        session.step_count = 4
+        session.markup_recovered = 2
+        return session
+
+    monkeypatch.setattr(workflow_session, "build_session", fake_build_session)
+
+    async def one_then_block(ctx, _args):
+        await ctx.agent("one")
+        session_finished.set()
+        await asyncio.Event().wait()
+
+    with pytest.raises(workflow_runtime.WorkflowDeadlineExceeded) as caught:
+        await workflow_runtime.run_workflow(
+            one_then_block,
+            {},
+            cfg=_cfg(),
+            workspace=str(tmp_path),
+            deadline_monotonic=asyncio.get_running_loop().time() + 10,
+            cleanup_timeout=0.2,
+            return_details=True,
+        )
+
+    details = caught.value.result
+    assert details is not None
+    assert details.tokens == 8
+    assert details.sessions == 1
+    assert details.steps == 4
+    assert details.markup_recovered == 2

--- a/tests/workflow_context_test_support.py
+++ b/tests/workflow_context_test_support.py
@@ -202,4 +202,6 @@ class FakeProbe:
         return self._changed
 
     async def diff(self) -> str:
+        if self._boom:
+            raise RuntimeError("git unavailable")
         return "diff"

--- a/tests/workflow_runtime_test_support.py
+++ b/tests/workflow_runtime_test_support.py
@@ -28,6 +28,8 @@ class _FakeSession:
         self.agent = agent
         self.tools = tools
         self.used_tokens = 0
+        self.step_count = 0
+        self.markup_recovered = 0
         self.prompt: str | None = None
 
     async def add_user_message(self, content: str) -> None:


### PR DESCRIPTION
## 为什么需要这个 PR

OpenCollab-Eval 从框架仓库拆出后，真实联动暴露出 OpenCollab 0.4 公共接口的缺口。外部消费者若要配置模型、构造工具、选择执行环境、运行工作流并取得终态证据，只能读取私有 Bootstrap 路径和具体 Adapter，或者在外部仓库重复实现生命周期逻辑。两种方式都会让外部项目绑定内部目录结构，也会让运行与清理语义在两个仓库间逐渐分叉。

这个 PR 为 OpenCollab 建立紧凑的公共能力边界。跨仓消费者只依赖 `opencollab` 公开模块即可完成运行时配置、工具构造、环境选择、Agent 执行和工作流执行。内部 Adapter 仍由 Bootstrap 组合，外部项目无需了解具体实现路径。

## 为什么这些修改属于 OpenCollab

模型配置快照、工具工厂、环境生命周期、工作流上下文、运行结果和静止证据都是通用框架能力。任何使用 OpenCollab SDK 的程序都需要这些契约，因此由 OpenCollab 提供并维护更合适。

数据集读取、SWE 任务身份、候选补丁构造、Docker official harness、测试证据和 resolved 报告继续由 OpenCollab-Eval 负责。这个 PR 没有加入 SWE-bench 题目、评测调度、候选提取或实验报告代码。

## 主要改动

公共配置现在提供深拷贝的 `thinking_params` 和脱敏后的 `base_url_sha256`，API key 与原始 base URL 不会进入公开快照。公共工具模块提供 `builtin_tools`、`coding_toolset` 和窄 `VerificationTool` 协议，调用方可以组合框架工具而无需导入私有注册表。

公共环境模块提供 Local、Worktree 和基于镜像的 Docker 工厂。`EnvironmentPort.setup()` 成为稳定契约，三类环境使用一致签名。Worktree 对不支持的挂载参数明确报错，避免调用方依赖具体 Adapter 的偶然行为。

Agent 与 workflow 支持步数限制、系统提示、清理超时和证据目录。运行结果保留步骤数、会话数、令牌量、markup 恢复情况和净化后的子代理失败信息。工作流上下文公开 diff 与预算观测能力，外部工作流可以基于真实执行状态作出决定。

终态证据覆盖成功、执行失败、预算停止、超时和取消。`workflow.json` 记录 `status`、`reason`、`failure_type` 与 `evidence_complete`。清理、manifest 或 trace 持久化失败会通过公共 `RunError` 失败，避免把缺失证据的执行包装成普通业务失败。

## 评审发现与修正

独立审查发现，调用方注入的 Environment 由调用方持有，OpenCollab 没有执行环境清理，却曾把 `cleanup_quiesced` 和 `execution_quiesced` 固定记为真。现在证据拆成 `session_quiesced`、`environment_owned`、`environment_cleanup_quiesced` 和 `environment_quiesced`。聚合字段只有在完整证据成立时为真，调用方持有环境且缺少清理证明时为 `None`。

工作流失败但已经产生 artifact 时曾缺少 `workflow.json`，同时结果仍可能声称证据完整。现在所有可验证终态都会在清理成功后写入 manifest，证据写入或清理失败直接进入技术失败。

早期公共 `WorkflowContext` 协议带入了 `enforcement_strength`、`commit_reserve` 和 `harvest_fallback` 等评测策略参数。它们已经从稳定公共协议移除，具体运行时仍可在内部使用，公共边界只保留通用工作流能力。

Security 检查还发现测试中的审计假密钥因新增导入移动了行号。最终提交通过格式化减少两行，让假密钥保持在已审计位置，无需修改 `.secrets.baseline`。随后重写最后两个 PR 提交，使每一个可达提交都通过逐提交凭据扫描。重写前后的源码 tree 完全一致。

## 改动规模

相对 `main` 共修改 29 个文件，增加 1340 行，删除 90 行。新增内容中有 655 行测试，占 48.9%。公开源码新增 599 行，README 与 CHANGELOG 新增 86 行。测试覆盖公共 API、真实 Bootstrap 委托、环境所有权、终态 manifest、超时、预算停止、证据失败和兼容行为。

## 验证证据

OpenCollab 全仓 Ruff 通过，`git diff --check` 通过，完整测试为 `1444 passed`。与 CI 相同的逐提交凭据历史扫描通过。

使用当前 OpenCollab 与 OpenCollab-Eval 构建的两个 wheel 完成隔离契约验证，结果为 `2041 passed, 14 skipped`。确定性端到端测试真实经历源码同步、模型 HTTP、Agent 修改、候选补丁提取、身份绑定和 official eval，终态为 `resolved=1`、`unresolved=0`、`technical_failed=0`。候选补丁 SHA-256 为 `1ea2efd402436befc7d74f66f1fd6c02fd7f4129d16b1134742cc1696dec857f`。

GitHub Actions 在 head `7a2612e658d0c452b34fe20f980f139b845a591b` 上全部通过。覆盖 Security、Python 3.10 至 3.14、发行包、macOS 路径、Conventional Commit 标题和新增文件卫生检查。

独立只读 Reviewer 对最终源码 tree 给出 APPROVE。审查范围覆盖公共依赖边界、调用方环境所有权、假静止证据、终态 manifest、重复生命周期实现、测试覆盖和跨仓 wheel 兼容性。PR 继续保持 Draft，后续批准与合并由维护者完成。
