### PR TITLE
fix(llm): 登记 Kimi K3 模型能力

### DIFF
--- a/opencollab/adapters/llm/types.py
+++ b/opencollab/adapters/llm/types.py
@@ -107,6 +107,11 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
 }
 
 _EXACT_MODEL_CAPABILITIES: dict[str, ModelCapabilities] = {
+    "k3": ModelCapabilities(
+        context_window=1_048_576,
+        supports_forced_tool_choice=False,
+        honors_workflow_thinking_override=False,
+    ),
     "kimi-for-coding": ModelCapabilities(
         context_window=262_144,
         supports_forced_tool_choice=False,

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -273,9 +273,10 @@ def test_openai_tool_choice_required_is_passed_through():
         (False, {"type": "function", "function": {"name": "structured_output"}}),
     ],
 )
-def test_openai_kimi_uses_auto_for_unsupported_forced_tool_choice(thinking, tool_choice):
+@pytest.mark.parametrize("model", ["k3", "kimi-for-coding"])
+def test_openai_kimi_uses_auto_for_unsupported_forced_tool_choice(thinking, tool_choice, model):
     kwargs = build_openai_kwargs(
-        "kimi-for-coding",
+        model,
         [{"role": "user", "content": "write the final patch"}],
         [{"type": "function", "function": {"name": "write_file", "parameters": {}}}],
         1.0,
@@ -314,10 +315,14 @@ def test_openai_other_model_keeps_named_tool_choice():
     assert kwargs["tool_choice"] == choice
 
 
-def test_exact_model_capabilities_centralize_provider_compatibility():
-    capabilities = model_capabilities("kimi-for-coding")
+@pytest.mark.parametrize(
+    ("model", "context_window"),
+    [("k3", 1_048_576), ("kimi-for-coding", 262_144)],
+)
+def test_exact_model_capabilities_centralize_provider_compatibility(model, context_window):
+    capabilities = model_capabilities(model)
 
-    assert capabilities.context_window == 262_144
+    assert capabilities.context_window == context_window
     assert capabilities.supports_forced_tool_choice is False
     assert capabilities.honors_workflow_thinking_override is False
 

--- a/tests/test_tool_output_clear_shaper.py
+++ b/tests/test_tool_output_clear_shaper.py
@@ -148,8 +148,9 @@ def test_model_context_window_lookup_matches_by_substring():
     assert model_context_window("gpt-4o-mini") == 128_000
     assert model_context_window("deepseek-chat") == 64_000
     assert model_context_window("glm-5.2") == 400_000
+    assert model_context_window("k3") == 1_048_576
     assert model_context_window("kimi-for-coding") == 262_144
-    for near_miss in ("kimi-k2.6", "kimi-k2.70", "kimi-for-coding-preview"):
+    for near_miss in ("k3-256k", "kimi-k3", "kimi-k2.6", "kimi-k2.70", "kimi-for-coding-preview"):
         assert model_context_window(near_miss) is None
     assert model_context_window("some-unknown-model") is None
     assert model_context_window(None) is None

--- a/tests/test_workflow_runtime.py
+++ b/tests/test_workflow_runtime.py
@@ -87,10 +87,11 @@ async def test_built_context_threads_session_limits_and_system_prompt(monkeypatc
     ]
 
 @pytest.mark.asyncio
-async def test_kimi_global_thinking_applies_to_fast_structured_roles(monkeypatch):
+@pytest.mark.parametrize("model", ["k3", "kimi-for-coding"])
+async def test_kimi_global_thinking_applies_to_fast_structured_roles(monkeypatch, model):
     calls = _patch_build_session(monkeypatch)
     ctx = workflow_runtime.build_workflow_context(
-        cfg=_cfg(model="kimi-for-coding", provider="openai", thinking=True)
+        cfg=_cfg(model=model, provider="openai", thinking=True)
     )
 
     await ctx.agent("solve", thinking=False)


### PR DESCRIPTION
## 背景

OpenCollab-Eval 已增加 Kimi K3 的 G11 固定评测配置。评测层会把运行身份记录为 `k3` 与 1048576 token 上下文。OpenCollab 当前没有登记这一精确模型标识，因此会把它当成未知模型，并采用默认的历史压缩阈值。报告中的百万上下文配置与 Agent 实际使用能力由此出现偏差。

## 修改内容

这次修改只扩展 OpenCollab 的精确模型能力表。`k3` 的上下文窗口登记为 1048576 token。它与现有 `kimi-for-coding` 使用相同的提供商兼容行为，工作流中的快速结构化角色无法关闭全局 thinking，Kimi 不支持的 required 或命名工具选择会降级为 auto。

精确匹配继续生效。`k3-256k`、`kimi-k3` 等相邻名称不会继承 `k3` 的能力，未知模型仍使用中性默认值。现有 `kimi-for-coding` 的 262144 token 上下文和工具调用行为保持不变。

## 测试证据

新增与扩展的回归测试覆盖 K3 上下文识别、相邻模型拒绝、全局 thinking 保留、required 工具选择和命名工具选择降级，同时复用同一组测试继续验证 `kimi-for-coding`。

Ruff 全仓检查通过。

完整 pytest 通过，共 1449 项。

## 跨仓关系

OpenCollab-Eval 的 K3 G11 配置会固定使用包含此修复的 OpenCollab 源码树，并在模型调用前核验本地与远端运行时摘要。这个 PR 只提供模型能力元数据，不包含评测任务、实验结果或凭据。

等待项目成员审查。请勿自动批准或合并。
