### PR TITLE
fix(llm): bound structured correction retry time

### DIFF
--- a/opencollab/application/workflow_structured.py
+++ b/opencollab/application/workflow_structured.py
@@ -41,6 +41,11 @@ _STRUCTURED_RETRY = (
     "required schema. Do not explore further or answer in prose."
 )
 
+# The corrective session has one tool and no exploration responsibility. Give
+# it enough time for one reasoning turn without letting an endpoint that
+# degrades forced tool choice to ``auto`` consume the caller's full role budget.
+DEFAULT_STRUCTURED_RETRY_TIMEOUT_SECONDS = 60.0
+
 
 def _named_tool_choice(tool_name: str) -> dict[str, Any]:
     """OpenAI-style named-function ``tool_choice`` forcing exactly ``tool_name``.
@@ -74,6 +79,12 @@ def _schema_satisfied(captured: Any, schema: dict[str, Any]) -> bool:
         # captured dict (even ``{}``) is an accepted commit, not a miss.
         return True
     return all(key in captured for key in required)
+
+
+def _structured_retry_timeout(remaining: float | None) -> float:
+    if remaining is None:
+        return DEFAULT_STRUCTURED_RETRY_TIMEOUT_SECONDS
+    return min(remaining, DEFAULT_STRUCTURED_RETRY_TIMEOUT_SECONDS)
 
 
 class WorkflowStructuredMixin:
@@ -165,7 +176,9 @@ class WorkflowStructuredMixin:
         # passes; the first session is handed in so its exploration history is
         # carried into the corrective turn.
         try:
-            retry_timeout = self._remaining_timeout(deadline)
+            retry_timeout = _structured_retry_timeout(
+                self._remaining_timeout(deadline)
+            )
         except CallerTimeoutError:
             await self.log(
                 f"structured agent timed out ({label or 'agent'}) after {timeout}s"

--- a/tests/test_workflow_context.py
+++ b/tests/test_workflow_context.py
@@ -14,6 +14,7 @@ from workflow_context_test_support import (
 )
 
 import opencollab.application.workflow as workflow_module
+import opencollab.application.workflow_structured as workflow_structured_module
 from opencollab.application.session_run import ENFORCEMENT_ON
 from opencollab.application.workflow import (
     WorkflowContext,
@@ -364,6 +365,36 @@ async def test_structured_agent_timeout_bounds_forced_retry_and_returns_none():
             "properties": {"verdict": {"type": "string"}},
         },
         timeout=0.01,
+    )
+
+    assert result is None
+    assert any("structured retry timed out" in e.message for e in sink.events)
+
+
+@pytest.mark.asyncio
+async def test_structured_retry_has_independent_short_deadline(monkeypatch):
+    first = FakeSession(reply="prose instead of structured output")
+    gate = asyncio.Event()
+    retry = FakeSession(reply="ok", gate=gate)
+    sink = RecordingSink()
+    ctx = WorkflowContext(FakeFactory([first, retry]), event_sink=sink)
+    monkeypatch.setattr(
+        workflow_structured_module,
+        "DEFAULT_STRUCTURED_RETRY_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    result = await asyncio.wait_for(
+        ctx.agent(
+            "needs structured",
+            schema={
+                "type": "object",
+                "required": ["verdict"],
+                "properties": {"verdict": {"type": "string"}},
+            },
+            timeout=10.0,
+        ),
+        timeout=0.5,
     )
 
     assert result is None


### PR DESCRIPTION
## 问题

K3 会拒绝强制命名的 structured_output 工具选择，并回退为自动工具选择。原实现让纠正会话继续使用角色剩余的完整时限，评测中的每个结构化角色因此可能额外等待五分钟。OpenCollab-Eval 同时可能同步到缺少 K3 能力声明的旧版 0.4.0，进一步放大该问题。

## 修改

结构化纠正会话现在拥有独立的六十秒上限，同时仍受调用方剩余时限约束。SDK 版本提升为 0.4.1，供评测仓库建立准确的最低兼容门禁。新增确定性异步测试，验证调用方时限很长时，纠正会话仍会在短时限内退出。

## 验证

Ruff 全仓检查通过。完整 pytest 通过。结构化输出、模型能力、SDK 与发布元数据相关的 159 项聚焦测试通过。已构建 opencollab-0.4.1 wheel，并验证安装后的 K3 能力为 1048576 上下文且不强制 named tool choice。

该 PR 等待人工审查，未执行批准或合并。