### PR TITLE
docs: 指引 OpenCollab-Eval 使用文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ for a complete module.
 
 ## Learn more
 
+For benchmark execution and reporting, use
+the [OpenCollab-Eval README](https://github.com/RISE-X-Lab/OpenCollab-Eval#readme),
+which contains installation, command, and official-evaluation instructions.
+
 | You want… | Read |
 | --- | --- |
 | Installation, CLI, SDK, architecture, and runtime details | [Package guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/opencollab/README.md) |

--- a/tests/test_public_readiness.py
+++ b/tests/test_public_readiness.py
@@ -59,8 +59,12 @@ def _public_text_files() -> list[Path]:
 
 def test_public_text_is_english_and_uses_canonical_project_names() -> None:
     stale_owner = "Yihong" + "Dong/OpenCollab"
-    unpublished_eval = "OpenCollab" + "-Eval"
-    forbidden = (stale_owner, unpublished_eval)
+    eval_name = "OpenCollab" + "-Eval"
+    forbidden = (
+        stale_owner,
+        f"KaiEureka/{eval_name}",
+        f"YihongDong/{eval_name}",
+    )
     findings: list[str] = []
 
     for path in _public_text_files():
@@ -74,6 +78,14 @@ def test_public_text_is_english_and_uses_canonical_project_names() -> None:
                     findings.append(f"{relative}:{line_number}: stale public name {value!r}")
 
     assert not findings, "\n".join(findings)
+
+
+def test_readme_points_to_the_canonical_evaluation_guide() -> None:
+    readme = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    eval_name = "OpenCollab" + "-Eval"
+    canonical = f"https://github.com/RISE-X-Lab/{eval_name}#readme"
+
+    assert f"[{eval_name} README]({canonical})" in readme
 
 
 def test_distribution_metadata_points_to_the_canonical_repository() -> None:


### PR DESCRIPTION
## 改动说明

在 OpenCollab README 的 Learn more 区域增加一段简短说明，引导需要运行基准评测和生成报告的用户前往团队仓库 OpenCollab-Eval。链接直接定位到 OCE README，其中包含安装方式、命令说明和官方评测流程。

同步更新公开准备门禁。门禁现在拒绝个人仓库中的旧 OCE 地址，并要求 OC README 使用 RISE-X-Lab/OpenCollab-Eval 的规范链接。

## 验证结果

Ruff 全量检查通过。文档与公开准备相关测试 16 项通过。完整测试 1450 项通过。

## 合并条件

OpenCollab-Eval 当前仍为 private。请在 OCE 转为 public、匿名访问链接确认正常后，再将本 PR 转为可审状态。此 PR 未批准、未合并。