### PR TITLE
docs: align changelog with v0.4.1 baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,24 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-08-03
-
 ### Added
 - Added Mini Edict, a bilingual, tested Three Departments and Six Ministries
   example with both a team configuration and a hard-gated workflow.
+- Added a public maintainer release procedure covering exact-SHA validation,
+  artifact construction, signed tagging, publication, and failure handling.
+
+### Changed
+- Replaced changelog links that depended on the absent remote `v0.1.0` tag with
+  exact historical commit links.
+
+### Fixed
+- Capped structured-output corrective retries at 60 seconds while preserving
+  shorter caller deadlines, so endpoints that degrade forced tool choice cannot
+  consume the caller's full role budget.
+
+## [0.4.1] - 2026-07-31
+
+### Added
 - Added immutable non-secret effective configuration metadata, public stateless
   tool composition, and caller-owned Local, Worktree, and image-backed Docker
   environment factories for external integrations. Configuration metadata
@@ -51,9 +64,6 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 - Raised the package version to 0.4.1 for the incompatible compact SDK boundary.
 
 ### Fixed
-- Capped structured-output corrective retries at 60 seconds while preserving
-  shorter caller deadlines, so endpoints that degrade forced tool choice cannot
-  consume the caller's full role budget.
 - Restored the exact terminal state after turn-scoped TUI keyboard navigation on
   macOS and added the terminal probe to macOS CI.
 - Emitted valid JavaScript comments around the vendored js-yaml license in Team


### PR DESCRIPTION
## Summary

- define `7c2c4a345dcd8d511957e63f8846a64aa08ee9ce` as the exact `v0.4.1` release boundary
- restore the 0.4.1 changelog date and contents to the tagged tree
- move the later structured-retry fix, Mini Edict example, release procedure, and historical-link correction back under `Unreleased`

## Verification

- `uv lock --check`
- `uv run ruff check .`
- `uv run pytest -q` (`1512 passed, 1 skipped`)
- `git diff --check origin/main..HEAD`

## Release boundary

This PR changes changelog classification only. It does not create a tag, publish a release, or publish to PyPI.