### PR TITLE
docs: humanize public documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to OpenCollab
 
-This guide covers the development environment, required checks, and dependency
-rule for OpenCollab contributions.
+This guide explains how to prepare a development environment and submit changes
+that satisfy OpenCollab's checks and dependency rule.
 
 ## Project layout
 
@@ -90,4 +90,5 @@ documentation changes.
 ## Reporting issues
 
 - Functional bugs and feature requests: open a GitHub issue using the templates.
-- Report security vulnerabilities privately through [SECURITY.md](SECURITY.md).
+- Security vulnerabilities must not be reported in a public issue. Use the
+  private process in [SECURITY.md](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,34 @@
 # Contributing to OpenCollab
 
-Thanks for your interest in improving OpenCollab! This guide covers how to set
-up a development environment, the checks your change must pass, and the one
-architectural rule the codebase enforces.
+This guide covers the development environment, required checks, and dependency
+rule for OpenCollab contributions.
 
 ## Project layout
 
-OpenCollab follows a strict clean architecture — dependencies point inward only:
+OpenCollab follows strict clean architecture. Dependencies point inward.
 
 ```
 adapters  →  application  →  domain
 ```
 
-- `opencollab/domain/` — pure value objects + the session FSM. Standard library only, no I/O.
-- `opencollab/application/` — use cases, scheduler, ports (`application/ports.py`). Imports `domain` + stdlib only.
-- `opencollab/adapters/` — concrete implementations: `cli/`, `tui/`, `llm/`, `tools/`, environments, tracing, session store.
-- `opencollab/bootstrap/` — composition root; the only layer that knows concrete types.
-- `opencollab/sdk/` — the versioned boundary for external workflow and evaluation packages.
-- `scripts/` — framework launchers and provider diagnostics.
+- `opencollab/domain/` contains pure value objects and the session FSM. It uses the standard library and performs no I/O.
+- `opencollab/application/` contains use cases, the scheduler, and ports in `application/ports.py`. It imports `domain` and the standard library.
+- `opencollab/adapters/` contains the CLI, TUI, LLM providers, tools, environments, tracing, and session store.
+- `opencollab/bootstrap/` is the composition root and the only layer that knows concrete types.
+- `opencollab/sdk/` is the versioned boundary for external workflow and evaluation packages.
+- `scripts/` contains framework launchers and provider diagnostics.
 
 ## Development setup
 
-OpenCollab uses [uv](https://docs.astral.sh/uv/). From the repository root:
+OpenCollab uses [uv](https://docs.astral.sh/uv/). Run the following command from
+the repository root.
 
 ```bash
 uv sync --extra dev            # create .venv with runtime + dev dependencies
 ```
 
-Copy the example config and point it at any OpenAI-compatible (or Anthropic)
-endpoint — **never commit real API keys**:
+Copy the example config and point it at an OpenAI-compatible or Anthropic
+endpoint. **Never commit real API keys.**
 
 ```bash
 cp configs/.env.example configs/.env   # then set OPENCOLLAB_API_KEY
@@ -45,14 +45,15 @@ New behavior needs tests, and the suite must stay green.
 
 ### Enforced automatically in CI
 
-- **Lint** — `ruff check .` over the whole repository; config lives in the
+- **Lint** runs `ruff check .` over the whole repository. Config lives in the
   repository-root `ruff.toml`.
-- **PR title** — must follow Conventional Commits; squash-merge uses it as the
+- **PR title** must follow Conventional Commits. Squash-merge uses it as the
   commit subject on `main`.
-- **File hygiene** — a newly added file over 500 KB, or a new `.py` module over
-  800 lines, fails the build. Commit `.tex`/`.md` sources, not compiled PDFs.
+- **File hygiene** rejects a newly added file over 500 KB or a new `.py` module over
+  800 lines. Commit `.tex`/`.md` sources, not compiled PDFs.
 
-Optionally mirror these locally: `pip install pre-commit && pre-commit install`.
+To run the same hooks locally, use
+`pip install pre-commit && pre-commit install`.
 
 ## The architecture rule (enforced by tests)
 
@@ -65,10 +66,10 @@ Optionally mirror these locally: `pip install pre-commit && pre-commit install`.
 
 ## Commits & pull requests
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) in English:
+- Use [Conventional Commits](https://www.conventionalcommits.org/) in English.
   `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
 - `refactor:` commits must stay behavior-preserving.
-- Keep pull requests focused; describe what changed and how you verified it.
+- Keep pull requests focused. Describe what changed and how you verified it.
 - Keep code, comments, tracked documentation, commit summaries, pull request
   titles, pull request descriptions, and review replies in English.
 
@@ -89,4 +90,4 @@ documentation changes.
 ## Reporting issues
 
 - Functional bugs and feature requests: open a GitHub issue using the templates.
-- Security vulnerabilities: **do not** open a public issue — see [SECURITY.md](SECURITY.md).
+- Report security vulnerabilities privately through [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <b>A Python framework for multi-agent teams and workflows.</b>
+  <b>An Operating Theory of Organized Intelligence.</b>
 </p>
 
 <p align="center">
@@ -34,12 +34,17 @@ OpenCollab supports two forms of collaboration on the same agent runtime.
 | **Team** | `opencollab [--team-config FILE] --workspace .` | A lead plans the work and spawns specialists that collaborate until the task is done. The agents decide the division of labor. |
 | **Workflow** | `opencollab workflow run NAME` | Python defines fan-out, pipeline, loop, and verification behavior while agents complete each step. |
 
-Experiments can replace each runtime component independently.
+Model access, context handling, tool execution, orchestration, and environments
+have separate extension points. An experiment can change one component at a
+time.
+
+New collaboration designs can reuse this runtime and live in a small team file
+and workflow.
 
 [Edict](https://github.com/cft0808/edict) implements the Three
 Departments and Six Ministries as a standalone system with roughly 24,000
-source lines. [Mini Edict](examples/mini-edict/) implements the same
-review-and-dispatch structure in 239 lines of team and workflow code on the
+source lines. [Mini Edict](examples/mini-edict/) implements Edict's core
+review-and-dispatch protocol in 239 lines of team and workflow code on the
 OpenCollab runtime. The example includes a bilingual guide and tests.
 
 ## Quick start
@@ -72,8 +77,8 @@ for a complete module.
 ## Evaluate with OpenCollab-Eval
 
 [OpenCollab-Eval](https://github.com/RISE-X-Lab/OpenCollab-Eval) is a downstream
-application built on OpenCollab's public Python API. It exercises the framework
-from outside this repository.
+application built on OpenCollab's public Python API. It exercises agents, teams,
+workflows, tools, and environments from outside this repository.
 
 OpenCollab-Eval runs agents on software-engineering benchmarks. It creates an
 isolated workspace for each task and records the Solver's patch. It then runs
@@ -81,8 +86,9 @@ the official tests and keeps the commands and reports needed to inspect the
 result. It currently supports SWE-bench Pro-Lite and provides a generic task
 runner for other evaluation workloads.
 
-OpenCollab-Eval owns benchmark execution and its experiment records. This
-repository contains the collaboration framework.
+Datasets, Docker integration, benchmark adapters, experiment reports, and their
+execution records live in OpenCollab-Eval. This repository contains the
+collaboration framework.
 
 The [evaluation guide](https://github.com/RISE-X-Lab/OpenCollab-Eval#supported-environment)
 explains how to run it. The [integrity guide](https://github.com/RISE-X-Lab/OpenCollab-Eval/blob/main/docs/evaluation-integrity.md)
@@ -92,19 +98,20 @@ records the boundary between the repositories.
 ## Documentation
 
 The [package guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/opencollab/README.md)
-covers installation and the Python API. The [configuration guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/configs/README.md)
-covers models and teams.
+covers installation, the CLI, the Python API, architecture, and runtime
+behavior. The [configuration guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/configs/README.md)
+covers providers, models, and teams.
 
 [Mini Edict](https://github.com/RISE-X-Lab/OpenCollab/tree/main/examples/mini-edict)
-is the smallest complete workflow example. The [skills guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/skills/README.md)
-and [scripts guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/scripts/README.md)
-cover the optional tools around it.
+shows a nine-role institutional workflow. The [skills guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/skills/README.md)
+documents on-demand instructions. The [scripts guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/scripts/README.md)
+documents launchers and provider diagnostics.
 
 Repository development is documented in [CONTRIBUTING.md](https://github.com/RISE-X-Lab/OpenCollab/blob/main/CONTRIBUTING.md).
 Maintainers can follow [RELEASING.md](https://github.com/RISE-X-Lab/OpenCollab/blob/main/RELEASING.md)
 when preparing a release.
 The [documentation index](https://github.com/RISE-X-Lab/OpenCollab/blob/main/docs/README.md)
-links the current design records. Benchmark users should begin with the
+links design records and research notes. Benchmark users should begin with the
 [OpenCollab-Eval README](https://github.com/RISE-X-Lab/OpenCollab-Eval#readme).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <b>An Operating Theory of Organized Intelligence.</b>
+  <b>A Python framework for multi-agent teams and workflows.</b>
 </p>
 
 <p align="center">
@@ -27,22 +27,20 @@
   </picture>
 </p>
 
-The same agent runtime supports two explicit forms of collaboration:
+OpenCollab supports two forms of collaboration on the same agent runtime.
 
 | Mode | Command | What it is |
 | --- | --- | --- |
 | **Team** | `opencollab [--team-config FILE] --workspace .` | A lead plans the work and spawns specialists that collaborate until the task is done. The agents decide the division of labor. |
-| **Workflow** | `opencollab workflow run NAME` | Python defines the control flow—fan-out, pipelines, loops, and verification gates—while agents complete each step. |
+| **Workflow** | `opencollab workflow run NAME` | Python defines fan-out, pipeline, loop, and verification behavior while agents complete each step. |
 
-OpenCollab keeps the model, context, tools, orchestration, and execution
-environment separable so experiments can change one component at a time.
+Experiments can replace each runtime component independently.
 
-OpenCollab turns new collaboration ideas into small protocols instead of new
-platforms. [Edict](https://github.com/cft0808/edict) implements the Three
+[Edict](https://github.com/cft0808/edict) implements the Three
 Departments and Six Ministries as a standalone system with roughly 24,000
-source lines. [Mini Edict](examples/mini-edict/) captures its core
-review-and-dispatch protocol in 239 lines of team and workflow code, packaged
-with its own bilingual guide and tests.
+source lines. [Mini Edict](examples/mini-edict/) implements the same
+review-and-dispatch structure in 239 lines of team and workflow code on the
+OpenCollab runtime. The example includes a bilingual guide and tests.
 
 ## Quick start
 
@@ -55,14 +53,14 @@ uv run opencollab --workspace .
 Point `configs/.env` at an OpenAI-compatible or Anthropic endpoint. The command
 starts with the built-in single `lead`, which may spawn ad-hoc specialists.
 Never commit real API keys. To use declared roles and a fixed topology, select a
-team file explicitly:
+team file explicitly.
 
 ```bash
 cp configs/team.example.yaml configs/team.yaml
 uv run opencollab --team-config configs/team.yaml --workspace .
 ```
 
-For repeatable pipelines, author a Python workflow and run it by name:
+For repeatable pipelines, author a Python workflow and run it by name.
 
 ```bash
 uv run opencollab workflow run NAME --args '{"task": "..."}'
@@ -73,39 +71,41 @@ for a complete module.
 
 ## Evaluate with OpenCollab-Eval
 
-[OpenCollab-Eval](https://github.com/RISE-X-Lab/OpenCollab-Eval) is a
-separate application built on OpenCollab's public Python API. It gives
-OpenCollab a real downstream user, so changes to agents, teams, workflows,
-tools, and environments can be exercised outside this repository.
+[OpenCollab-Eval](https://github.com/RISE-X-Lab/OpenCollab-Eval) is a downstream
+application built on OpenCollab's public Python API. It exercises the framework
+from outside this repository.
 
 OpenCollab-Eval runs agents on software-engineering benchmarks. It creates an
-isolated workspace for each task, records the Solver's patch, runs the official
-tests against that patch, and keeps the commands and reports needed to inspect
-the result. It currently supports SWE-bench Pro-Lite and also provides a
-generic task runner for other evaluation workloads.
+isolated workspace for each task and records the Solver's patch. It then runs
+the official tests and keeps the commands and reports needed to inspect the
+result. It currently supports SWE-bench Pro-Lite and provides a generic task
+runner for other evaluation workloads.
 
-Datasets, Docker integration, benchmark adapters, and experiment reports live
-in OpenCollab-Eval. Keeping them there lets this repository stay focused on
-agent collaboration while OpenCollab-Eval handles experiment operation and
-result checking.
+OpenCollab-Eval owns benchmark execution and its experiment records. This
+repository contains the collaboration framework.
 
-[Run an evaluation](https://github.com/RISE-X-Lab/OpenCollab-Eval#supported-environment)
-· [See how results are checked](https://github.com/RISE-X-Lab/OpenCollab-Eval/blob/main/docs/evaluation-integrity.md)
-· [Read the repository boundary](https://github.com/RISE-X-Lab/OpenCollab-Eval/blob/main/MIGRATION.md)
+The [evaluation guide](https://github.com/RISE-X-Lab/OpenCollab-Eval#supported-environment)
+explains how to run it. The [integrity guide](https://github.com/RISE-X-Lab/OpenCollab-Eval/blob/main/docs/evaluation-integrity.md)
+explains how results are checked. [MIGRATION.md](https://github.com/RISE-X-Lab/OpenCollab-Eval/blob/main/MIGRATION.md)
+records the boundary between the repositories.
 
-## Learn more
+## Documentation
 
-| You want… | Read |
-| --- | --- |
-| Benchmark execution and verified reports | [OpenCollab-Eval README](https://github.com/RISE-X-Lab/OpenCollab-Eval#readme) |
-| Installation, CLI, SDK, architecture, and runtime details | [Package guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/opencollab/README.md) |
-| Model, provider, and team configuration | [Configuration guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/configs/README.md) |
-| A nine-role institution in one small workflow | [Mini Edict](https://github.com/RISE-X-Lab/OpenCollab/tree/main/examples/mini-edict) |
-| On-demand agent skills | [Skills guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/skills/README.md) |
-| Launchers and provider diagnostics | [Scripts guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/scripts/README.md) |
-| Contribution and development checks | [Contributing](https://github.com/RISE-X-Lab/OpenCollab/blob/main/CONTRIBUTING.md) |
-| Maintainer release procedure | [Releasing](https://github.com/RISE-X-Lab/OpenCollab/blob/main/RELEASING.md) |
-| Design records and research notes | [Documentation index](https://github.com/RISE-X-Lab/OpenCollab/blob/main/docs/README.md) |
+The [package guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/opencollab/README.md)
+covers installation and the Python API. The [configuration guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/configs/README.md)
+covers models and teams.
+
+[Mini Edict](https://github.com/RISE-X-Lab/OpenCollab/tree/main/examples/mini-edict)
+is the smallest complete workflow example. The [skills guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/skills/README.md)
+and [scripts guide](https://github.com/RISE-X-Lab/OpenCollab/blob/main/scripts/README.md)
+cover the optional tools around it.
+
+Repository development is documented in [CONTRIBUTING.md](https://github.com/RISE-X-Lab/OpenCollab/blob/main/CONTRIBUTING.md).
+Maintainers can follow [RELEASING.md](https://github.com/RISE-X-Lab/OpenCollab/blob/main/RELEASING.md)
+when preparing a release.
+The [documentation index](https://github.com/RISE-X-Lab/OpenCollab/blob/main/docs/README.md)
+links the current design records. Benchmark users should begin with the
+[OpenCollab-Eval README](https://github.com/RISE-X-Lab/OpenCollab-Eval#readme).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,16 @@
 
 ## Reporting a vulnerability
 
-Report suspected security vulnerabilities **privately** through GitHub's
+Do not open a public issue for a suspected vulnerability. Report it privately
+through GitHub's
 [Report a vulnerability](https://github.com/RISE-X-Lab/OpenCollab/security/advisories/new)
 (Security Advisories). We aim to acknowledge reports within 72 hours.
 
 ## Risk surface
 
-OpenCollab runs LLM-generated code and shell/tool calls against a real
-repository, uses provider API keys, and can drive Docker containers. Treat it
-as code execution and use these precautions.
+OpenCollab can run LLM-generated code and tool calls against a real repository.
+It also handles provider credentials and Docker containers. Treat it as code
+execution and use these precautions.
 
 - Run untrusted or benchmark tasks only in an **isolated, disposable
   environment** (container or VM), never against sensitive systems.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,7 @@
 
 ## Reporting a vulnerability
 
-Please report suspected security vulnerabilities **privately** — do not open a
-public issue. Use GitHub's
+Report suspected security vulnerabilities **privately** through GitHub's
 [Report a vulnerability](https://github.com/RISE-X-Lab/OpenCollab/security/advisories/new)
 (Security Advisories). We aim to acknowledge reports within 72 hours.
 
@@ -11,15 +10,15 @@ public issue. Use GitHub's
 
 OpenCollab runs LLM-generated code and shell/tool calls against a real
 repository, uses provider API keys, and can drive Docker containers. Treat it
-accordingly:
+as code execution and use these precautions.
 
 - Run untrusted or benchmark tasks only in an **isolated, disposable
   environment** (container or VM), never against sensitive systems.
 - Keep credentials in `configs/.env` (gitignored). **Never commit real API
-  keys** — see `configs/.env.example`.
+  keys.** See `configs/.env.example`.
 - Review an agent's tool permissions before granting broad filesystem or shell
   access.
 
 ## Supported versions
 
-OpenCollab is pre-1.0; security fixes land on `main`.
+OpenCollab is pre-1.0. Security fixes land on `main`.

--- a/assets/README.md
+++ b/assets/README.md
@@ -8,6 +8,11 @@ The OpenCollab mark has five nodes on a pentagon ring joined by open arc
 segments. The equal-width gradient ring has a circular notch at each node and a
 dot in the center of each notch.
 
+The ring represents collaboration without a permanent central role. Its open
+segments reflect control moving between roles. The full mark depicts
+intelligence emerging from the organization. The official tagline is *An
+Operating Theory of Organized Intelligence.*
+
 ## Files
 
 The SVG assets contain their gradients, masks, and text paths within each file.
@@ -27,8 +32,8 @@ generated brand board converts that copy to paths.
 | [`app-icon.svg`](app-icon.svg) | Mark on a dark rounded square (512×512) | App or launcher icon on any theme |
 | [`app-icon-mono.svg`](app-icon-mono.svg) | Monochrome rounded-square icon | One-colour app icon |
 | [`favicon.svg`](favicon.svg) | Tightly cropped mark | Favicon / 16–32 px tabs |
-| [`brand-guidelines.svg`](brand-guidelines.svg) | Brand board with construction, colour, clear space, sizing, mono, and application guidance | Reference |
-| [`brand-guidelines.svg.in`](brand-guidelines.svg.in) | Editable brand-board template | Regeneration input only |
+| [`brand-guidelines.svg`](brand-guidelines.svg) | Authoritative brand board with construction and usage guidance | Reference |
+| [`brand-guidelines.svg.in`](brand-guidelines.svg.in) | Source for mark geometry and board copy | Regeneration input only |
 
 ## Colour
 
@@ -49,7 +54,7 @@ The five node dots use colors sampled along the gradient (`#713AED`, `#2A53EB`,
 | Clear space | Keep at least one node diameter (*x*) of empty space on all four sides of the mark. |
 | Minimum size | Use the full-detail mark at about 48 px or larger. At 32 px and below, use the simplified `favicon` crop. |
 | Background | The gradient `mark`, `banner-dark`, and `app-icon` work across themes. Use dark-ink lockups on light backgrounds and `mark-mono-white` on dark backgrounds. |
-| Alterations | Use the supplied gradient, proportions, orientation, and stroke treatment. Keep enough contrast with the background. |
+| Alterations | Keep the supplied gradient, proportions, orientation, and stroke treatment. Do not recolour, stretch, rotate, add shadows or outlines, or use a low-contrast mark on a busy background. |
 
 <p align="center">
   <img src="mark.svg" alt="mark" width="88">
@@ -90,7 +95,7 @@ Liberation Sans is licensed under the **SIL Open Font License 1.1**. Its
 copyright notice and complete license are retained in
 [`LICENSES/LiberationSans-OFL-1.1.txt`](LICENSES/LiberationSans-OFL-1.1.txt).
 Generation uses the font binaries as inputs. The repository stores the
-generated lockups as vector outlines.
+generated lockups as vector outlines and does not store the font binaries.
 
 Regenerate with the pinned path converter.
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -4,39 +4,30 @@
 
 # Brand assets
 
-The OpenCollab mark is **five nodes on a pentagon ring, joined by open arc
-segments** — an equal-width gradient ring with a circular notch bitten out at
-each node, plus five center dots. It encodes how the framework works:
-
-- **Organization** — the ring is non-linear and decentralized; every role is
-  interconnected, none is the hub.
-- **Control** — authority is not fixed to one node; it flows around the ring
-  as collaborators exchange ownership of the work.
-- **Emergence** — intelligence comes from the whole ring, not any single dot.
-
-> *An Operating Theory of Organized Intelligence — organization shapes intelligence.*
+The OpenCollab mark has five nodes on a pentagon ring joined by open arc
+segments. The equal-width gradient ring has a circular notch at each node and a
+dot in the center of each notch.
 
 ## Files
 
-The deployment-ready assets are self-contained SVG (inline gradients, masks,
-and text paths; no external resources), so they render consistently in places
-such as GitHub Markdown. The brand-board template keeps its explanatory copy as
-editable text; the generated brand board converts all of it to paths.
+The SVG assets contain their gradients, masks, and text paths within each file.
+The brand-board template keeps its explanatory copy as editable text. The
+generated brand board converts that copy to paths.
 
 | File | What it is | Use it on |
 |------|------------|-----------|
-| [`mark.svg`](mark.svg) | Primary mark — gradient ring + five dots, transparent background | Anywhere; theme-safe (no dark ink) |
+| [`mark.svg`](mark.svg) | Primary mark with a gradient ring, five dots, and a transparent background | Any theme |
 | [`mark-mono-black.svg`](mark-mono-black.svg) | Single-colour mark, black | Light backgrounds, one-colour print |
-| [`mark-mono-gray.svg`](mark-mono-gray.svg) | Single-colour mark, gray | Muted / secondary placements |
+| [`mark-mono-gray.svg`](mark-mono-gray.svg) | Single-colour mark, gray | Muted or secondary placements |
 | [`mark-mono-white.svg`](mark-mono-white.svg) | Single-colour mark, white | Dark backgrounds |
-| [`lockup-horizontal.svg`](lockup-horizontal.svg) | Mark + "OpenCollab" wordmark, side by side (dark ink) | **Light** backgrounds |
-| [`lockup-horizontal-tagline.svg`](lockup-horizontal-tagline.svg) | Horizontal lockup + tagline (dark ink) | **Light** backgrounds, hero placements |
+| [`lockup-horizontal.svg`](lockup-horizontal.svg) | Mark and "OpenCollab" wordmark side by side in dark ink | **Light** backgrounds |
+| [`lockup-horizontal-tagline.svg`](lockup-horizontal-tagline.svg) | Horizontal lockup and tagline in dark ink | **Light** backgrounds and hero placements |
 | [`lockup-stacked.svg`](lockup-stacked.svg) | Mark above the wordmark (dark ink) | **Light** backgrounds, square-ish space |
-| [`banner-dark.svg`](banner-dark.svg) | Mark + white wordmark on a dark rounded panel | README headers; theme-safe (own background) |
-| [`app-icon.svg`](app-icon.svg) | Mark on a dark rounded square (512×512) | App / launcher icon; theme-safe |
+| [`banner-dark.svg`](banner-dark.svg) | Mark and white wordmark on a dark rounded panel | README headers on any theme |
+| [`app-icon.svg`](app-icon.svg) | Mark on a dark rounded square (512×512) | App or launcher icon on any theme |
 | [`app-icon-mono.svg`](app-icon-mono.svg) | Monochrome rounded-square icon | One-colour app icon |
 | [`favicon.svg`](favicon.svg) | Tightly cropped mark | Favicon / 16–32 px tabs |
-| [`brand-guidelines.svg`](brand-guidelines.svg) | **Authoritative brand board** — construction, principles, colour, clear space, sizing, mono, applications | Reference / source of truth |
+| [`brand-guidelines.svg`](brand-guidelines.svg) | Brand board with construction, colour, clear space, sizing, mono, and application guidance | Reference |
 | [`brand-guidelines.svg.in`](brand-guidelines.svg.in) | Editable brand-board template | Regeneration input only |
 
 ## Colour
@@ -48,20 +39,17 @@ editable text; the generated brand board converts all of it to paths.
 | Ink / dark surface | `#0F172A` |
 | Light surface | `#E2E8F0` |
 
-The five node dots are sampled along the gradient (`#713AED`, `#2A53EB`,
-`#2563EB`, `#5556EC`, `#7C3AED`) so the ring reads as one continuous sweep.
+The five node dots use colors sampled along the gradient (`#713AED`, `#2A53EB`,
+`#2563EB`, `#5556EC`, `#7C3AED`).
 
 ## Usage
 
-- **Clear space** — keep at least one node-diameter (*x*) of empty space on all
-  four sides of the mark.
-- **Minimum size** — the full-detail mark holds down to ~48 px. At 32 px and
-  below, use the simplified / `favicon` crop.
-- **Pick by background** — gradient `mark` or `banner-dark`/`app-icon` (which
-  carry their own dark panel) are safe on any theme; the dark-ink lockups are
-  for light backgrounds; `mark-mono-white` is for dark backgrounds.
-- **Don't** — recolour the gradient, stretch or rotate the mark, add shadows or
-  outlines, or place a low-contrast variant on a busy background.
+| Requirement | Guidance |
+| --- | --- |
+| Clear space | Keep at least one node diameter (*x*) of empty space on all four sides of the mark. |
+| Minimum size | Use the full-detail mark at about 48 px or larger. At 32 px and below, use the simplified `favicon` crop. |
+| Background | The gradient `mark`, `banner-dark`, and `app-icon` work across themes. Use dark-ink lockups on light backgrounds and `mark-mono-white` on dark backgrounds. |
+| Alterations | Use the supplied gradient, proportions, orientation, and stroke treatment. Keep enough contrast with the background. |
 
 <p align="center">
   <img src="mark.svg" alt="mark" width="88">
@@ -71,17 +59,16 @@ The five node dots are sampled along the gradient (`#713AED`, `#2A53EB`,
 
 ## Terminal splash
 
-The TUI uses a separate pulsing brand dot in
-[`opencollab/adapters/tui/brand_motion.py`](../opencollab/adapters/tui/brand_motion.py).
-It does not render these SVG files and is not generated by the SVG asset script.
+[`opencollab/adapters/tui/brand_motion.py`](../opencollab/adapters/tui/brand_motion.py)
+defines the TUI's pulsing brand dot separately from the SVG assets and their
+generator.
 
 ## Source & regeneration
 
-The source of truth for mark geometry and board copy is
-[`brand-guidelines.svg.in`](brand-guidelines.svg.in). The ring-width / radius is
+[`brand-guidelines.svg.in`](brand-guidelines.svg.in) contains the mark geometry
+and board copy. The ring-width / radius is
 about 0.19, node-radius / radius is about 0.28, and notch-radius / radius is
-about 0.38. The generator preserves that geometry and regenerates these
-products:
+about 0.38. The generator preserves that geometry and produces these files.
 
 - `banner-dark.svg`
 - `lockup-horizontal.svg`
@@ -92,7 +79,7 @@ products:
 The wordmark uses **Liberation Sans 2.1.5 Bold** and the tagline uses
 **Liberation Sans 2.1.5 Regular**. The inputs came from Debian package
 `fonts-liberation 1:2.1.5-3`, corresponding to the upstream
-[`liberation-fonts` 2.1.5 source](https://github.com/liberationfonts/liberation-fonts/tree/2.1.5):
+[`liberation-fonts` 2.1.5 source](https://github.com/liberationfonts/liberation-fonts/tree/2.1.5).
 
 | Input | SHA-256 |
 |-------|---------|
@@ -102,10 +89,10 @@ The wordmark uses **Liberation Sans 2.1.5 Bold** and the tagline uses
 Liberation Sans is licensed under the **SIL Open Font License 1.1**. Its
 copyright notice and complete license are retained in
 [`LICENSES/LiberationSans-OFL-1.1.txt`](LICENSES/LiberationSans-OFL-1.1.txt).
-The font binaries are generation inputs and are not stored in this repository;
-the generated lockups contain vector outlines only.
+Generation uses the font binaries as inputs. The repository stores the
+generated lockups as vector outlines.
 
-Regenerate with the pinned path converter:
+Regenerate with the pinned path converter.
 
 ```bash
 uv run --no-project --with "fonttools==4.59.2" \

--- a/configs/README.md
+++ b/configs/README.md
@@ -2,13 +2,13 @@
 
 Runtime configuration lives in this directory.
 
-Create `configs/.env` from the example:
+Create `configs/.env` from the example.
 
 ```bash
 cp configs/.env.example configs/.env
 ```
 
-OpenCollab loads config in this order:
+OpenCollab loads config in the following order.
 
 1. Process environment variables
 2. `configs/.env`
@@ -23,7 +23,7 @@ env file.
 OpenCollab supports OpenAI-compatible APIs through the OpenAI client path. Set
 `provider=openai` and a compatible `base_url` for those providers.
 
-Environment variable example:
+The environment variables can be set as follows.
 
 ```bash
 export OPENCOLLAB_PROVIDER=openai
@@ -33,7 +33,7 @@ export OPENCOLLAB_API_KEY=<your-api-key>
 export OPENCOLLAB_LLM_TIMEOUT=600
 ```
 
-Equivalent `configs/.env` values:
+The equivalent `configs/.env` values follow.
 
 ```dotenv
 OPENCOLLAB_PROVIDER=openai
@@ -50,20 +50,20 @@ preferred over generic API-key variables for DashScope base URLs.
 
 Compatibility differences are recorded in
 `opencollab.adapters.llm.types.model_capabilities` and consumed by the provider
-and workflow adapters. Generic runtime code does not branch on product names.
+and workflow adapters. Product-specific behavior stays in those adapters.
 
 | Exact model id | Context window | Forced tool choice | Per-role thinking override |
 | --- | ---: | --- | --- |
 | `kimi-for-coding` | 262,144 | Falls back to `auto` | Keeps global thinking enabled |
 
-Models without an exact entry use provider-neutral defaults and the
+Unlisted models use provider-neutral defaults and the
 best-effort context-window families in the same module.
 
 ## Sampling
 
 `OPENCOLLAB_TEMPERATURE` sets the LLM sampling temperature for every agent.
-It defaults to `0.2`; `0.0` is fully deterministic. The value must be in the
-range `0.0`–`2.0`.
+It defaults to `0.2`. A value of `0.0` is fully deterministic. The value must be
+in the range `0.0`–`2.0`.
 
 ```dotenv
 OPENCOLLAB_TEMPERATURE=0.2
@@ -71,7 +71,7 @@ OPENCOLLAB_TEMPERATURE=0.2
 
 A team file may override the temperature per role via a `temperature:` field on
 the role (see [Team](#team) below). A role that leaves it unset inherits this
-global value; a role override of `0.0` is honored (not treated as "unset").
+global value. A role value of `0.0` overrides the global setting.
 
 ## Display
 
@@ -79,11 +79,11 @@ The TUI retains a separate stream for every agent, starts on the Lead (agent 0),
 and switches focus with Tab/Shift+Tab both during a turn and at the main prompt.
 The prompt redraws the selected agent's complete history collected during the
 current TUI session without changing the current input buffer. The switch order
-includes configured roles marked `available`; their view stays empty until the
-role spawns, then follows the new live agent automatically.
+includes configured roles marked `available`. Their view stays empty until the
+role spawns and then follows the new live agent automatically.
 
-`OPENCOLLAB_FILTER_MESSAGES` remains accepted for compatibility, but no longer
-controls event retention or the selected-agent view. Both values are lossless.
+OpenCollab still accepts `OPENCOLLAB_FILTER_MESSAGES` for compatibility. Event
+retention and the selected-agent view are lossless for either value.
 
 ```dotenv
 OPENCOLLAB_FILTER_MESSAGES=true
@@ -91,33 +91,31 @@ OPENCOLLAB_FILTER_MESSAGES=true
 
 ## Team
 
-Define a multi-agent team — per-role prompts, model overrides, per-role
-`temperature:` overrides, tool allowlists, and a directed spawn/message
-topology — in a YAML file:
+Define a multi-agent team in a YAML file. The file can set role prompts, model
+and temperature overrides, tool allowlists, and the directed spawn and message
+topology.
 
 ```bash
 cp configs/team.example.yaml configs/team.yaml
 uv run opencollab --team-config configs/team.yaml --workspace .
 ```
 
-OpenCollab never discovers a team file by conventional filename. It selects a
-team only through one of these explicit inputs, in priority order:
+OpenCollab selects a team through these inputs, in priority order.
 
 1. CLI `--team-config /path/to/team.yaml` or SDK `team(config=...)`
 2. Process environment variable `OPENCOLLAB_TEAM_FILE=/path/to/team.yaml`
 3. The built-in single `lead` configuration
 
-Merely creating `configs/team.yaml` does not activate it. With no explicit team
-file, the built-in `lead` may still spawn any ad-hoc role. See
+Select `configs/team.yaml` through one of these inputs to activate it. With no
+selected team file, the built-in `lead` may spawn any ad-hoc role. See
 `team.example.yaml` for the schema (lead/analyst/coder/reviewer plus a
-`topology` graph). An explicitly selected file that is missing or unsafe fails
-fast instead of falling back to the built-in team.
+`topology` graph). A selected file that is missing or unsafe raises an error.
 
 ## Validation
 
 The final resolved configuration is validated by a Pydantic model. `budget`
-must be a positive integer; `llm_timeout` must be a positive number of seconds;
-`temperature` must be within `0.0`–`2.0`; blank `api_key` and `base_url` values
+must be a positive integer. `llm_timeout` must be a positive number of seconds.
+`temperature` must be within `0.0`–`2.0`. Blank `api_key` and `base_url` values
 are treated as unset.
 
 Do not commit `configs/.env` or any file containing real API keys.

--- a/configs/README.md
+++ b/configs/README.md
@@ -23,7 +23,7 @@ env file.
 OpenCollab supports OpenAI-compatible APIs through the OpenAI client path. Set
 `provider=openai` and a compatible `base_url` for those providers.
 
-The environment variables can be set as follows.
+Set the shell environment variables directly.
 
 ```bash
 export OPENCOLLAB_PROVIDER=openai
@@ -33,7 +33,7 @@ export OPENCOLLAB_API_KEY=<your-api-key>
 export OPENCOLLAB_LLM_TIMEOUT=600
 ```
 
-The equivalent `configs/.env` values follow.
+The same settings can be written to `configs/.env`.
 
 ```dotenv
 OPENCOLLAB_PROVIDER=openai
@@ -50,7 +50,7 @@ preferred over generic API-key variables for DashScope base URLs.
 
 Compatibility differences are recorded in
 `opencollab.adapters.llm.types.model_capabilities` and consumed by the provider
-and workflow adapters. Product-specific behavior stays in those adapters.
+and workflow adapters. Those adapters handle product-specific behavior.
 
 | Exact model id | Context window | Forced tool choice | Per-role thinking override |
 | --- | ---: | --- | --- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,19 +6,15 @@ API, and architecture boundary.
 
 ## Current documentation
 
-- [`sdk-0.4-explainer.html`](sdk-0.4-explainer.html) is the visual guide to the
-  compact SDK introduced for the 0.4 series.
-- [`../configs/README.md`](../configs/README.md) documents provider, model, and
-  team configuration.
-- [`../skills/README.md`](../skills/README.md) documents on-demand agent skills.
-- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) and
-  [`../SECURITY.md`](../SECURITY.md) cover contributions and vulnerability
-  reporting.
+The [SDK 0.4 visual guide](sdk-0.4-explainer.html) explains the public research
+interfaces. The [configuration guide](../configs/README.md) covers providers,
+models, and team files. The [skills guide](../skills/README.md) explains
+on-demand agent skills. Contribution checks and vulnerability reporting are in
+[CONTRIBUTING.md](../CONTRIBUTING.md) and [SECURITY.md](../SECURITY.md).
 
 ## Design records
 
-Dated Markdown files in this directory and `archive/` preserve design context.
-They are historical records, not current API contracts. Their branch names,
-line-number anchors, test counts, and implementation status may have drifted.
-Use the current source and tests when an old record disagrees with the package
-guide.
+Dated Markdown files in this directory and `archive/` record earlier design
+work. Their branch names, line-number anchors, test counts, and implementation
+status reflect the repository at the time of writing. The package guide,
+current source, and tests define current behavior.

--- a/docs/sdk-0.4-explainer.html
+++ b/docs/sdk-0.4-explainer.html
@@ -1,14 +1,14 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light">
   <meta name="theme-color" content="#eaf1f2">
-  <title>OpenCollab SDK 0.4 — A compact surface for topology research</title>
+  <title>OpenCollab SDK 0.4 | Research interfaces</title>
   <meta
     name="description"
-    content="OpenCollab topology research uses the compact SDK, while harness ablations use Clean Architecture through Bootstrap, Ports, and Adapters."
+    content="Use the OpenCollab SDK for topology experiments and Clean Architecture interfaces for implementation ablations."
   >
   <style>
     :root {
@@ -955,7 +955,7 @@
 
     .ownership {
       display: grid;
-      grid-template-rows: repeat(3, 1fr);
+      grid-template-rows: repeat(2, 1fr);
       color: var(--paper);
       background: var(--ink);
       border: 1px solid rgba(248, 251, 250, 0.24);
@@ -978,10 +978,6 @@
       color: var(--mint);
       font: 700 9px/1.4 var(--mono);
       letter-spacing: 0.1em;
-    }
-
-    .ownership-item:nth-child(3) span {
-      color: var(--coral);
     }
 
     .ownership-item strong {
@@ -1134,7 +1130,7 @@
       }
 
       .ownership {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(2, 1fr);
         grid-template-rows: 1fr;
       }
 
@@ -1347,19 +1343,19 @@
 
     <div class="hero-grid">
       <div class="hero-copy">
-        <p class="eyebrow">Choose the surface by research question</p>
+        <p class="eyebrow">Research interfaces</p>
         <h1>
-          <span>Study topology</span>
-          <span class="accent">with a compact SDK</span>
+          <span>Run topology experiments</span>
+          <span class="accent">with the OpenCollab SDK</span>
         </h1>
         <p class="hero-lede">
           Establish a baseline with <code>agent</code>, then study collaboration
-          control graphs with <code>team</code> and <code>workflow</code>. When the
-          question becomes an ablation of models, tools, or environments, enter
-          through Clean Architecture instead of expanding the SDK.
+          control graphs with <code>team</code> and <code>workflow</code>. Use
+          Clean Architecture interfaces for ablations of models, tools, or
+          environments.
         </p>
         <div class="hero-thesis">
-          <strong>CHOOSE THE RIGHT ENTRY</strong><br>
+          <strong>RESEARCH ENTRY POINTS</strong><br>
           topology → OpenCollab SDK<br>
           harness → Bootstrap + Ports + Adapters
         </div>
@@ -1368,7 +1364,7 @@
       <figure class="lens-board" aria-labelledby="board-title">
         <div class="board-head">
           <strong id="board-title">RESEARCH LENS BOARD / OC-04</strong>
-          <span>orthogonal questions · shared runtime</span>
+          <span>topology and implementation ablations</span>
         </div>
 
         <div class="lens-grid">
@@ -1387,10 +1383,6 @@
               <div>
                 <dt>CHOOSE</dt>
                 <dd>agent · team · workflow</dd>
-              </div>
-              <div>
-                <dt>RETURN</dt>
-                <dd>one RunResult envelope</dd>
               </div>
             </dl>
           </article>
@@ -1411,10 +1403,6 @@
                 <dt>CHANGE</dt>
                 <dd>one Adapter via one Port</dd>
               </div>
-              <div>
-                <dt>COMPOSE</dt>
-                <dd>Bootstrap binds treatment</dd>
-              </div>
             </dl>
           </article>
         </div>
@@ -1426,42 +1414,19 @@
         </div>
         <figcaption class="board-caption">
           <span>The research object determines the entry point</span>
-          <span>The SDK does not own harness assembly</span>
+          <span>Clean Architecture handles harness assembly</span>
         </figcaption>
       </figure>
     </div>
   </header>
 
   <main id="main">
-    <section class="view-index" aria-label="Overview of two research perspectives">
-      <div class="view-index-inner">
-        <div class="index-thesis">
-          <span>ONE DECISION</span>
-          <strong>Start by asking: what am I studying?</strong>
-        </div>
-        <div class="index-item">
-          <span>TOPOLOGY → SDK</span>
-          <div>
-            <strong>Run the control condition directly</strong>
-            <p>Agent baseline, dynamic team topology, or programmed workflow topology.</p>
-          </div>
-        </div>
-        <div class="index-item">
-          <span>HARNESS → CLEAN ARCHITECTURE</span>
-          <div>
-            <strong>Isolate an infrastructure variable</strong>
-            <p>Hold the control regime fixed and replace one Adapter through one Port.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <section class="research-section" id="topology">
       <div class="section-head">
         <div class="view-badge" aria-hidden="true">A</div>
         <div class="section-title">
           <p class="section-kicker">Topology research · SDK entry</p>
-          <h2>Three conditions, one call surface</h2>
+          <h2>A shared call surface for topology experiments</h2>
         </div>
         <p class="section-intro">
           Construct <code>OpenCollab</code> once, then choose the baseline, a
@@ -1517,15 +1482,8 @@
           <div class="ownership-item">
             <span>INIT</span>
             <div>
-              <strong>Construct once</strong>
-              <p><code>OpenCollab(".")</code> resolves the workspace and configuration once.</p>
-            </div>
-          </div>
-          <div class="ownership-item">
-            <span>SELECT</span>
-            <div>
-              <strong>The method is the condition</strong>
-              <p><code>agent</code>, <code>team</code>, and <code>workflow</code> state the control condition directly.</p>
+              <strong>Construct once, then select a condition</strong>
+              <p><code>OpenCollab(".")</code> resolves the workspace and configuration. The <code>agent</code>, <code>team</code>, and <code>workflow</code> methods select the control condition.</p>
             </div>
           </div>
           <div class="ownership-item">
@@ -1539,7 +1497,7 @@
       </div>
 
       <div class="public-surface">
-        <strong>COMPLETE EVERYDAY SURFACE</strong>
+        <strong>PUBLIC PACKAGE ROOT</strong>
         <div class="surface-names">
           <code>OpenCollab</code>
           <code>RunResult</code>
@@ -1611,8 +1569,7 @@
       <strong>Change the entry point when the research question changes</strong>
       <p>
         To ablate a model, tool, environment, or context strategy, hold the
-        control condition fixed and move through Bootstrap, Ports, and Adapters
-        instead of adding more SDK parameters.
+        control condition fixed and use Bootstrap, Ports, and Adapters.
       </p>
     </aside>
 
@@ -1624,9 +1581,9 @@
           <h2>Hold the regime fixed, isolate one variable</h2>
         </div>
         <p class="section-intro">
-          The Harness defines the experimental condition, and Bootstrap
-          assembles concrete Adapters. Application depends only on Ports;
-          Domain remains unaware of the experimental infrastructure.
+          The Harness defines the experimental condition. Bootstrap assembles
+          concrete Adapters. Application depends on Ports, and Domain retains
+          the same state semantics across treatments.
         </p>
       </div>
 
@@ -1704,15 +1661,15 @@
       </div>
 
       <div class="clean-note">
-        <strong>BOUNDARY RULE</strong>
-        <p>Topology selects a control graph through the SDK; the Harness replaces implementations through Ports. Neither research path contaminates the core.</p>
+        <strong>ARCHITECTURE BOUNDARY</strong>
+        <p>Topology selects a control graph through the SDK. The Harness replaces implementations through Ports. Both paths share the same Application and Domain semantics.</p>
       </div>
     </section>
   </main>
 
   <footer class="page-footer">
     <div class="footer-inner">
-      <p>Topology uses the SDK. <span>Harnesses use Ports.</span></p>
+      <p>See the package guide for the SDK and architecture reference.</p>
       <a
         href="https://github.com/RISE-X-Lab/OpenCollab/blob/main/opencollab/README.md"
         target="_blank"

--- a/docs/sdk-0.4-explainer.html
+++ b/docs/sdk-0.4-explainer.html
@@ -1569,7 +1569,8 @@
       <strong>Change the entry point when the research question changes</strong>
       <p>
         To ablate a model, tool, environment, or context strategy, hold the
-        control condition fixed and use Bootstrap, Ports, and Adapters.
+        control condition fixed and use Bootstrap, Ports, and Adapters. Keep
+        implementation variables out of the SDK call surface.
       </p>
     </aside>
 
@@ -1582,8 +1583,9 @@
         </div>
         <p class="section-intro">
           The Harness defines the experimental condition. Bootstrap assembles
-          concrete Adapters. Application depends on Ports, and Domain retains
-          the same state semantics across treatments.
+          concrete Adapters. Application depends only on Ports. Domain has no
+          dependency on experimental infrastructure, so treatments retain the
+          same state semantics.
         </p>
       </div>
 

--- a/examples/mini-edict/README.md
+++ b/examples/mini-edict/README.md
@@ -2,10 +2,9 @@
 
 [English](README.md) | [Chinese](README.zh-CN.md)
 
-Mini Edict turns the Three Departments and Six Ministries into a compact,
-executable governance protocol. Everything specific to the example lives in
-this directory. OpenCollab provides agent sessions, model access, concurrency,
-budgets, tracing, and persistence.
+Mini Edict implements the Three Departments and Six Ministries as an executable
+governance protocol. Everything specific to the example lives in this
+directory. OpenCollab provides the agent runtime.
 
 ```text
 task
@@ -23,7 +22,7 @@ The one-shot workflow enforces this separation in Python control flow. Execution
 cannot start before Menxia approval. A veto returns concrete findings to
 Zhongshu. Shangshu assigns distinct work and acceptance criteria only to
 ministries relevant to the task. The final audit checks the memorial against the
-approved proposal, assignments, ministry reports, and their evidence.
+complete execution record.
 
 ## Talk to Zhongshu
 
@@ -46,7 +45,7 @@ mode.
 
 ## Run one decree
 
-The same institution is available as a hard-gated one-shot workflow.
+The same institution can run as a one-shot workflow with fixed approval gates.
 
 ```bash
 OPENCOLLAB_WORKFLOWS_DIR=examples/mini-edict/workflows \
@@ -55,27 +54,21 @@ OPENCOLLAB_WORKFLOWS_DIR=examples/mini-edict/workflows \
   --args '{"task":"Design a six-month open-source community growth plan."}'
 ```
 
-This command prints each institutional phase and returns the proposal, review
-history, dispatch decision, selected ministry reports, final memorial, audit,
-and total token use.
+This command prints each institutional phase and returns the complete execution
+record with its token use.
 
 ## Design references
 
 The workflow adapts Edict's mandatory
 [Menxia review](https://github.com/cft0808/edict/blob/main/agents/menxia/SOUL.md)
 and dynamic [Shangshu routing](https://github.com/cft0808/edict/blob/main/agents/shangshu/SOUL.md).
-It also follows the skill-first packaging, bounded revision loop, selective
-dispatch, and evidence-oriented output described by
-[Agent-Team](https://github.com/EthanHuangEbor/Agent-Team). The implementation
-uses OpenCollab's workflow API instead of copying either project's runtime or
-operations stack.
+It also uses [Agent-Team](https://github.com/EthanHuangEbor/Agent-Team) as a
+reference for packaging skills and controlling revision and dispatch. The
+implementation uses OpenCollab's workflow API.
 
-## Why the example is small
+## Files to edit
 
-The example contains one team file for conversation and one workflow file for
-hard-gated execution. Changing the organization means editing role mandates or
-stage order. Generic agent infrastructure remains in OpenCollab.
-
-This is the point of the demonstration. A collaboration idea that often becomes
-a standalone multi-agent repository can be expressed as a small, inspectable
-protocol on top of a shared framework.
+The team file defines the conversational roles and the workflow file defines
+the gated execution path. Edit role mandates in `team.yaml` and stage order in
+the workflow. Together, these files implement the protocol on OpenCollab's
+shared runtime.

--- a/examples/mini-edict/README.md
+++ b/examples/mini-edict/README.md
@@ -4,7 +4,8 @@
 
 Mini Edict implements the Three Departments and Six Ministries as an executable
 governance protocol. Everything specific to the example lives in this
-directory. OpenCollab provides the agent runtime.
+directory. OpenCollab provides agent sessions and model access. It also handles
+concurrency, token budgets, tracing, and persistence.
 
 ```text
 task
@@ -22,7 +23,8 @@ The one-shot workflow enforces this separation in Python control flow. Execution
 cannot start before Menxia approval. A veto returns concrete findings to
 Zhongshu. Shangshu assigns distinct work and acceptance criteria only to
 ministries relevant to the task. The final audit checks the memorial against the
-complete execution record.
+approved proposal and assigned work. It also checks the ministry reports and
+their evidence.
 
 ## Talk to Zhongshu
 
@@ -54,8 +56,9 @@ OPENCOLLAB_WORKFLOWS_DIR=examples/mini-edict/workflows \
   --args '{"task":"Design a six-month open-source community growth plan."}'
 ```
 
-This command prints each institutional phase and returns the complete execution
-record with its token use.
+This command prints each institutional phase. Its return value contains the
+proposal, review history, dispatch decision, selected ministry reports, final
+memorial, audit, and token use.
 
 ## Design references
 
@@ -63,12 +66,12 @@ The workflow adapts Edict's mandatory
 [Menxia review](https://github.com/cft0808/edict/blob/main/agents/menxia/SOUL.md)
 and dynamic [Shangshu routing](https://github.com/cft0808/edict/blob/main/agents/shangshu/SOUL.md).
 It also uses [Agent-Team](https://github.com/EthanHuangEbor/Agent-Team) as a
-reference for packaging skills and controlling revision and dispatch. The
-implementation uses OpenCollab's workflow API.
+reference for skill packaging and the bounded revision loop. The workflow
+dispatches only the ministries needed for the task and carries their evidence
+into the final audit. The implementation uses OpenCollab's workflow API.
 
-## Files to edit
+## Implementation
 
-The team file defines the conversational roles and the workflow file defines
-the gated execution path. Edit role mandates in `team.yaml` and stage order in
-the workflow. Together, these files implement the protocol on OpenCollab's
-shared runtime.
+The protocol lives in `team.yaml` and one workflow module, together totaling
+239 lines. Edit role mandates in `team.yaml` and stage order in the workflow.
+OpenCollab supplies the shared runtime.

--- a/examples/mini-edict/README.zh-CN.md
+++ b/examples/mini-edict/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-Mini Edict 把三省六部实现为一套可执行的组织协议。这个目录保存示例本身，Agent 运行时由 OpenCollab 提供。
+Mini Edict 把三省六部实现为一套可执行的组织协议。这个目录保存示例本身。OpenCollab 提供 Agent 会话和模型访问，并负责并发、token 预算、追踪和持久化。
 
 ```text
 任务
@@ -16,7 +16,7 @@ Mini Edict 把三省六部实现为一套可执行的组织协议。这个目录
        -> 形成完成或阻断结果
 ```
 
-工作流用 Python 控制流程保证职责分离。门下省批准前无法进入执行阶段。封驳意见会交回中书省用于修订。尚书省根据任务选择有关部门，并为每个部门给出独立任务与验收条件。最终复核会检查完整的执行记录。
+工作流用 Python 控制流程保证职责分离。门下省批准前无法进入执行阶段。封驳意见会交回中书省用于修订。尚书省根据任务选择有关部门，并为每个部门给出独立任务与验收条件。最终复核会将奏报与获批方案及部门分工逐项核对，同时检查部门报告及其证据。
 
 ## 与中书省对话
 
@@ -41,12 +41,12 @@ OPENCOLLAB_WORKFLOWS_DIR=examples/mini-edict/workflows \
   --args '{"task":"Design a six-month open-source community growth plan."}'
 ```
 
-命令会显示每个阶段，并返回完整执行记录及其 token 用量。
+命令会显示每个阶段。返回值保存中书方案、审议记录和派发决定，并附上六部报告、最终奏报、复核结果及 token 用量。
 
 ## 设计参考
 
-工作流采用了 Edict 的[门下省强制审议](https://github.com/cft0808/edict/blob/main/agents/menxia/SOUL.md)和[尚书省动态派发](https://github.com/cft0808/edict/blob/main/agents/shangshu/SOUL.md)设计。[Agent-Team](https://github.com/EthanHuangEbor/Agent-Team) 提供了技能封装和修订控制方面的参考。实现使用 OpenCollab 的工作流 API。
+工作流采用了 Edict 的[门下省强制审议](https://github.com/cft0808/edict/blob/main/agents/menxia/SOUL.md)和[尚书省动态派发](https://github.com/cft0808/edict/blob/main/agents/shangshu/SOUL.md)设计。[Agent-Team](https://github.com/EthanHuangEbor/Agent-Team) 提供了技能封装和有限修订方面的参考。工作流按任务选择六部，并把部门证据交给最终复核。实现使用 OpenCollab 的工作流 API。
 
-## 需要编辑的文件
+## 实现位置
 
-团队文件定义对话角色，工作流文件定义带审批节点的执行路径。修改角色职责时编辑 `team.yaml`，调整阶段顺序时编辑工作流。这两个文件通过 OpenCollab 的共享运行时实现完整协议。
+协议位于 `team.yaml` 和一个工作流模块中，合计 239 行。修改角色职责时编辑 `team.yaml`，调整阶段顺序时编辑工作流。共享运行时由 OpenCollab 提供。

--- a/examples/mini-edict/README.zh-CN.md
+++ b/examples/mini-edict/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-Mini Edict 把三省六部组织方式写成了一套紧凑且可执行的协作协议。这个目录包含示例所需的全部配置、工作流、说明和测试。Agent 会话、模型接入、并发、预算、追踪和持久化由 OpenCollab 提供。
+Mini Edict 把三省六部实现为一套可执行的组织协议。这个目录保存示例本身，Agent 运行时由 OpenCollab 提供。
 
 ```text
 任务
@@ -16,7 +16,7 @@ Mini Edict 把三省六部组织方式写成了一套紧凑且可执行的协作
        -> 形成完成或阻断结果
 ```
 
-工作流用 Python 控制流程保证职责分离。门下省批准前无法进入执行阶段。封驳意见会交回中书省用于修订。尚书省根据任务选择有关部门，并为每个部门给出独立任务与验收条件。最终复核会同时检查批准后的方案、部门分工、执行报告和证据。
+工作流用 Python 控制流程保证职责分离。门下省批准前无法进入执行阶段。封驳意见会交回中书省用于修订。尚书省根据任务选择有关部门，并为每个部门给出独立任务与验收条件。最终复核会检查完整的执行记录。
 
 ## 与中书省对话
 
@@ -32,7 +32,7 @@ uv run opencollab \
 
 ## 执行一道政令
 
-同一套组织方式也可以作为流程固定的单次工作流运行。
+同一套组织方式也可以作为带有固定审批节点的单次工作流运行。
 
 ```bash
 OPENCOLLAB_WORKFLOWS_DIR=examples/mini-edict/workflows \
@@ -41,14 +41,12 @@ OPENCOLLAB_WORKFLOWS_DIR=examples/mini-edict/workflows \
   --args '{"task":"Design a six-month open-source community growth plan."}'
 ```
 
-命令会显示每个阶段，并返回中书方案、审议记录、派发决定、六部报告、最终奏报、复核结果和 token 用量。
+命令会显示每个阶段，并返回完整执行记录及其 token 用量。
 
 ## 设计参考
 
-工作流吸收了 Edict 的[门下省强制审议](https://github.com/cft0808/edict/blob/main/agents/menxia/SOUL.md)和[尚书省动态派发](https://github.com/cft0808/edict/blob/main/agents/shangshu/SOUL.md)设计，也参考了 [Agent-Team](https://github.com/EthanHuangEbor/Agent-Team) 对技能封装、有限修订、按需派发和证据化输出的处理。这里通过 OpenCollab 的工作流 API 表达这些规则，没有复制两个项目的运行时和运维代码。
+工作流采用了 Edict 的[门下省强制审议](https://github.com/cft0808/edict/blob/main/agents/menxia/SOUL.md)和[尚书省动态派发](https://github.com/cft0808/edict/blob/main/agents/shangshu/SOUL.md)设计。[Agent-Team](https://github.com/EthanHuangEbor/Agent-Team) 提供了技能封装和修订控制方面的参考。实现使用 OpenCollab 的工作流 API。
 
-## 为什么它很小
+## 需要编辑的文件
 
-Mini Edict 的组织逻辑集中在一个团队文件和一个工作流文件中。修改角色职责时编辑 `team.yaml`，调整阶段顺序时编辑工作流即可。其余通用能力由 OpenCollab 统一提供。
-
-这个示例展示了 OpenCollab 的核心价值。一种原本需要完整多智能体仓库表达的协作构想，可以缩成一套容易阅读、运行和修改的小型协议。
+团队文件定义对话角色，工作流文件定义带审批节点的执行路径。修改角色职责时编辑 `team.yaml`，调整阶段顺序时编辑工作流。这两个文件通过 OpenCollab 的共享运行时实现完整协议。

--- a/examples/team-issue/README.md
+++ b/examples/team-issue/README.md
@@ -1,9 +1,9 @@
 # Team issue TUI demo
 
-This demo runs a deliberately small failing issue through an explicit
+This demo runs a small failing issue through an explicit
 `analyst -> coder -> tester` team. The analyst is agent 0 and the TUI entry.
 
-From the repository root, with a provider configured, run:
+Configure a provider, then run this command from the repository root.
 
 ```bash
 ./scripts/demo_team_issue.sh
@@ -14,17 +14,17 @@ starts with one failing and two passing tests without modifying this fixture.
 It then starts OpenCollab with the explicit `team.yaml`, the issue as a one-shot
 prompt, shared filesystem mode, and the completed-run TUI hold.
 
-The launcher also opts into `--allow-local-child-tests` so the coder and tester
-can execute this known fixture on the host. That flag deliberately remains off
-by default; do not use it for an untrusted workspace because project tests run
-code outside an OS process sandbox.
+The launcher enables `--allow-local-child-tests` so the coder and tester can
+execute this known fixture on the host. The flag is disabled by default. Use it
+only for a trusted workspace because project tests run code outside an OS
+process sandbox.
 
 While the team runs, use `Tab` or `Shift+Tab` to follow any live agent. After
 the run completes, the same keys inspect the final analyst, coder, and tester
-transcripts; press `q` to close the TUI. The launcher prints and retains the
+transcripts. Press `q` to close the TUI. The launcher prints and retains the
 temporary workspace path for inspection after the run.
 
-Additional OpenCollab options can be appended, for example:
+Additional OpenCollab options can be appended as shown below.
 
 ```bash
 ./scripts/demo_team_issue.sh --model your-model

--- a/examples/team-issue/README.md
+++ b/examples/team-issue/README.md
@@ -24,7 +24,7 @@ the run completes, the same keys inspect the final analyst, coder, and tester
 transcripts. Press `q` to close the TUI. The launcher prints and retains the
 temporary workspace path for inspection after the run.
 
-Additional OpenCollab options can be appended as shown below.
+Append additional OpenCollab options to the script command.
 
 ```bash
 ./scripts/demo_team_issue.sh --model your-model

--- a/opencollab/README.md
+++ b/opencollab/README.md
@@ -1,24 +1,26 @@
 # OpenCollab Python Package
 
-This guide documents the installed package and the framework internals behind
-the concise [project homepage](../README.md). Run repository commands from the
-repository root unless noted otherwise.
+OpenCollab is installed as a Python package and exposes a small public API over
+the framework runtime. The [project homepage](../README.md) gives the quick
+start. Run repository commands from the repository root unless a command says
+otherwise.
 
 ## Install
 
 OpenCollab supports Linux and macOS hosts. Its local file adapters require
 descriptor-relative operations, no-follow `stat`, `O_NOFOLLOW`, fd-based
-directory listing, callable `fcntl.flock`, and an atomic no-clobber rename:
-`renameat2(RENAME_NOREPLACE)` on Linux or `renameatx_np(RENAME_EXCL)` on macOS
-10.12 and newer. Missing primitives produce an explicit capability error.
+directory listing, callable `fcntl.flock`, and an atomic no-clobber rename. The
+rename primitive is `renameat2(RENAME_NOREPLACE)` on Linux and
+`renameatx_np(RENAME_EXCL)` on macOS 10.12 and newer. OpenCollab reports a
+capability error when the host lacks a required primitive.
 
-Install the project and development dependencies with `uv`:
+Install the project and development dependencies with `uv`.
 
 ```bash
 uv sync --extra dev
 ```
 
-Or create a conventional virtual environment with `pip`:
+Or create a conventional virtual environment with `pip`.
 
 ```bash
 python3 -m venv .venv
@@ -27,7 +29,7 @@ python3 -m venv .venv
 
 ## Commands
 
-The registered CLI is the preferred entry point during development:
+During development, run the registered CLI from the project environment.
 
 ```bash
 uv run opencollab --workspace .
@@ -35,11 +37,11 @@ uv run opencollab --workspace .
 
 It runs the current checkout in the project environment, resolves
 `configs/.env`, and starts agent 0 with the built-in lead-only configuration.
-There is no separate `team` subcommand: pass `--team-config PATH` to select a
-declared multi-agent team explicitly. `scripts/start_opencollab.sh` remains a
-compatibility launcher for environments that need its physical-path handling.
+Pass `--team-config PATH` to select a declared multi-agent team.
+`scripts/start_opencollab.sh` remains available for environments that need its
+physical-path handling.
 
-After installation, invoke the CLI directly from the active environment:
+After installation, invoke the CLI directly from the active environment.
 
 ```bash
 opencollab --workspace .
@@ -52,18 +54,17 @@ A workflow directory contains caller-authored Python modules tagged with
 `@workflow`. `OPENCOLLAB_WORKFLOWS_DIR` applies to both `workflow list` and
 `workflow run`.
 
-Useful flags:
+The following flags control tracing, isolation, team selection, and approvals.
 
 - `--trace` records every LLM call and tool execution.
 - `--no-worktrees` disables per-child git-worktree isolation.
-- `--team-config PATH` selects a team YAML file instead of the built-in lead.
+- `--team-config PATH` selects a team YAML file.
 - `--yolo` auto-approves risky commands.
 
 ## Python SDK
 
-The package root is the complete everyday API: one stateful client, one result
-type, one error, and the workflow decorator. Compatibility follows package
-SemVer.
+The package root exposes `OpenCollab`, `RunResult`, `RunError`, and the
+`workflow` decorator. Compatibility follows package SemVer.
 
 ```python
 import asyncio
@@ -84,8 +85,8 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-The same client exposes `agent(...)`, `team(...)`, and `workflow(...)`; all
-return `RunResult`. Import optional authoring contracts from
+The same client exposes `agent(...)`, `team(...)`, and `workflow(...)`. All
+three return `RunResult`. Import optional authoring contracts from
 `opencollab.tools`, `opencollab.environments`, and `opencollab.workflows`.
 Treat other package paths as internal. An `artifacts` directory, when supplied,
 must be new or empty because each run claims it for executable evidence.
@@ -94,17 +95,17 @@ argument names a team YAML file.
 
 `OpenCollab.configuration` is a read-only snapshot of effective model,
 provider, budget, timeout, sampling, output-token, and thinking settings.
-`thinking_params` is deep-copied so callers cannot mutate client state. API keys
+`thinking_params` is deep-copied, so callers receive an independent snapshot. API keys
 and base URLs are excluded. `base_url_sha256` provides a stable endpoint
 fingerprint without exposing credentials embedded in a URL. Agent runs accept
-`max_steps` and `cleanup_timeout`; the older `steps` spelling remains a supported
+`max_steps` and `cleanup_timeout`. The older `steps` spelling remains a supported
 alias.
 Workflow runs accept `max_steps`, `system_prompt`, and `cleanup_timeout`.
 Completed, stopped, and failed workflow results report aggregate session,
 step, token, and markup-recovery metrics. Sanitized child-provider failures are
 available through `RunResult.agent_failures`.
 
-Built-in tools can be composed without importing concrete adapters:
+Use `builtin_tools` to compose tools through the public package.
 
 ```python
 from opencollab.tools import builtin_tools
@@ -124,7 +125,7 @@ the public `VerificationTool` protocol. Its read-only `verified_targets`
 property contains exact requested targets whose latest parser-backed verdict
 was green.
 
-Environment composition uses the same narrow public module:
+Environment composition uses the same narrow public module.
 
 ```python
 from opencollab.environments import (
@@ -138,11 +139,11 @@ isolated_source = worktree_environment(".")
 container = docker_environment("python:3.11-slim", isolated_source)
 ```
 
-These factories construct caller-owned environments without eagerly setting
-them up. Every public environment supports `await environment.setup()`. Docker
-environments additionally accept `mount_dir`; host and worktree environments
-reject that argument. The caller retains setup, mount, and cleanup timing.
-Concrete adapter classes stay behind the bootstrap boundary.
+These factories return caller-owned environments whose setup has not started.
+Every public environment supports `await environment.setup()`. Docker
+environments also accept `mount_dir`. Host and worktree environments raise an
+argument error for `mount_dir`. The caller controls setup, mount, and cleanup
+timing. Concrete adapter classes live in `adapters`, and Bootstrap wires them.
 
 Run metrics separate OpenCollab-owned session quiescence from environment
 quiescence. `session_quiesced` proves that session and persistence work has
@@ -153,7 +154,7 @@ performs and verifies its own environment cleanup.
 ### Workflow authoring
 
 A workflow is a plain async Python function tagged with `@workflow`. Create
-`workflows/implement_and_review.py`:
+`workflows/implement_and_review.py` as shown below.
 
 ```python
 from typing import Any
@@ -180,7 +181,7 @@ async def implement_and_review(
 ```
 
 OpenCollab discovers top-level `*.py` modules in `workflows/` by default. Run
-the decorated function through the CLI:
+the decorated function through the CLI.
 
 ```bash
 uv run opencollab workflow run implement-and-review \
@@ -193,20 +194,20 @@ embedding OpenCollab in Python.
 
 Evidence-preserving workflows can call `ctx.draft_findings(...)` to capture a
 structured cite-or-abstain draft before exploration. OpenCollab owns this
-generic capture primitive; benchmark-specific prompts, policies, datasets, and
-runners remain in OpenCollab-Eval.
+generic capture primitive. OpenCollab-Eval owns benchmark prompts, policies,
+datasets, and runners.
 
 For a visual architecture walkthrough, open the
 [SDK 0.4 research architecture](../docs/sdk-0.4-explainer.html).
 
-Evaluation runners and benchmark-specific workflows intentionally live outside
-the framework package. Topology research uses `team(...)` and `workflow(...)`;
-external harnesses define ablations while Bootstrap binds each treatment
-through the Clean Architecture ports.
+OpenCollab-Eval contains evaluation runners and benchmark workflows. Topology
+research uses `team(...)` and `workflow(...)`. External harnesses define
+ablations, and Bootstrap binds each treatment through the Clean Architecture
+ports.
 
 ## Architecture
 
-OpenCollab follows strict clean architecture: dependencies point inward only,
+OpenCollab follows strict clean architecture. Dependencies point inward along
 `adapters → application → domain`.
 
 - `domain/` contains pure value objects and the session state machine. It uses
@@ -220,7 +221,7 @@ OpenCollab follows strict clean architecture: dependencies point inward only,
 - `sdk/` is the versioned integration surface for external packages.
 
 Boundary tests enforce the dependency direction. An outer capability needed by
-the application becomes a port; its concrete implementation is wired in
+the application becomes a port. Its concrete implementation is wired in
 `bootstrap/`. This keeps the domain and application testable without network or
 filesystem access.
 
@@ -229,18 +230,18 @@ filesystem access.
 ### Validated agent sessions
 
 A single agent is a validated state machine in `domain/session.py`. Invalid
-edges raise instead of silently passing. Every early stop is one of three
-named terminal states: `DONE` (a final answer), `ERROR` (an unhandled fault),
-and `STOPPED`-a single graceful-stop terminal whose `reason` records whether
-the halt was a budget, step, loop, or context overflow.
+edges raise an error. Every early stop has a named terminal state. `DONE`
+contains a final answer, `ERROR` records an unhandled fault, and `STOPPED`
+records a graceful halt. Its `reason` identifies a budget, step, loop, or
+context overflow.
 
 ### Cooperative teams
 
-A team follows an OS-process-inspired model: the session table is the process
-table, `spawn` resembles `fork`, and agents suspend and wake through a
-cooperative scheduler. Budget is reserved before the first `await`, preventing
-a concurrent child batch from overspending the shared pool. Each child can work
-in an isolated git worktree, and its diff returns to the parent with its result.
+A team stores active agents in a session table and schedules them cooperatively.
+The `spawn` operation creates child sessions. Budget is reserved before the
+first `await`, so a concurrent child batch cannot overspend the shared pool.
+Each child can work in an isolated git worktree and return its diff with the
+result.
 
 ### Swappable components
 
@@ -257,15 +258,14 @@ in an isolated git worktree, and its diff returns to the parent with its result.
 The test suite pins core invariants such as session transitions, budget
 reservation, context shaping, and import boundaries.
 
-Open research gaps remain: port-level ablations have not yet been run,
-workflow-versus-team comparisons are incomplete, prompt caching is not wired,
-and the session state machine does not yet persist budget and phase across
+Port-level ablations and workflow-versus-team comparisons have not been
+completed. Prompt caching is unavailable. Budget and phase reset when a session
 restarts. See [`../docs/`](../docs/) for design records and research notes.
 
 ## Development
 
 Respect the dependency direction and keep public names re-exported when modules
-move. From the repository root, run:
+move. Run the checks from the repository root.
 
 ```bash
 uv run ruff check .
@@ -275,7 +275,8 @@ uv run pytest -q
 See [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for contributor guidance and
 [`../CLAUDE.md`](../CLAUDE.md) for repository-specific architecture notes. The
 archived module map under [`../docs/archive/repomap/`](../docs/archive/repomap/)
-is a historical snapshot rather than a maintained source of truth.
+records an earlier revision. Use the current source and tests for the current
+module layout.
 
 ## License
 

--- a/opencollab/README.md
+++ b/opencollab/README.md
@@ -37,9 +37,9 @@ uv run opencollab --workspace .
 
 It runs the current checkout in the project environment, resolves
 `configs/.env`, and starts agent 0 with the built-in lead-only configuration.
-Pass `--team-config PATH` to select a declared multi-agent team.
-`scripts/start_opencollab.sh` remains available for environments that need its
-physical-path handling.
+Team mode uses the root command with `--team-config PATH`; there is no separate
+`team` subcommand. `scripts/start_opencollab.sh` remains available for
+environments that need its physical-path handling.
 
 After installation, invoke the CLI directly from the active environment.
 
@@ -154,7 +154,7 @@ performs and verifies its own environment cleanup.
 ### Workflow authoring
 
 A workflow is a plain async Python function tagged with `@workflow`. Create
-`workflows/implement_and_review.py` as shown below.
+`workflows/implement_and_review.py` with this implementation.
 
 ```python
 from typing import Any
@@ -230,7 +230,7 @@ filesystem access.
 ### Validated agent sessions
 
 A single agent is a validated state machine in `domain/session.py`. Invalid
-edges raise an error. Every early stop has a named terminal state. `DONE`
+edges raise an error. The state machine has three terminal states. `DONE`
 contains a final answer, `ERROR` records an unhandled fault, and `STOPPED`
 records a graceful halt. Its `reason` identifies a budget, step, loop, or
 context overflow.
@@ -259,8 +259,10 @@ The test suite pins core invariants such as session transitions, budget
 reservation, context shaping, and import boundaries.
 
 Port-level ablations and workflow-versus-team comparisons have not been
-completed. Prompt caching is unavailable. Budget and phase reset when a session
-restarts. See [`../docs/`](../docs/) for design records and research notes.
+completed. Prompt caching is unavailable. Session snapshots restore token usage
+and recoverable terminal or awaiting-event phases. In-flight provider and tool
+phases resume from `IDLE` because their process-local coroutines do not survive
+a restart. See [`../docs/`](../docs/) for design records and research notes.
 
 ## Development
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,8 @@
 # Framework scripts
 
 This directory contains OpenCollab framework launchers and provider diagnostics.
-Benchmark generation, evaluation, reporting, and remote execution commands are
-owned by [OpenCollab-Eval](https://github.com/RISE-X-Lab/OpenCollab-Eval)
-rather than this framework package.
+[OpenCollab-Eval](https://github.com/RISE-X-Lab/OpenCollab-Eval) contains the
+benchmark generation, evaluation, reporting, and remote execution commands.
 
 Use `uv run opencollab` as the standard development entry point.
 `start_opencollab.sh` remains a compatibility launcher for callers that need

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,9 +1,10 @@
 # Skills
 
-A **skill** is an on-demand instruction set stored in `SKILL.md`. The model loads
-it by name when a task matches its description. A skill directory may also hold
-templates, scripts, or assets used through the role's existing tools. All skills
-share the generic `use_skill` tool.
+A **skill** is an on-demand instruction set stored in `SKILL.md`. It adds
+procedural guidance to a role without registering a new runtime function or a
+dedicated tool. A skill directory may contain supporting files used through
+tools the role already has. Enabled roles load skills through the generic
+`use_skill` tool.
 
 At runtime, discovery and loading happen in two steps.
 
@@ -13,9 +14,7 @@ At runtime, discovery and loading happen in two steps.
    `use_skill(name)` tool, which loads that skill's full instruction **body** into the
    conversation.
 
-The same `use_skill` tool serves the full catalog.
-
-> The implementation history is recorded in
+> The design record explains this interface in
 > [`docs/2026-06-18-skill-interface-design.md`](../docs/2026-06-18-skill-interface-design.md).
 
 ---
@@ -76,7 +75,7 @@ that omit it keep their existing tool set and system prompt.
 ### 3. Restart OpenCollab
 
 After restart, the role's system prompt lists the new skill and the model can
-invoke it by name.
+invoke it by name. Adding a skill requires no registration or code change.
 
 ---
 
@@ -86,13 +85,13 @@ invoke it by name.
 | --- | --- |
 | Naming | Use a short kebab-case `name` equal to the directory name. The model must type it exactly. |
 | Description | Write a specific task trigger such as "when you need to …". The model decides whether to load the skill from this field. |
-| Body | Write self-contained instructions that use tools already assigned to the role. |
+| Body | Write self-contained instructions that use tools already assigned to the role. A skill cannot grant additional tools. |
 | Size | The loader caps the body at 8000 characters and the description at 500 characters. It marks a truncated body clearly. |
-| Malformed file | The loader omits a `SKILL.md` with a missing `name`, unclosed frontmatter, or read error. Check the frontmatter and `name` if a skill is absent from the catalog. |
+| Malformed file | The loader skips a `SKILL.md` with a missing `name`, unclosed frontmatter, or read error, while startup continues. Check the frontmatter and `name` if a skill is absent from the catalog. |
 | Unknown name | `use_skill` returns `Unknown skill '<x>'. Available skills: …`. |
 
 ## Where skills are loaded from
 
 The current loader reads the `skills/` directory at the workspace root. In this
-repository, that path is `skills/`. The design record covers possible global and
-project-specific search paths.
+repository, that path is `skills/`. The design record discusses global and
+project-specific search paths that the current loader does not implement.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,12 +1,11 @@
 # Skills
 
-A **skill** is an on-demand *instruction set* — a packaged unit of procedural
-knowledge an agent can pull into its context when the task calls for it. A skill is
-**not** a tool and registers no runtime function. Its `SKILL.md` contains the
-instructions the model loads by name; the package may also include supporting
-templates, scripts, or assets that those instructions use through existing tools.
+A **skill** is an on-demand instruction set stored in `SKILL.md`. The model loads
+it by name when a task matches its description. A skill directory may also hold
+templates, scripts, or assets used through the role's existing tools. All skills
+share the generic `use_skill` tool.
 
-How it works at runtime:
+At runtime, discovery and loading happen in two steps.
 
 1. On startup, every skill under this directory is discovered and a **catalog**
    (each skill's `name` + `description`) is folded into the agent's system prompt.
@@ -14,9 +13,9 @@ How it works at runtime:
    `use_skill(name)` tool, which loads that skill's full instruction **body** into the
    conversation.
 
-One `use_skill` tool serves every skill — adding skills never adds tools.
+The same `use_skill` tool serves the full catalog.
 
-> Internals / design rationale: see
+> The implementation history is recorded in
 > [`docs/2026-06-18-skill-interface-design.md`](../docs/2026-06-18-skill-interface-design.md).
 
 ---
@@ -25,7 +24,7 @@ One `use_skill` tool serves every skill — adding skills never adds tools.
 
 ### 1. Create the file
 
-Each skill is one directory holding a `SKILL.md` and optional supporting files:
+Each skill uses one directory containing `SKILL.md` and any supporting files.
 
 ```
 skills/
@@ -34,7 +33,8 @@ skills/
     └── scripts/ or templates/ (optional)
 ```
 
-`SKILL.md` is YAML frontmatter (delimited by `---`) followed by the instruction body:
+`SKILL.md` contains YAML frontmatter delimited by `---`, followed by the
+instruction body.
 
 ```markdown
 ---
@@ -42,7 +42,7 @@ name: review-migration
 description: Review a database migration for safety and reversibility
 ---
 
-When asked to review a migration:
+When asked to review a migration, follow these steps.
 
 1. Check the migration is reversible (a `down`/rollback exists and is correct).
 2. Flag any non-concurrent index build or table rewrite on a large table.
@@ -50,20 +50,19 @@ When asked to review a migration:
 4. Summarise risk as LOW / MEDIUM / HIGH with the single biggest concern.
 ```
 
-Frontmatter fields:
+The frontmatter has two required fields.
 
 | Field | Required | Purpose |
 |---|---|---|
-| `name` | yes | The **invocation key** — what the model passes to `use_skill(name)`. Keep it equal to the directory name. |
+| `name` | yes | The invocation key passed to `use_skill(name)`. Keep it equal to the directory name. |
 | `description` | yes | One line shown in the catalog. This is what the model matches against the task, so make it specific and trigger-worthy. |
 
-Everything after the closing `---` is the **body** — the instructions loaded when the
-skill is invoked.
+Everything after the closing `---` is the body loaded when the skill is invoked.
 
-### 2. Enable skills for a role (the opt-in switch)
+### 2. Enable skills for a role
 
-A role only sees the catalog and gets the `use_skill` tool if you add `use_skill` to
-its `tools:` list in your team config (`team.yaml`):
+A role sees the catalog and gets the `use_skill` tool after you add `use_skill` to
+its `tools:` list in your team config (`team.yaml`).
 
 ```yaml
 roles:
@@ -71,38 +70,29 @@ roles:
     tools: [bash, file_read, use_skill]   # <- add use_skill
 ```
 
-Without this, skills stay invisible to that role. This is intentional — skills are
-**off by default** until a role opts in.
+Adding `use_skill` gives the role access to the skill catalog and loader. Roles
+that omit it keep their existing tool set and system prompt.
 
-### 3. That's it
+### 3. Restart OpenCollab
 
-No registration, no code changes. Restart the app and the role's system prompt will
-list your new skill; the model invokes it by name when relevant.
+After restart, the role's system prompt lists the new skill and the model can
+invoke it by name.
 
 ---
 
 ## Conventions & limits
 
-- **Naming.** Use a short, kebab-case `name` that matches the directory. The model
-  must type it exactly, so prefer clarity over cleverness.
-- **Descriptions are triggers.** The model decides whether to load a skill from its
-  `description` alone — write it as "when you need to …", not as a title.
-- **Bodies should be self-contained instructions.** A body may *refer* to tools the
-  role already has (e.g. "run the tests with bash"), but it cannot grant new tools.
-- **Size caps** (enforced when loading, single-sited in the store):
-  - body: 8000 characters (longer bodies are truncated with a clear marker);
-  - description: 500 characters.
-  Keep bodies tight — they cost context every time they're loaded.
-- **Malformed skills are skipped, never fatal.** A `SKILL.md` with no `name`, an
-  unclosed frontmatter block, or an unreadable file is silently ignored at startup —
-  it will simply not appear in the catalog. If your skill isn't showing up, check the
-  frontmatter delimiters and that `name` is present.
-- **Unknown invocation is graceful.** If the model calls `use_skill` with a name that
-  doesn't exist, it gets back `Unknown skill '<x>'. Available skills: …` rather than
-  an error.
+| Topic | Convention |
+| --- | --- |
+| Naming | Use a short kebab-case `name` equal to the directory name. The model must type it exactly. |
+| Description | Write a specific task trigger such as "when you need to …". The model decides whether to load the skill from this field. |
+| Body | Write self-contained instructions that use tools already assigned to the role. |
+| Size | The loader caps the body at 8000 characters and the description at 500 characters. It marks a truncated body clearly. |
+| Malformed file | The loader omits a `SKILL.md` with a missing `name`, unclosed frontmatter, or read error. Check the frontmatter and `name` if a skill is absent from the catalog. |
+| Unknown name | `use_skill` returns `Unknown skill '<x>'. Available skills: …`. |
 
 ## Where skills are loaded from
 
-Skills are read from the `skills/` directory at the **workspace root** the agent runs
-against. Today that is this repository's `skills/`. (A global skills layer and
-per-project overrides are planned but not yet implemented — see the design doc.)
+The current loader reads the `skills/` directory at the workspace root. In this
+repository, that path is `skills/`. The design record covers possible global and
+project-specific search paths.


### PR DESCRIPTION
这次修改审阅 OpenCollab 的公开文档，范围包括主要入口、目录说明、SDK 架构页和 Mini Edict 示例。共修改 13 个文件，新增 298 行，删除 359 行。\n\n文档现在直接说明功能、使用方法和能力边界。宣传式语句、重复过渡、机械排比和无意义的自我否定已经删改。命令、配置、品牌规范、安全规则和架构关系保留原有含义。\n\n第二轮逐文件复核发现首版润色删掉了部分有效信息。当前版本已经恢复模型与环境的独立扩展点、OpenCollab-Eval 的仓库边界、CLI 的 Team 入口、会话恢复语义、Skill 权限边界、Application 与 Domain 的依赖关系、漏洞私密报告方式和品牌来源信息。\n\nMini Edict 现在明确描述 Edict 的核心审议与派发协议，没有扩大等价范围。239 行统计由 63 行团队配置和 176 行工作流组成。中英文说明均列出方案、审议记录、派发决定、部门报告、证据、奏报、复核结果和 token 用量。\n\n本地 Ruff 已通过。完整测试结果为 1513 passed。diff 检查、HTML 解析和 Markdown 相对链接检查均已通过。\n\n两位独立 Reviewer 分别检查技术事实与文风。两次复核结论均为 APPROVE。分支已经更新到最新 main，当前 PR 保持 Draft 状态，等待人工评审。