### PR TITLE
fix(adapters): land audited adapter-layer bug fixes (batch 1/N)

### DIFF
--- a/opencollab/adapters/_env_base.py
+++ b/opencollab/adapters/_env_base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+ENV_FILE_WRITE_LIMIT_BYTES = 4 * 1024 * 1024
+
 
 @dataclass(slots=True)
 class ExecResult:
@@ -75,4 +77,4 @@ class Environment:
         await self.cleanup()
 
 
-__all__ = ["Environment", "ExecResult"]
+__all__ = ["ENV_FILE_WRITE_LIMIT_BYTES", "Environment", "ExecResult"]

--- a/opencollab/adapters/_env_base.py
+++ b/opencollab/adapters/_env_base.py
@@ -18,6 +18,15 @@ class ExecResult:
     stderr_dropped_bytes: int = 0
 
 
+@dataclass(slots=True)
+class TextFileRange:
+    lines: list[str]
+    start_line: int
+    total_lines: int | None
+    has_more: bool
+    chars_truncated: bool = False
+
+
 class Environment:
     """Abstract execution environment used by tools and workflows."""
 
@@ -54,6 +63,31 @@ class Environment:
     async def read_file(self, path: str) -> str:
         raise NotImplementedError
 
+    async def read_text_range(
+        self,
+        path: str,
+        *,
+        offset: int,
+        limit: int,
+        max_chars: int,
+    ) -> TextFileRange:
+        content = await self.read_file(path)
+        lines = content.splitlines()
+        start = max(0, offset - 1)
+        end = min(len(lines), start + limit)
+        selected = lines[start:end]
+        joined = "\n".join(selected)
+        chars_truncated = len(joined) > max_chars
+        if chars_truncated:
+            selected = joined[:max_chars].split("\n")
+        return TextFileRange(
+            lines=selected,
+            start_line=start + 1,
+            total_lines=len(lines),
+            has_more=end < len(lines) or chars_truncated,
+            chars_truncated=chars_truncated,
+        )
+
     async def write_file(self, path: str, content: str) -> None:
         raise NotImplementedError
 
@@ -77,4 +111,4 @@ class Environment:
         await self.cleanup()
 
 
-__all__ = ["ENV_FILE_WRITE_LIMIT_BYTES", "Environment", "ExecResult"]
+__all__ = ["ENV_FILE_WRITE_LIMIT_BYTES", "Environment", "ExecResult", "TextFileRange"]

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -115,6 +115,8 @@ class DockerEnvironment(Environment):
         self._container_id = self._attached_reference if self._attached else None
         self._attached_bound = False
         self._attach_lock = asyncio.Lock()
+        self._active_exec_lock = asyncio.Lock()
+        self._active_execs: dict[str, asyncio.Task | None] = {}
         self._container_name: str | None = None
         self._owner_token = None if self._attached else uuid.uuid4().hex
         self._exec_workdir = exec_workdir
@@ -340,6 +342,9 @@ class DockerEnvironment(Environment):
         if self._container_id is None:
             raise RuntimeError("Container not started. Call setup() first.")
         token = uuid.uuid4().hex
+        async with self._active_exec_lock:
+            self._ensure_active()
+            self._active_execs[token] = asyncio.current_task()
         try:
             result = await self._docker(
                 *self._exec_argv(cmd, token, interactive=input_bytes is not None),
@@ -361,6 +366,9 @@ class DockerEnvironment(Environment):
             if not await await_owned_operation(self._recover_inner(token)):
                 add_exception_note(exc, "cancelled container command did not quiesce")
             raise
+        finally:
+            async with self._active_exec_lock:
+                self._active_execs.pop(token, None)
         return result.to_exec_result()
 
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
@@ -499,5 +507,36 @@ class DockerEnvironment(Environment):
             self._cleanup_resources(),
             propagate_cancellation=True,
         )
+
+    async def abort(self) -> None:
+        self.revoke()
+        if not self._attached:
+            await self.cleanup()
+            return
+        async with self._active_exec_lock:
+            active = dict(self._active_execs)
+        if not active:
+            return
+        cancelled = await asyncio.gather(
+            *(self._cancel_inner(token) for token in active),
+            return_exceptions=True,
+        )
+        current = asyncio.current_task()
+        pending = {
+            task
+            for task in active.values()
+            if task is not None and task is not current and not task.done()
+        }
+        if pending:
+            _done, pending = await asyncio.wait(
+                pending,
+                timeout=DOCKER_CONTROL_TIMEOUT_SECONDS,
+            )
+        failed_cancellations = any(
+            result is not True and (task is None or not task.done())
+            for result, task in zip(cancelled, active.values())
+        )
+        if failed_cancellations or pending:
+            raise ProcessCleanupError("attached container commands did not quiesce during abort")
 
 __all__ = ["DockerEnvironment"]

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -613,51 +613,87 @@ class DockerEnvironment(Environment):
         if failures:
             raise RuntimeError("Docker cleanup failed") from failures[0]
 
+    async def _cleanup_attached_resources(self) -> None:
+        container_id = self._container_id
+        if container_id is None:
+            if self._temporary_files:
+                raise RuntimeError("attached Docker temporary files cannot be reached")
+            return
+        failures: list[BaseException] = []
+        for path in tuple(self._temporary_files):
+            try:
+                removed = await self._docker(
+                    "exec",
+                    "--",
+                    container_id,
+                    "rm",
+                    "-f",
+                    "--",
+                    path,
+                )
+            except BaseException as exc:
+                failures.append(exc)
+                continue
+            if removed.returncode != 0:
+                failures.append(
+                    OSError(f"failed to remove container temporary file: {path}")
+                )
+                continue
+            self._temporary_files.discard(path)
+        if failures:
+            raise OSError(
+                "failed to remove one or more attached Docker temporary files"
+            ) from failures[0]
+
     async def cleanup(self) -> None:
         async with self._lifecycle_lock:
+            await self._abort_resources_locked()
             if self._attached:
+                await await_owned_operation(
+                    self._cleanup_attached_resources(),
+                    propagate_cancellation=True,
+                )
                 return
-            self.revoke()
+
+    async def abort(self) -> None:
+        async with self._lifecycle_lock:
+            await self._abort_resources_locked()
+
+    async def _abort_resources_locked(self) -> None:
+        """Abort resources while the lifecycle lock is already held."""
+        self.revoke()
+        if not self._attached:
             await await_owned_operation(
                 self._cleanup_resources(),
                 propagate_cancellation=True,
             )
-
-    async def abort(self) -> None:
-        async with self._lifecycle_lock:
-            self.revoke()
-            if not self._attached:
-                await await_owned_operation(
-                    self._cleanup_resources(),
-                    propagate_cancellation=True,
-                )
-                return
-            async with self._active_exec_lock:
-                active = dict(self._active_execs)
-            if not active:
-                return
-            cancelled = await asyncio.gather(
-                *(self._cancel_inner(token) for token in active),
-                return_exceptions=True,
+            return
+        async with self._active_exec_lock:
+            active = dict(self._active_execs)
+        if not active:
+            return
+        cancelled = await asyncio.gather(
+            *(self._cancel_inner(token) for token in active),
+            return_exceptions=True,
+        )
+        current = asyncio.current_task()
+        pending = {
+            task
+            for task in active.values()
+            if task is not None and task is not current and not task.done()
+        }
+        if pending:
+            _done, pending = await asyncio.wait(
+                pending,
+                timeout=DOCKER_CONTROL_TIMEOUT_SECONDS,
             )
-            current = asyncio.current_task()
-            pending = {
-                task
-                for task in active.values()
-                if task is not None and task is not current and not task.done()
-            }
-            if pending:
-                _done, pending = await asyncio.wait(
-                    pending,
-                    timeout=DOCKER_CONTROL_TIMEOUT_SECONDS,
-                )
-            failed_cancellations = any(
-                result is not True and (task is None or not task.done())
-                for result, task in zip(cancelled, active.values())
+        failed_cancellations = any(
+            result is not True and (task is None or not task.done())
+            for result, task in zip(cancelled, active.values())
+        )
+        if failed_cancellations or pending:
+            raise ProcessCleanupError(
+                "attached container commands did not quiesce during abort"
             )
-            if failed_cancellations or pending:
-                raise ProcessCleanupError(
-                    "attached container commands did not quiesce during abort"
-                )
 
 __all__ = ["DockerEnvironment"]

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -36,21 +36,45 @@ pidfile=$1
 shellflag=$2
 command=$3
 cleanup() { rm -f -- "$pidfile"; }
-terminate() {
-    kill -TERM -- "-$child" 2>/dev/null || true
-    sleep 0.1
-    kill -KILL -- "-$child" 2>/dev/null || true
+group_alive() {
+    [ -n "$child" ] && kill -0 -- "-$child" 2>/dev/null
 }
-trap 'terminate; cleanup; exit 143' TERM INT HUP
+wait_for_group_exit() {
+    attempts=0
+    while group_alive; do
+        attempts=$((attempts + 1))
+        [ "$attempts" -ge 20 ] && return 1
+        sleep 0.05
+    done
+    return 0
+}
+terminate() {
+    if ! group_alive; then
+        return 0
+    fi
+    kill -TERM -- "-$child" 2>/dev/null || true
+    if wait_for_group_exit; then
+        return 0
+    fi
+    kill -KILL -- "-$child" 2>/dev/null || true
+    wait_for_group_exit
+}
+cancel_and_exit() {
+    if terminate; then
+        cleanup
+        exit 143
+    fi
+    exit 125
+}
+child=
+trap cancel_and_exit TERM INT HUP
 set -m
 bash "$shellflag" "$command" &
 child=$!
-printf '%s\n' "$child" > "$pidfile" || { terminate; cleanup; exit 125; }
+printf '%s\n' "$child" > "$pidfile" || { terminate || true; cleanup; exit 125; }
 wait "$child"
 status=$?
-if kill -0 -- "-$child" 2>/dev/null; then
-    terminate
-    cleanup
+if group_alive && ! terminate; then
     exit 125
 fi
 cleanup
@@ -63,11 +87,27 @@ if ! read -r child < "$pidfile" 2>/dev/null; then
     exit 124
 fi
 case "$child" in ''|*[!0-9]*) exit 125 ;; esac
+group_alive() {
+    kill -0 -- "-$child" 2>/dev/null
+}
+wait_for_group_exit() {
+    attempts=0
+    while group_alive; do
+        attempts=$((attempts + 1))
+        [ "$attempts" -ge 20 ] && return 1
+        sleep 0.05
+    done
+    return 0
+}
 kill -TERM -- "-$child" 2>/dev/null || true
-sleep 0.1
-kill -KILL -- "-$child" 2>/dev/null || true
-rm -f -- "$pidfile"
-exit 0
+if ! wait_for_group_exit; then
+    kill -KILL -- "-$child" 2>/dev/null || true
+    if ! wait_for_group_exit; then
+        exit 125
+    fi
+fi
+rm -f -- "$pidfile" && exit 0
+exit 125
 """.strip()
 
 

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -12,7 +12,7 @@ import uuid
 from collections.abc import Callable
 from typing import NoReturn
 
-from opencollab.adapters._env_base import Environment, ExecResult
+from opencollab.adapters._env_base import ENV_FILE_WRITE_LIMIT_BYTES, Environment, ExecResult
 from opencollab.adapters._env_process import (
     PROCESS_OUTPUT_CAPTURE_BYTES,
     ProcessCleanupError,
@@ -405,6 +405,10 @@ class DockerEnvironment(Environment):
 
     async def _write_file_atomic(self, target: str, content: str) -> None:
         payload = content.encode("utf-8")
+        if len(payload) > ENV_FILE_WRITE_LIMIT_BYTES:
+            raise OSError(
+                f"docker file exceeds write limit of {ENV_FILE_WRITE_LIMIT_BYTES} bytes: {target}"
+            )
         digest = hashlib.sha256(payload).hexdigest()
         directory, filename = posixpath.split(target)
         temporary = posixpath.join(

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -602,7 +602,7 @@ class DockerEnvironment(Environment):
     async def _cleanup_resources(self) -> None:
         failures: list[BaseException] = []
         if not await self._remove_container_if_owned():
-            failures.append(RuntimeError("owned Docker container could not be removed"))
+            raise RuntimeError("owned Docker container could not be removed")
         if self._backing_environment is not None:
             try:
                 await self._backing_environment.cleanup()

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import posixpath
 import re
 import shlex
 import uuid
@@ -28,6 +29,7 @@ DOCKER_WRITE_TIMEOUT_SECONDS = 120.0
 _IMAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@:+-]{0,511}$")
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,254}$")
 _FULL_ID_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_WRITE_LOCKS: dict[str, asyncio.Lock] = {}
 
 _EXEC_WRAPPER = r"""
 pidfile=$1
@@ -373,20 +375,85 @@ class DockerEnvironment(Environment):
         return result.stdout
 
     async def write_file(self, path: str, content: str) -> None:
+        self._ensure_active()
+        await self._bind_attached()
+        container_id = self._container_id
+        if container_id is None:
+            raise RuntimeError("Container not started. Call setup() first.")
+        target = self._normalize_container_path(path)
+        lock = _WRITE_LOCKS.setdefault(f"{container_id}\0{target}", asyncio.Lock())
+        async with lock:
+            self._ensure_active()
+            await self._write_file_atomic(target, content)
+
+    @staticmethod
+    def _normalize_container_path(path: str) -> str:
+        if not isinstance(path, str) or not path or "\0" in path:
+            raise ValueError("container file path must be non-empty text without NUL bytes")
+        normalized = posixpath.normpath(path)
+        if normalized in (".", "/") or posixpath.basename(normalized) in (".", ".."):
+            raise ValueError("container file path must name a file")
+        return normalized
+
+    async def _write_file_atomic(self, target: str, content: str) -> None:
         payload = content.encode("utf-8")
         digest = hashlib.sha256(payload).hexdigest()
-        command = (
-            'target=$1; mkdir -p -- "$(dirname -- "$target")" && cat > "$target" && '
-            'bytes=$(wc -c < "$target") && '
-            'digest=$(sha256sum -- "$target" 2>/dev/null | awk \'{print $1}\' || '
-            'shasum -a 256 -- "$target" | awk \'{print $1}\') && '
-            'printf "%s\\t%s\\n" "$bytes" "$digest"'
+        directory, filename = posixpath.split(target)
+        temporary = posixpath.join(
+            directory or ".",
+            f".{filename}.opencollab-write-{uuid.uuid4().hex}.tmp",
         )
-        wrapped = f"bash -c {shlex.quote(command)} opencollab-write {shlex.quote(path)}"
-        result = await self._exec(wrapped, timeout=DOCKER_WRITE_TIMEOUT_SECONDS, input_bytes=payload)
-        expected = f"{len(payload)}\t{digest}"
-        if result.returncode != 0 or result.stdout.strip() != expected:
-            raise OSError(f"docker write verification failed for {path}")
+        command = (
+            'target=$1; temporary=$2; expected_bytes=$3; expected_digest=$4; '
+            'cleanup() { rm -f -- "$temporary"; }; trap cleanup EXIT HUP INT TERM; '
+            'mkdir -p -- "$(dirname -- "$target")" && '
+            '(umask 077; set -C; : > "$temporary") && '
+            'cat > "$temporary" && '
+            'bytes=$(wc -c < "$temporary") && '
+            'digest=$(sha256sum -- "$temporary" 2>/dev/null | awk \'{print $1}\' || '
+            'shasum -a 256 -- "$temporary" | awk \'{print $1}\') && '
+            '[ "$bytes" = "$expected_bytes" ] && [ "$digest" = "$expected_digest" ] && '
+            'mv -f -- "$temporary" "$target" && '
+            'trap - EXIT HUP INT TERM && printf "%s\\t%s\\n" "$bytes" "$digest"'
+        )
+        wrapped = (
+            f"bash -c {shlex.quote(command)} opencollab-write {shlex.quote(target)} "
+            f"{shlex.quote(temporary)} {len(payload)} {digest}"
+        )
+        committed = False
+        try:
+            result = await self._exec(
+                wrapped,
+                timeout=DOCKER_WRITE_TIMEOUT_SECONDS,
+                input_bytes=payload,
+            )
+            expected = f"{len(payload)}\t{digest}"
+            if result.returncode != 0 or result.stdout.strip() != expected:
+                raise OSError(f"docker write verification failed for {target}")
+            committed = True
+        finally:
+            if not committed:
+                await await_owned_operation(
+                    self._discard_write_temporary(temporary),
+                    propagate_cancellation=False,
+                )
+
+    async def _discard_write_temporary(self, temporary: str) -> None:
+        container_id = self._container_id
+        if container_id is None:
+            return
+        try:
+            await self._docker(
+                "exec",
+                "--",
+                container_id,
+                "rm",
+                "-f",
+                "--",
+                temporary,
+            )
+        except BaseException:
+            pass
 
     async def write_temp_file(
         self,

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -151,6 +151,12 @@ class DockerEnvironment(Environment):
         super().__init__()
         if container_id is not None and backing_environment is not None:
             raise ValueError("an attached Docker environment cannot own a backing environment")
+        if (
+            isinstance(timeout_returncode, bool)
+            or not isinstance(timeout_returncode, int)
+            or timeout_returncode == 0
+        ):
+            raise ValueError("timeout_returncode must be a non-zero integer")
         self._image = _validate_image(image)
         self.workspace = workspace
         self._attached = container_id is not None

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -240,6 +240,11 @@ class DockerEnvironment(Environment):
             return self._container_id
         if self._container_id is not None:
             return self._container_id
+        host_mount: str | None = None
+        if mount_dir is not None:
+            host_mount = os.path.realpath(os.path.abspath(mount_dir))
+            if not os.path.isdir(host_mount):
+                raise NotADirectoryError(host_mount)
         self._container_name = f"opencollab-{uuid.uuid4().hex[:16]}"
         args = [
             "run",
@@ -252,8 +257,8 @@ class DockerEnvironment(Environment):
             "--label",
             f"{DOCKER_OWNER_LABEL}={self._owner_token}",
         ]
-        if mount_dir:
-            args.extend(("-v", f"{os.path.abspath(mount_dir)}:{self.workspace}"))
+        if host_mount is not None:
+            args.extend(("-v", f"{host_mount}:{self.workspace}"))
         args.extend(("-w", self.workspace, self._image, "sleep", "infinity"))
         try:
             result = await self._docker(*args, timeout=DOCKER_SETUP_TIMEOUT_SECONDS)
@@ -268,6 +273,7 @@ class DockerEnvironment(Environment):
                 )
             )
         self._container_id = candidate.lower()
+        self.host_workspace = host_mount
         return self._container_id
 
     async def _discard_failed_setup(self, failure: BaseException) -> NoReturn:

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -12,7 +12,12 @@ import uuid
 from collections.abc import Callable
 from typing import NoReturn
 
-from opencollab.adapters._env_base import ENV_FILE_WRITE_LIMIT_BYTES, Environment, ExecResult
+from opencollab.adapters._env_base import (
+    ENV_FILE_WRITE_LIMIT_BYTES,
+    Environment,
+    ExecResult,
+    TextFileRange,
+)
 from opencollab.adapters._env_process import (
     PROCESS_OUTPUT_CAPTURE_BYTES,
     ProcessCleanupError,
@@ -426,6 +431,54 @@ class DockerEnvironment(Environment):
         if result.stdout_truncated:
             raise OSError(f"docker read exceeded capture limit for {path}")
         return result.stdout
+
+    async def read_text_range(
+        self,
+        path: str,
+        *,
+        offset: int,
+        limit: int,
+        max_chars: int,
+    ) -> TextFileRange:
+        if (
+            isinstance(offset, bool)
+            or not isinstance(offset, int)
+            or offset < 1
+            or isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or limit < 1
+            or isinstance(max_chars, bool)
+            or not isinstance(max_chars, int)
+            or max_chars < 1
+        ):
+            raise ValueError("offset, limit, and max_chars must be positive integers")
+        final_line = offset + limit
+        byte_cap = max_chars * 4 + limit + 1
+        quoted_path = shlex.quote(path)
+        command = (
+            f"[ -f {quoted_path} ] && [ -r {quoted_path} ] || exit 66; "
+            "command -v sed >/dev/null && command -v head >/dev/null || exit 127; "
+            f"sed -n '{offset},{final_line}p;{final_line}q' < {quoted_path} "
+            f"| head -c {byte_cap}"
+        )
+        result = await self.exec_cmd(command)
+        if result.returncode != 0:
+            raise FileNotFoundError(result.stderr)
+        lines = result.stdout.splitlines()
+        has_more = len(lines) > limit
+        selected = lines[:limit]
+        joined = "\n".join(selected)
+        chars_truncated = len(joined) > max_chars or result.stdout_truncated
+        if chars_truncated:
+            selected = joined[:max_chars].split("\n")
+            has_more = True
+        return TextFileRange(
+            selected,
+            offset,
+            None,
+            has_more,
+            chars_truncated=chars_truncated,
+        )
 
     async def write_file(self, path: str, content: str) -> None:
         self._ensure_active()

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -155,6 +155,7 @@ class DockerEnvironment(Environment):
         self._container_id = self._attached_reference if self._attached else None
         self._attached_bound = False
         self._attach_lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
         self._active_exec_lock = asyncio.Lock()
         self._active_execs: dict[str, asyncio.Task | None] = {}
         self._container_name: str | None = None
@@ -217,6 +218,10 @@ class DockerEnvironment(Environment):
             self._attached_bound = True
 
     async def setup(self, mount_dir: str | None = None) -> str:
+        async with self._lifecycle_lock:
+            return await self._setup_locked(mount_dir)
+
+    async def _setup_locked(self, mount_dir: str | None) -> str:
         self._ensure_active()
         if self._attached:
             await self._bind_attached()
@@ -544,43 +549,50 @@ class DockerEnvironment(Environment):
             raise RuntimeError("Docker cleanup failed") from failures[0]
 
     async def cleanup(self) -> None:
-        if self._attached:
-            return
-        self.revoke()
-        await await_owned_operation(
-            self._cleanup_resources(),
-            propagate_cancellation=True,
-        )
+        async with self._lifecycle_lock:
+            if self._attached:
+                return
+            self.revoke()
+            await await_owned_operation(
+                self._cleanup_resources(),
+                propagate_cancellation=True,
+            )
 
     async def abort(self) -> None:
-        self.revoke()
-        if not self._attached:
-            await self.cleanup()
-            return
-        async with self._active_exec_lock:
-            active = dict(self._active_execs)
-        if not active:
-            return
-        cancelled = await asyncio.gather(
-            *(self._cancel_inner(token) for token in active),
-            return_exceptions=True,
-        )
-        current = asyncio.current_task()
-        pending = {
-            task
-            for task in active.values()
-            if task is not None and task is not current and not task.done()
-        }
-        if pending:
-            _done, pending = await asyncio.wait(
-                pending,
-                timeout=DOCKER_CONTROL_TIMEOUT_SECONDS,
+        async with self._lifecycle_lock:
+            self.revoke()
+            if not self._attached:
+                await await_owned_operation(
+                    self._cleanup_resources(),
+                    propagate_cancellation=True,
+                )
+                return
+            async with self._active_exec_lock:
+                active = dict(self._active_execs)
+            if not active:
+                return
+            cancelled = await asyncio.gather(
+                *(self._cancel_inner(token) for token in active),
+                return_exceptions=True,
             )
-        failed_cancellations = any(
-            result is not True and (task is None or not task.done())
-            for result, task in zip(cancelled, active.values())
-        )
-        if failed_cancellations or pending:
-            raise ProcessCleanupError("attached container commands did not quiesce during abort")
+            current = asyncio.current_task()
+            pending = {
+                task
+                for task in active.values()
+                if task is not None and task is not current and not task.done()
+            }
+            if pending:
+                _done, pending = await asyncio.wait(
+                    pending,
+                    timeout=DOCKER_CONTROL_TIMEOUT_SECONDS,
+                )
+            failed_cancellations = any(
+                result is not True and (task is None or not task.done())
+                for result, task in zip(cancelled, active.values())
+            )
+            if failed_cancellations or pending:
+                raise ProcessCleanupError(
+                    "attached container commands did not quiesce during abort"
+                )
 
 __all__ = ["DockerEnvironment"]

--- a/opencollab/adapters/_env_local.py
+++ b/opencollab/adapters/_env_local.py
@@ -77,7 +77,7 @@ class LocalEnvironment(Environment):
     async def read_file(self, path: str) -> str:
         self._ensure_active()
         payload = read_regular_bytes(self._full_path(path), max_bytes=LOCAL_FILE_READ_LIMIT_BYTES)
-        return payload.decode("utf-8", errors="replace")
+        return payload.decode("utf-8")
 
     async def write_file(self, path: str, content: str) -> None:
         self._ensure_active()

--- a/opencollab/adapters/_env_local.py
+++ b/opencollab/adapters/_env_local.py
@@ -7,7 +7,7 @@ import os
 import re
 import uuid
 
-from opencollab.adapters._env_base import Environment, ExecResult
+from opencollab.adapters._env_base import ENV_FILE_WRITE_LIMIT_BYTES, Environment, ExecResult
 from opencollab.adapters._env_process import (
     PROCESS_OUTPUT_CAPTURE_BYTES,
     ProcessCleanupError,
@@ -22,7 +22,7 @@ from opencollab.adapters.safe_files import (
 )
 
 LOCAL_FILE_READ_LIMIT_BYTES = 4 * 1024 * 1024
-LOCAL_FILE_WRITE_LIMIT_BYTES = 4 * 1024 * 1024
+LOCAL_FILE_WRITE_LIMIT_BYTES = ENV_FILE_WRITE_LIMIT_BYTES
 _TEMP_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 

--- a/opencollab/adapters/_env_local.py
+++ b/opencollab/adapters/_env_local.py
@@ -9,7 +9,12 @@ import uuid
 from collections.abc import Callable
 from typing import TypeVar
 
-from opencollab.adapters._env_base import ENV_FILE_WRITE_LIMIT_BYTES, Environment, ExecResult
+from opencollab.adapters._env_base import (
+    ENV_FILE_WRITE_LIMIT_BYTES,
+    Environment,
+    ExecResult,
+    TextFileRange,
+)
 from opencollab.adapters._env_process import (
     PROCESS_OUTPUT_CAPTURE_BYTES,
     ProcessCleanupError,
@@ -19,6 +24,7 @@ from opencollab.adapters._env_process import (
 from opencollab.adapters.safe_files import (
     create_regular_bytes_atomic,
     read_regular_bytes,
+    read_regular_text_range,
     unlink_regular_file_durable,
     write_regular_bytes_atomic,
 )
@@ -114,6 +120,22 @@ class LocalEnvironment(Environment):
             max_bytes=LOCAL_FILE_READ_LIMIT_BYTES,
         )
         return payload.decode("utf-8")
+
+    async def read_text_range(
+        self,
+        path: str,
+        *,
+        offset: int,
+        limit: int,
+        max_chars: int,
+    ) -> TextFileRange:
+        return await self._run_file_operation(
+            read_regular_text_range,
+            self._full_path(path),
+            offset=offset,
+            limit=limit,
+            max_chars=max_chars,
+        )
 
     async def write_file(self, path: str, content: str) -> None:
         self._ensure_active()

--- a/opencollab/adapters/_env_local.py
+++ b/opencollab/adapters/_env_local.py
@@ -6,6 +6,8 @@ import asyncio
 import os
 import re
 import uuid
+from collections.abc import Callable
+from typing import TypeVar
 
 from opencollab.adapters._env_base import ENV_FILE_WRITE_LIMIT_BYTES, Environment, ExecResult
 from opencollab.adapters._env_process import (
@@ -20,10 +22,13 @@ from opencollab.adapters.safe_files import (
     unlink_regular_file_durable,
     write_regular_bytes_atomic,
 )
+from opencollab.application.async_timeout import await_owned_operation, consume_task_result
 
 LOCAL_FILE_READ_LIMIT_BYTES = 4 * 1024 * 1024
 LOCAL_FILE_WRITE_LIMIT_BYTES = ENV_FILE_WRITE_LIMIT_BYTES
 _TEMP_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_FILE_IO_CONCURRENCY = 4
+T = TypeVar("T")
 
 
 class LocalEnvironment(Environment):
@@ -41,6 +46,8 @@ class LocalEnvironment(Environment):
         self.source_workspace = self.workspace
         self._processes = ProcessRegistry()
         self._temporary_files: set[str] = set()
+        self._file_io_semaphore = asyncio.Semaphore(_FILE_IO_CONCURRENCY)
+        self._file_operations: set[asyncio.Task] = set()
 
     def _full_path(self, path: str) -> str:
         if not isinstance(path, str) or not path or "\0" in path:
@@ -74,9 +81,38 @@ class LocalEnvironment(Environment):
             raise
         return result.to_exec_result()
 
+    async def _execute_file_operation(
+        self,
+        operation: Callable[..., T],
+        *args: object,
+        **kwargs: object,
+    ) -> T:
+        async with self._file_io_semaphore:
+            return await asyncio.to_thread(operation, *args, **kwargs)
+
+    async def _run_file_operation(
+        self,
+        operation: Callable[..., T],
+        *args: object,
+        require_active: bool = True,
+        **kwargs: object,
+    ) -> T:
+        if require_active:
+            self._ensure_active()
+        owner = asyncio.create_task(
+            self._execute_file_operation(operation, *args, **kwargs)
+        )
+        self._file_operations.add(owner)
+        owner.add_done_callback(self._file_operations.discard)
+        owner.add_done_callback(consume_task_result)
+        return await asyncio.shield(owner)
+
     async def read_file(self, path: str) -> str:
-        self._ensure_active()
-        payload = read_regular_bytes(self._full_path(path), max_bytes=LOCAL_FILE_READ_LIMIT_BYTES)
+        payload = await self._run_file_operation(
+            read_regular_bytes,
+            self._full_path(path),
+            max_bytes=LOCAL_FILE_READ_LIMIT_BYTES,
+        )
         return payload.decode("utf-8")
 
     async def write_file(self, path: str, content: str) -> None:
@@ -86,7 +122,8 @@ class LocalEnvironment(Environment):
             raise OSError(
                 f"local file exceeds write limit of {LOCAL_FILE_WRITE_LIMIT_BYTES} bytes: {path}"
             )
-        write_regular_bytes_atomic(
+        await self._run_file_operation(
+            write_regular_bytes_atomic,
             self._full_path(path),
             payload,
             max_bytes=LOCAL_FILE_WRITE_LIMIT_BYTES,
@@ -106,33 +143,48 @@ class LocalEnvironment(Environment):
         if len(payload) > LOCAL_FILE_WRITE_LIMIT_BYTES:
             raise OSError("temporary file exceeds local write limit")
         path = os.path.join(self.workspace, f"{prefix}{uuid.uuid4().hex}{suffix}")
-        create_regular_bytes_atomic(
+        self._temporary_files.add(path)
+        await self._run_file_operation(
+            create_regular_bytes_atomic,
             path,
             payload,
             max_bytes=LOCAL_FILE_WRITE_LIMIT_BYTES,
         )
-        self._temporary_files.add(path)
         return path
 
     async def remove_file(self, path: str) -> None:
+        self._ensure_active()
         target = self._full_path(path)
         if target not in self._temporary_files:
             raise OSError(f"refusing to remove unowned local temporary file: {path}")
-        unlink_regular_file_durable(target)
+        await self._run_file_operation(unlink_regular_file_durable, target)
         self._temporary_files.discard(target)
 
-    async def cleanup(self) -> None:
-        self.revoke()
-        await self._processes.abort()
+    async def _cleanup_files(self) -> None:
+        while self._file_operations:
+            pending = tuple(self._file_operations)
+            await asyncio.gather(*pending, return_exceptions=True)
         failures: list[OSError] = []
         for path in tuple(self._temporary_files):
             try:
-                unlink_regular_file_durable(path)
+                await self._run_file_operation(
+                    unlink_regular_file_durable,
+                    path,
+                    require_active=False,
+                )
             except OSError as exc:
                 failures.append(exc)
             else:
                 self._temporary_files.discard(path)
         if failures:
             raise OSError("failed to remove one or more environment temporary files") from failures[0]
+
+    async def cleanup(self) -> None:
+        self.revoke()
+        await self._processes.abort()
+        await await_owned_operation(
+            self._cleanup_files(),
+            propagate_cancellation=True,
+        )
 
 __all__ = ["LocalEnvironment"]

--- a/opencollab/adapters/_env_process.py
+++ b/opencollab/adapters/_env_process.py
@@ -48,17 +48,25 @@ async def _read_bounded(
 ) -> tuple[bytes, int]:
     if stream is None:
         return b"", 0
-    retained = bytearray()
-    dropped = 0
+    head_limit = (limit + 1) // 2
+    tail_limit = limit - head_limit
+    head = bytearray()
+    tail = bytearray()
+    total = 0
     while True:
         chunk = await stream.read(64 * 1024)
         if not chunk:
             break
-        available = max(0, limit - len(retained))
-        kept = chunk[:available]
-        retained.extend(kept)
-        dropped += len(chunk) - len(kept)
-    return bytes(retained), dropped
+        total += len(chunk)
+        available = max(0, head_limit - len(head))
+        head.extend(chunk[:available])
+        remainder = chunk[available:]
+        if tail_limit and remainder:
+            tail.extend(remainder)
+            if len(tail) > tail_limit:
+                del tail[:-tail_limit]
+    retained = bytes(head + tail)
+    return retained, max(0, total - len(retained))
 
 
 def _group_exists(group_id: int) -> bool:

--- a/opencollab/adapters/_env_process.py
+++ b/opencollab/adapters/_env_process.py
@@ -15,6 +15,7 @@ from opencollab.application.async_timeout import await_owned_operation
 PROCESS_OUTPUT_CAPTURE_BYTES = 1024 * 1024
 PROCESS_TERM_GRACE_SECONDS = 0.05
 PROCESS_KILL_GRACE_SECONDS = 2.0
+_BACKGROUND_SPAWN_CLEANUPS: set[asyncio.Task[None]] = set()
 
 
 class ProcessCleanupError(RuntimeError):
@@ -182,7 +183,15 @@ class ProcessRegistry:
     async def _abort_owned(self) -> None:
         async with self._condition:
             self._revoked = True
-            await self._condition.wait_for(lambda: self._handoffs == 0)
+            try:
+                await asyncio.wait_for(
+                    self._condition.wait_for(lambda: self._handoffs == 0),
+                    timeout=PROCESS_KILL_GRACE_SECONDS,
+                )
+            except asyncio.TimeoutError as exc:
+                raise ProcessCleanupError(
+                    "subprocess spawn handoff did not quiesce"
+                ) from exc
             processes = tuple(self._processes)
         results = await asyncio.gather(
             *(terminate_process(process) for process in processes),
@@ -214,6 +223,64 @@ async def _spawn_owned(
         raise cancellation
 
 
+def _retain_spawn_cleanup(task: asyncio.Task[None]) -> None:
+    """Keep a late spawn reaper alive and consume its terminal result."""
+    _BACKGROUND_SPAWN_CLEANUPS.add(task)
+
+    def finish(completed: asyncio.Task[None]) -> None:
+        _BACKGROUND_SPAWN_CLEANUPS.discard(completed)
+        try:
+            completed.result()
+        except BaseException:
+            pass
+
+    task.add_done_callback(finish)
+
+
+async def _reap_late_spawn(
+    spawn_owner: asyncio.Task[asyncio.subprocess.Process],
+    registry: ProcessRegistry | None,
+) -> None:
+    """Terminate a process that appears after its caller stopped waiting."""
+    try:
+        process = await spawn_owner
+    except BaseException:
+        return
+    await _require_process_exit(
+        process,
+        "late subprocess spawn did not quiesce",
+        propagate=False,
+    )
+    if registry is not None:
+        registry.discard(process)
+
+
+async def _spawn_before_deadline(
+    spawn_awaitable: Awaitable[asyncio.subprocess.Process],
+    *,
+    deadline: float,
+    registry: ProcessRegistry | None,
+) -> asyncio.subprocess.Process:
+    """Bound the spawn handoff while preserving ownership of late processes."""
+    spawn_owner = asyncio.create_task(spawn_awaitable)
+    remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+    try:
+        done, _pending = await asyncio.wait({spawn_owner}, timeout=remaining)
+    except asyncio.CancelledError:
+        spawn_owner.cancel()
+        _retain_spawn_cleanup(
+            asyncio.create_task(_reap_late_spawn(spawn_owner, registry))
+        )
+        raise
+    if spawn_owner not in done:
+        spawn_owner.cancel()
+        _retain_spawn_cleanup(
+            asyncio.create_task(_reap_late_spawn(spawn_owner, registry))
+        )
+        raise asyncio.TimeoutError("subprocess spawn exceeded command timeout")
+    return spawn_owner.result()
+
+
 async def run_process(
     command: str | Sequence[str],
     *,
@@ -230,6 +297,8 @@ async def run_process(
         raise ValueError("timeout must be a positive number")
     if not isinstance(output_limit, int) or isinstance(output_limit, bool) or output_limit < 0:
         raise ValueError("output_limit must be a non-negative integer")
+    timeout_seconds = float(timeout)
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
     process_kwargs: dict[str, Any] = {
         "cwd": cwd,
         "env": env,
@@ -249,7 +318,11 @@ async def run_process(
             raise TypeError("exec commands must be a sequence")
         return await asyncio.create_subprocess_exec(*command, **process_kwargs)
 
-    process = await (registry.spawn(spawn) if registry is not None else _spawn_owned(spawn))
+    process = await _spawn_before_deadline(
+        registry.spawn(spawn) if registry is not None else _spawn_owned(spawn),
+        deadline=deadline,
+        registry=registry,
+    )
 
     stdout_task = asyncio.create_task(_read_bounded(process.stdout, output_limit))
     stderr_task = asyncio.create_task(_read_bounded(process.stderr, output_limit))
@@ -272,7 +345,8 @@ async def run_process(
 
     try:
         try:
-            await asyncio.wait_for(write_input_and_wait(), timeout=float(timeout))
+            remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+            await asyncio.wait_for(write_input_and_wait(), timeout=remaining)
         except asyncio.TimeoutError as exc:
             await _require_process_exit(process, "timed out command did not quiesce", exc)
             quiesced = True

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -47,6 +47,7 @@ class WorktreeEnvironment(Environment):
         self._branch_owned = False
         self._owned_branch_oid: str | None = None
         self._worktree_registered = False
+        self._lifecycle_lock = asyncio.Lock()
 
     async def _git(self, *args: str, timeout: float = WORKTREE_GIT_TIMEOUT_SECONDS) -> ExecResult:
         result = await run_process(
@@ -58,6 +59,10 @@ class WorktreeEnvironment(Environment):
         return result.to_exec_result()
 
     async def setup(self, mount_dir: str | None = None) -> str:
+        async with self._lifecycle_lock:
+            return await self._setup_locked(mount_dir)
+
+    async def _setup_locked(self, mount_dir: str | None) -> str:
         self._ensure_active()
         if mount_dir is not None:
             raise ValueError("mount_dir is supported only by container environments")
@@ -331,11 +336,21 @@ class WorktreeEnvironment(Environment):
             raise RuntimeError("worktree cleanup failed") from failures[0]
 
     async def cleanup(self) -> None:
-        await self._ensure_directory_copy_changes_exported()
-        self.revoke()
-        await await_owned_operation(
-            self._cleanup_resources(),
-            propagate_cancellation=True,
-        )
+        async with self._lifecycle_lock:
+            await self._ensure_directory_copy_changes_exported()
+            self.revoke()
+            await await_owned_operation(
+                self._cleanup_resources(),
+                propagate_cancellation=True,
+            )
+
+    async def abort(self) -> None:
+        async with self._lifecycle_lock:
+            self.revoke()
+            await self._ensure_directory_copy_changes_exported()
+            await await_owned_operation(
+                self._cleanup_resources(),
+                propagate_cancellation=True,
+            )
 
 __all__ = ["WorktreeEnvironment"]

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -215,23 +215,25 @@ class WorktreeEnvironment(Environment):
         self._worktree_registered = True
         await self._initialize_available_submodules()
 
-    async def _worktree_git(self, *args: str) -> ExecResult:
-        assert self._worktree_dir is not None
+    async def _git_in(self, workspace: str, *args: str) -> ExecResult:
         result = await run_process(
-            ("git", "-C", self._worktree_dir, *args),
+            ("git", "-C", workspace, *args),
             shell=False,
             timeout=WORKTREE_GIT_TIMEOUT_SECONDS,
         )
         return result.to_exec_result()
 
-    async def _initialize_available_submodules(self) -> None:
-        repository_root = self._repository_root
-        if repository_root is None or self._worktree_dir is None:
-            return
-        modules_file = os.path.join(repository_root, ".gitmodules")
+    async def _configured_source_submodules(
+        self,
+        source_repository: str,
+        *,
+        source_prefix: str,
+    ) -> list[tuple[str, str, str]]:
+        modules_file = os.path.join(source_repository, ".gitmodules")
         if not os.path.isfile(modules_file):
-            return
-        configured = await self._git(
+            return []
+        configured = await self._git_in(
+            source_repository,
             "config",
             "--file",
             modules_file,
@@ -239,7 +241,7 @@ class WorktreeEnvironment(Environment):
             r"^submodule\..*\.path$",
         )
         if configured.returncode == 1:
-            return
+            return []
         if (
             configured.returncode != 0
             or configured.stdout_truncated
@@ -247,9 +249,7 @@ class WorktreeEnvironment(Environment):
         ):
             raise RuntimeError("cannot inspect Git submodule configuration")
 
-        paths: list[str] = []
-        url_overrides: list[str] = []
-        source_prefix = self._source_subdir.replace(os.sep, "/").rstrip("/")
+        submodules: list[tuple[str, str, str]] = []
         for line in configured.stdout.splitlines():
             try:
                 key, configured_path = line.split(maxsplit=1)
@@ -273,56 +273,102 @@ class WorktreeEnvironment(Environment):
             ):
                 continue
             source_module = os.path.realpath(
-                os.path.join(repository_root, *normalized_path.split("/"))
+                os.path.join(source_repository, *normalized_path.split("/"))
             )
-            if (
-                os.path.commonpath((repository_root, source_module))
-                != repository_root
-                or not os.path.isdir(source_module)
-            ):
+            try:
+                contained = os.path.commonpath((source_repository, source_module))
+            except ValueError:
+                contained = ""
+            if contained != source_repository or not os.path.isdir(source_module):
                 raise RuntimeError(
                     f"Git submodule is not initialized in source workspace: {configured_path}"
                 )
-            available = await run_process(
-                ("git", "-C", source_module, "rev-parse", "--is-inside-work-tree"),
-                shell=False,
-                timeout=WORKTREE_GIT_TIMEOUT_SECONDS,
+            available = await self._git_in(
+                source_module,
+                "rev-parse",
+                "--show-toplevel",
             )
             if (
                 available.returncode != 0
-                or available.stdout_dropped_bytes > 0
-                or available.stderr_dropped_bytes > 0
-                or available.stdout.decode("ascii", errors="ignore").strip() != "true"
+                or available.stdout_truncated
+                or available.stderr_truncated
+                or os.path.realpath(available.stdout.strip()) != source_module
             ):
                 raise RuntimeError(
                     f"Git submodule is not initialized in source workspace: {configured_path}"
                 )
-            paths.append(normalized_path)
-            url_overrides.extend(("-c", f"submodule.{name}.url={source_module}"))
+            submodules.append((name, normalized_path, source_module))
+        return submodules
 
-        if not paths:
+    async def _initialize_source_submodule_tree(
+        self,
+        source_repository: str,
+        target_repository: str,
+        *,
+        source_prefix: str,
+        active_sources: set[str],
+    ) -> None:
+        source_repository = os.path.realpath(source_repository)
+        if source_repository in active_sources:
+            raise RuntimeError("cyclic initialized Git submodule source")
+        active_sources.add(source_repository)
+        try:
+            submodules = await self._configured_source_submodules(
+                source_repository,
+                source_prefix=source_prefix,
+            )
+            for name, normalized_path, source_module in submodules:
+                updated = await self._git_in(
+                    target_repository,
+                    "-c",
+                    "protocol.allow=never",
+                    "-c",
+                    "protocol.file.allow=always",
+                    "-c",
+                    f"submodule.{name}.url={source_module}",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--no-fetch",
+                    "--",
+                    normalized_path,
+                )
+                if (
+                    updated.returncode != 0
+                    or updated.stdout_truncated
+                    or updated.stderr_truncated
+                ):
+                    detail = updated.stderr.strip() or "submodule checkout failed"
+                    raise RuntimeError(
+                        "cannot initialize source-available submodule "
+                        f"{normalized_path}: {detail}"
+                    )
+                target_module = os.path.realpath(
+                    os.path.join(
+                        target_repository,
+                        *normalized_path.split("/"),
+                    )
+                )
+                await self._initialize_source_submodule_tree(
+                    source_module,
+                    target_module,
+                    source_prefix="",
+                    active_sources=active_sources,
+                )
+        finally:
+            active_sources.remove(source_repository)
+
+    async def _initialize_available_submodules(self) -> None:
+        repository_root = self._repository_root
+        worktree_dir = self._worktree_dir
+        if repository_root is None or worktree_dir is None:
             return
-        updated = await self._worktree_git(
-            "-c",
-            "protocol.allow=never",
-            "-c",
-            "protocol.file.allow=always",
-            *url_overrides,
-            "submodule",
-            "update",
-            "--init",
-            "--no-fetch",
-            "--recursive",
-            "--",
-            *paths,
+        await self._initialize_source_submodule_tree(
+            repository_root,
+            worktree_dir,
+            source_prefix=self._source_subdir.replace(os.sep, "/").rstrip("/"),
+            active_sources=set(),
         )
-        if (
-            updated.returncode != 0
-            or updated.stdout_truncated
-            or updated.stderr_truncated
-        ):
-            detail = updated.stderr.strip() or "submodule checkout failed"
-            raise RuntimeError(f"cannot initialize source-available submodules: {detail}")
 
     async def _setup_directory_copy(self) -> None:
         self._copy_baseline_dir = tempfile.mkdtemp(prefix="opencollab-cp-baseline-")

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import shlex
 import shutil
 import tempfile
 import uuid
@@ -38,6 +39,8 @@ class WorktreeEnvironment(Environment):
         if not _BRANCH_RE.fullmatch(self._branch):
             raise ValueError("worktree branch name must be one safe Git ref component")
         self._worktree_dir: str | None = None
+        self._copy_baseline_dir: str | None = None
+        self._copy_exported_diff: str | None = None
         self._local_env: LocalEnvironment | None = None
         self._base_commit: str | None = None
         self._git_mode = False
@@ -144,7 +147,14 @@ class WorktreeEnvironment(Environment):
         self._worktree_registered = True
 
     def _setup_directory_copy(self) -> None:
+        self._copy_baseline_dir = tempfile.mkdtemp(prefix="opencollab-cp-baseline-")
         self._worktree_dir = tempfile.mkdtemp(prefix="opencollab-cp-")
+        shutil.copytree(
+            self._source,
+            self._copy_baseline_dir,
+            dirs_exist_ok=True,
+            symlinks=True,
+        )
         shutil.copytree(
             self._source,
             self._worktree_dir,
@@ -168,8 +178,12 @@ class WorktreeEnvironment(Environment):
 
     async def get_diff(self) -> str:
         self._ensure_active()
-        if self._local_env is None or not self._git_mode:
+        if self._local_env is None:
             return ""
+        if not self._git_mode:
+            diff = await self._directory_copy_diff()
+            self._copy_exported_diff = diff
+            return diff
         if self._base_commit is None:
             raise RuntimeError("worktree base commit is unavailable")
         result = await self._local_env.exec_cmd(
@@ -181,6 +195,38 @@ class WorktreeEnvironment(Environment):
             detail = result.stderr.strip() or f"git exited with status {result.returncode}"
             raise RuntimeError(f"worktree diff extraction failed: {detail}")
         return result.stdout
+
+    async def _directory_copy_diff(self) -> str:
+        if self._copy_baseline_dir is None or self._worktree_dir is None:
+            raise RuntimeError("non-Git worktree baseline is unavailable")
+        command = (
+            "git diff --no-index --binary --no-ext-diff -- "
+            f"{shlex.quote(self._copy_baseline_dir)} {shlex.quote(self._worktree_dir)}"
+        )
+        assert self._local_env is not None
+        result = await self._local_env.exec_cmd(command)
+        if result.stdout_truncated or result.stderr_truncated:
+            raise RuntimeError("non-Git worktree diff exceeded capture limit")
+        if result.returncode not in (0, 1):
+            detail = result.stderr.strip() or f"git exited with status {result.returncode}"
+            raise RuntimeError(f"non-Git worktree diff extraction failed: {detail}")
+        return (
+            result.stdout
+            .replace(f"a{self._copy_baseline_dir}/", "a/")
+            .replace(f"a{self._worktree_dir}/", "a/")
+            .replace(f"b{self._copy_baseline_dir}/", "b/")
+            .replace(f"b{self._worktree_dir}/", "b/")
+        )
+
+    async def _ensure_directory_copy_changes_exported(self) -> None:
+        if self._git_mode or self._copy_baseline_dir is None or self._worktree_dir is None:
+            return
+        current = await self._directory_copy_diff()
+        if current != (self._copy_exported_diff or ""):
+            raise RuntimeError(
+                "refusing to clean unexported non-Git worktree changes; "
+                "call get_diff() and deliver its artifact first"
+            )
 
     async def exec_cmd(self, cmd: str, timeout: float = 120.0) -> ExecResult:
         self._ensure_active()
@@ -244,6 +290,15 @@ class WorktreeEnvironment(Environment):
                 failures.append(exc)
             else:
                 self._worktree_dir = None
+        if self._worktree_dir is None and self._copy_baseline_dir is not None:
+            try:
+                shutil.rmtree(self._copy_baseline_dir)
+            except FileNotFoundError:
+                self._copy_baseline_dir = None
+            except BaseException as exc:
+                failures.append(exc)
+            else:
+                self._copy_baseline_dir = None
         if self._git_mode and self._branch_owned and self._worktree_dir is None:
             expected_oid = self._owned_branch_oid
             if expected_oid is None:
@@ -268,6 +323,7 @@ class WorktreeEnvironment(Environment):
             raise RuntimeError("worktree cleanup failed") from failures[0]
 
     async def cleanup(self) -> None:
+        await self._ensure_directory_copy_changes_exported()
         self.revoke()
         await await_owned_operation(
             self._cleanup_resources(),

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -69,6 +69,7 @@ class WorktreeEnvironment(Environment):
         self._lifecycle_lock = asyncio.Lock()
         self._source_subdir = ""
         self._repository_root: str | None = None
+        self._git_diff_delivery_pending = False
 
     async def _git(self, *args: str, timeout: float = WORKTREE_GIT_TIMEOUT_SECONDS) -> ExecResult:
         result = await run_process(
@@ -371,14 +372,21 @@ class WorktreeEnvironment(Environment):
             return diff
         if self._base_commit is None:
             raise RuntimeError("worktree base commit is unavailable")
+        self._git_diff_delivery_pending = True
         result = await self._local_env.exec_cmd(
             guarded_staged_diff_command(base_revision=self._base_commit)
         )
         if result.stdout_truncated or result.stderr_truncated:
-            raise RuntimeError("worktree diff exceeded capture limit")
+            raise RuntimeError(
+                f"worktree diff exceeded capture limit; worktree retained at {self.workspace}"
+            )
         if result.returncode != 0:
             detail = result.stderr.strip() or f"git exited with status {result.returncode}"
-            raise RuntimeError(f"worktree diff extraction failed: {detail}")
+            raise RuntimeError(
+                f"worktree diff extraction failed: {detail}; "
+                f"worktree retained at {self.workspace}"
+            )
+        self._git_diff_delivery_pending = False
         return result.stdout
 
     async def _directory_copy_diff(self) -> str:
@@ -529,6 +537,11 @@ class WorktreeEnvironment(Environment):
     async def cleanup(self) -> None:
         async with self._lifecycle_lock:
             await self._ensure_directory_copy_changes_exported()
+            if self._git_mode and self._git_diff_delivery_pending:
+                raise RuntimeError(
+                    "refusing to clean undelivered Git worktree changes; "
+                    f"worktree retained at {self.workspace}"
+                )
             self.revoke()
             await await_owned_operation(
                 self._cleanup_resources(),
@@ -537,8 +550,13 @@ class WorktreeEnvironment(Environment):
 
     async def abort(self) -> None:
         async with self._lifecycle_lock:
-            self.revoke()
             await self._ensure_directory_copy_changes_exported()
+            if self._git_mode and self._git_diff_delivery_pending:
+                raise RuntimeError(
+                    "refusing to clean undelivered Git worktree changes; "
+                    f"worktree retained at {self.workspace}"
+                )
+            self.revoke()
             await await_owned_operation(
                 self._cleanup_resources(),
                 propagate_cancellation=True,

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -18,6 +18,7 @@ from opencollab.application.exception_notes import add_exception_note
 
 WORKTREE_GIT_TIMEOUT_SECONDS = 30.0
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,180}$")
+_ZERO_OID = "0" * 40
 
 
 class WorktreeEnvironment(Environment):
@@ -41,6 +42,7 @@ class WorktreeEnvironment(Environment):
         self._base_commit: str | None = None
         self._git_mode = False
         self._branch_owned = False
+        self._owned_branch_oid: str | None = None
         self._worktree_registered = False
 
     async def _git(self, *args: str, timeout: float = WORKTREE_GIT_TIMEOUT_SECONDS) -> ExecResult:
@@ -108,13 +110,32 @@ class WorktreeEnvironment(Environment):
         if base.returncode != 0 or base.stdout_truncated or base.stderr_truncated:
             raise RuntimeError("cannot resolve worktree base commit")
         self._base_commit = base.stdout.strip()
-        self._worktree_dir = tempfile.mkdtemp(prefix="opencollab-wt-")
+        claimed = await self._git(
+            "update-ref",
+            f"refs/heads/{self._branch}",
+            self._base_commit,
+            _ZERO_OID,
+        )
+        if claimed.returncode != 0:
+            branch_probe = await self._git(
+                "show-ref",
+                "--verify",
+                "--quiet",
+                f"refs/heads/{self._branch}",
+            )
+            if branch_probe.returncode == 0:
+                raise RuntimeError(f"git worktree branch already exists: {self._branch}")
+            raise RuntimeError(f"cannot atomically claim worktree branch: {claimed.stderr.strip()}")
         self._branch_owned = True
+        self._owned_branch_oid = self._base_commit
+        self._worktree_dir = tempfile.mkdtemp(prefix="opencollab-wt-")
+        # The claimed ref is an ownership lease, not the worktree's HEAD. A
+        # detached worktree keeps its own commits from moving that lease, so a
+        # later external ref advance is observable and cannot be deleted by us.
         added = await self._git(
             "worktree",
             "add",
-            "-b",
-            self._branch,
+            "--detach",
             self._worktree_dir,
             self._base_commit,
         )
@@ -143,6 +164,7 @@ class WorktreeEnvironment(Environment):
         if deleted.returncode != 0:
             raise RuntimeError(f"cannot delete owned worktree branch: {deleted.stderr.strip()}")
         self._branch_owned = False
+        self._owned_branch_oid = None
 
     async def get_diff(self) -> str:
         self._ensure_active()
@@ -223,16 +245,25 @@ class WorktreeEnvironment(Environment):
             else:
                 self._worktree_dir = None
         if self._git_mode and self._branch_owned and self._worktree_dir is None:
-            branch = await self._git("rev-parse", f"refs/heads/{self._branch}")
-            if branch.returncode == 0:
-                try:
-                    await self._delete_owned_branch(branch.stdout.strip())
-                except BaseException as exc:
-                    failures.append(exc)
-            elif branch.returncode == 128:
+            expected_oid = self._owned_branch_oid
+            if expected_oid is None:
                 self._branch_owned = False
             else:
-                failures.append(RuntimeError("cannot inspect owned worktree branch"))
+                branch = await self._git("rev-parse", f"refs/heads/{self._branch}")
+                if branch.returncode == 0:
+                    if branch.stdout.strip() == expected_oid:
+                        try:
+                            await self._delete_owned_branch(expected_oid)
+                        except BaseException as exc:
+                            failures.append(exc)
+                    else:
+                        self._branch_owned = False
+                        self._owned_branch_oid = None
+                elif branch.returncode == 128:
+                    self._branch_owned = False
+                    self._owned_branch_oid = None
+                else:
+                    failures.append(RuntimeError("cannot inspect owned worktree branch"))
         if failures:
             raise RuntimeError("worktree cleanup failed") from failures[0]
 

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 import uuid
 
-from opencollab.adapters._env_base import Environment, ExecResult
+from opencollab.adapters._env_base import Environment, ExecResult, TextFileRange
 from opencollab.adapters._env_local import LocalEnvironment
 from opencollab.adapters._env_process import run_process
 from opencollab.adapters.git_patch import guarded_staged_diff_command
@@ -290,6 +290,25 @@ class WorktreeEnvironment(Environment):
             await self.setup()
         assert self._local_env is not None
         return await self._local_env.read_file(path)
+
+    async def read_text_range(
+        self,
+        path: str,
+        *,
+        offset: int,
+        limit: int,
+        max_chars: int,
+    ) -> TextFileRange:
+        self._ensure_active()
+        if self._local_env is None:
+            await self.setup()
+        assert self._local_env is not None
+        return await self._local_env.read_text_range(
+            path,
+            offset=offset,
+            limit=limit,
+            max_chars=max_chars,
+        )
 
     async def write_file(self, path: str, content: str) -> None:
         self._ensure_active()

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -71,7 +71,7 @@ class WorktreeEnvironment(Environment):
             if self._git_mode:
                 await self._setup_git_worktree()
             else:
-                self._setup_directory_copy()
+                await self._setup_directory_copy()
         except BaseException as original:
             try:
                 await await_owned_operation(
@@ -146,20 +146,28 @@ class WorktreeEnvironment(Environment):
             raise RuntimeError(f"git worktree add failed: {added.stderr.strip()}")
         self._worktree_registered = True
 
-    def _setup_directory_copy(self) -> None:
+    async def _setup_directory_copy(self) -> None:
         self._copy_baseline_dir = tempfile.mkdtemp(prefix="opencollab-cp-baseline-")
         self._worktree_dir = tempfile.mkdtemp(prefix="opencollab-cp-")
-        shutil.copytree(
-            self._source,
-            self._copy_baseline_dir,
-            dirs_exist_ok=True,
-            symlinks=True,
+        await await_owned_operation(
+            asyncio.to_thread(
+                shutil.copytree,
+                self._source,
+                self._copy_baseline_dir,
+                dirs_exist_ok=True,
+                symlinks=True,
+            ),
+            propagate_cancellation=True,
         )
-        shutil.copytree(
-            self._source,
-            self._worktree_dir,
-            dirs_exist_ok=True,
-            symlinks=True,
+        await await_owned_operation(
+            asyncio.to_thread(
+                shutil.copytree,
+                self._source,
+                self._worktree_dir,
+                dirs_exist_ok=True,
+                symlinks=True,
+            ),
+            propagate_cancellation=True,
         )
 
     async def _delete_owned_branch(self, expected_oid: str | None) -> None:
@@ -283,7 +291,7 @@ class WorktreeEnvironment(Environment):
                 self._worktree_registered = False
         if not self._worktree_registered and self._worktree_dir is not None:
             try:
-                shutil.rmtree(self._worktree_dir)
+                await asyncio.to_thread(shutil.rmtree, self._worktree_dir)
             except FileNotFoundError:
                 self._worktree_dir = None
             except BaseException as exc:
@@ -292,7 +300,7 @@ class WorktreeEnvironment(Environment):
                 self._worktree_dir = None
         if self._worktree_dir is None and self._copy_baseline_dir is not None:
             try:
-                shutil.rmtree(self._copy_baseline_dir)
+                await asyncio.to_thread(shutil.rmtree, self._copy_baseline_dir)
             except FileNotFoundError:
                 self._copy_baseline_dir = None
             except BaseException as exc:

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -67,6 +67,7 @@ class WorktreeEnvironment(Environment):
         self._owned_branch_oid: str | None = None
         self._worktree_registered = False
         self._lifecycle_lock = asyncio.Lock()
+        self._source_subdir = ""
 
     async def _git(self, *args: str, timeout: float = WORKTREE_GIT_TIMEOUT_SECONDS) -> ExecResult:
         result = await run_process(
@@ -91,11 +92,35 @@ class WorktreeEnvironment(Environment):
         if probe.stdout_truncated or probe.stderr_truncated:
             raise RuntimeError("git repository probe output was truncated")
         self._git_mode = probe.returncode == 0
+        if self._git_mode:
+            top_level = await self._git("rev-parse", "--show-toplevel")
+            if (
+                top_level.returncode != 0
+                or top_level.stdout_truncated
+                or top_level.stderr_truncated
+            ):
+                raise RuntimeError("cannot resolve Git repository root")
+            repository_root = os.path.realpath(top_level.stdout.strip())
+            try:
+                contained = os.path.commonpath((repository_root, self._source))
+            except ValueError as exc:
+                raise RuntimeError("source workspace is outside its Git repository") from exc
+            if contained != repository_root:
+                raise RuntimeError("source workspace is outside its Git repository")
+            relative_source = os.path.relpath(self._source, repository_root)
+            self._source_subdir = "" if relative_source == "." else relative_source
         try:
             if self._git_mode:
                 await self._setup_git_worktree()
             else:
                 await self._setup_directory_copy()
+            assert self._worktree_dir is not None
+            exposed_workspace = os.path.join(
+                self._worktree_dir,
+                self._source_subdir,
+            )
+            if not os.path.isdir(exposed_workspace):
+                raise RuntimeError("source subdirectory is absent from the worktree")
         except BaseException as original:
             try:
                 await await_owned_operation(
@@ -116,11 +141,10 @@ class WorktreeEnvironment(Environment):
                     f"{type(cleanup_error).__name__}: {cleanup_error}"
                 )
             raise
-        assert self._worktree_dir is not None
-        self.workspace = self._worktree_dir
-        self.host_workspace = self._worktree_dir
-        self._local_env = LocalEnvironment(self._worktree_dir)
-        return self._worktree_dir
+        self.workspace = exposed_workspace
+        self.host_workspace = exposed_workspace
+        self._local_env = LocalEnvironment(exposed_workspace)
+        return exposed_workspace
 
     async def _setup_git_worktree(self) -> None:
         status = await self._git(

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -340,7 +340,7 @@ class WorktreeEnvironment(Environment):
             try:
                 await self._local_env.cleanup()
             except BaseException as exc:
-                failures.append(exc)
+                raise RuntimeError("worktree cleanup failed") from exc
             else:
                 self._local_env = None
         if self._git_mode and self._worktree_registered and self._worktree_dir is not None:

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -68,6 +68,7 @@ class WorktreeEnvironment(Environment):
         self._worktree_registered = False
         self._lifecycle_lock = asyncio.Lock()
         self._source_subdir = ""
+        self._repository_root: str | None = None
 
     async def _git(self, *args: str, timeout: float = WORKTREE_GIT_TIMEOUT_SECONDS) -> ExecResult:
         result = await run_process(
@@ -101,6 +102,7 @@ class WorktreeEnvironment(Environment):
             ):
                 raise RuntimeError("cannot resolve Git repository root")
             repository_root = os.path.realpath(top_level.stdout.strip())
+            self._repository_root = repository_root
             try:
                 contained = os.path.commonpath((repository_root, self._source))
             except ValueError as exc:
@@ -210,6 +212,116 @@ class WorktreeEnvironment(Environment):
         if added.returncode != 0:
             raise RuntimeError(f"git worktree add failed: {added.stderr.strip()}")
         self._worktree_registered = True
+        await self._initialize_available_submodules()
+
+    async def _worktree_git(self, *args: str) -> ExecResult:
+        assert self._worktree_dir is not None
+        result = await run_process(
+            ("git", "-C", self._worktree_dir, *args),
+            shell=False,
+            timeout=WORKTREE_GIT_TIMEOUT_SECONDS,
+        )
+        return result.to_exec_result()
+
+    async def _initialize_available_submodules(self) -> None:
+        repository_root = self._repository_root
+        if repository_root is None or self._worktree_dir is None:
+            return
+        modules_file = os.path.join(repository_root, ".gitmodules")
+        if not os.path.isfile(modules_file):
+            return
+        configured = await self._git(
+            "config",
+            "--file",
+            modules_file,
+            "--get-regexp",
+            r"^submodule\..*\.path$",
+        )
+        if configured.returncode == 1:
+            return
+        if (
+            configured.returncode != 0
+            or configured.stdout_truncated
+            or configured.stderr_truncated
+        ):
+            raise RuntimeError("cannot inspect Git submodule configuration")
+
+        paths: list[str] = []
+        url_overrides: list[str] = []
+        source_prefix = self._source_subdir.replace(os.sep, "/").rstrip("/")
+        for line in configured.stdout.splitlines():
+            try:
+                key, configured_path = line.split(maxsplit=1)
+            except ValueError as exc:
+                raise RuntimeError("invalid Git submodule path configuration") from exc
+            prefix = "submodule."
+            suffix = ".path"
+            if not key.startswith(prefix) or not key.endswith(suffix):
+                raise RuntimeError("invalid Git submodule path configuration")
+            name = key[len(prefix) : -len(suffix)]
+            normalized_path = configured_path.replace("\\", "/").strip("/")
+            if (
+                not normalized_path
+                or normalized_path == ".."
+                or normalized_path.startswith("../")
+            ):
+                raise RuntimeError("invalid Git submodule path configuration")
+            if source_prefix and not (
+                normalized_path == source_prefix
+                or normalized_path.startswith(f"{source_prefix}/")
+            ):
+                continue
+            source_module = os.path.realpath(
+                os.path.join(repository_root, *normalized_path.split("/"))
+            )
+            if (
+                os.path.commonpath((repository_root, source_module))
+                != repository_root
+                or not os.path.isdir(source_module)
+            ):
+                raise RuntimeError(
+                    f"Git submodule is not initialized in source workspace: {configured_path}"
+                )
+            available = await run_process(
+                ("git", "-C", source_module, "rev-parse", "--is-inside-work-tree"),
+                shell=False,
+                timeout=WORKTREE_GIT_TIMEOUT_SECONDS,
+            )
+            if (
+                available.returncode != 0
+                or available.stdout_dropped_bytes > 0
+                or available.stderr_dropped_bytes > 0
+                or available.stdout.decode("ascii", errors="ignore").strip() != "true"
+            ):
+                raise RuntimeError(
+                    f"Git submodule is not initialized in source workspace: {configured_path}"
+                )
+            paths.append(normalized_path)
+            url_overrides.extend(("-c", f"submodule.{name}.url={source_module}"))
+
+        if not paths:
+            return
+        updated = await self._worktree_git(
+            "-c",
+            "protocol.allow=never",
+            "-c",
+            "protocol.file.allow=always",
+            *url_overrides,
+            "submodule",
+            "update",
+            "--init",
+            "--no-fetch",
+            "--recursive",
+            "--",
+            *paths,
+        )
+        if (
+            updated.returncode != 0
+            or updated.stdout_truncated
+            or updated.stderr_truncated
+        ):
+            detail = updated.stderr.strip() or "submodule checkout failed"
+            raise RuntimeError(f"cannot initialize source-available submodules: {detail}")
 
     async def _setup_directory_copy(self) -> None:
         self._copy_baseline_dir = tempfile.mkdtemp(prefix="opencollab-cp-baseline-")

--- a/opencollab/adapters/_env_worktree.py
+++ b/opencollab/adapters/_env_worktree.py
@@ -20,6 +20,25 @@ from opencollab.application.exception_notes import add_exception_note
 WORKTREE_GIT_TIMEOUT_SECONDS = 30.0
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,180}$")
 _ZERO_OID = "0" * 40
+_PORCELAIN_STATUS_CHARS = frozenset(" MADRCU?!")
+
+
+def _dirty_path_preview(output: str, *, limit: int = 12) -> str:
+    paths: list[str] = []
+    for record in filter(None, output.split("\0")):
+        if (
+            len(record) >= 4
+            and record[0] in _PORCELAIN_STATUS_CHARS
+            and record[1] in _PORCELAIN_STATUS_CHARS
+            and record[2] == " "
+        ):
+            paths.append(record[3:])
+        else:
+            paths.append(record)
+    preview = ", ".join(repr(path) for path in paths[:limit])
+    if len(paths) > limit:
+        preview += f", ... ({len(paths) - limit} more)"
+    return preview
 
 
 class WorktreeEnvironment(Environment):
@@ -104,6 +123,23 @@ class WorktreeEnvironment(Environment):
         return self._worktree_dir
 
     async def _setup_git_worktree(self) -> None:
+        status = await self._git(
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        )
+        if (
+            status.returncode != 0
+            or status.stdout_truncated
+            or status.stderr_truncated
+        ):
+            raise RuntimeError("cannot verify that the source workspace is clean")
+        if status.stdout:
+            raise RuntimeError(
+                "source workspace has uncommitted changes: "
+                f"{_dirty_path_preview(status.stdout)}"
+            )
         branch_probe = await self._git(
             "show-ref",
             "--verify",

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import uuid
 from typing import Any, Optional
 
@@ -74,6 +75,40 @@ def _get_prompt_session() -> Any:
     return _prompt_session
 
 
+async def _read_console_line(prompt_text: str) -> str:
+    """Read a terminal line without leaving an executor thread on cancellation."""
+    loop = asyncio.get_running_loop()
+    try:
+        stdin_fd = sys.stdin.fileno()
+    except (AttributeError, OSError) as exc:
+        raise RuntimeError("console input fallback requires a selectable stdin") from exc
+
+    console.print(prompt_text, end="")
+    result: asyncio.Future[str] = loop.create_future()
+
+    def on_readable() -> None:
+        if result.done():
+            return
+        try:
+            line = sys.stdin.readline()
+        except BaseException as exc:
+            result.set_exception(exc)
+            return
+        if line == "":
+            result.set_exception(EOFError())
+            return
+        result.set_result(line.rstrip("\r\n"))
+
+    try:
+        loop.add_reader(stdin_fd, on_readable)
+    except (AttributeError, NotImplementedError) as exc:
+        raise RuntimeError("console input fallback is unavailable on this event loop") from exc
+    try:
+        return await result
+    finally:
+        loop.remove_reader(stdin_fd)
+
+
 async def _read_line(
     prompt_text: Any,
     bottom_toolbar: Any = None,
@@ -94,9 +129,8 @@ async def _read_line(
             key_bindings=key_bindings,
         )
     except Exception:
-        loop = asyncio.get_running_loop()
         fallback = prompt_text if isinstance(prompt_text, str) else "> "
-        return await loop.run_in_executor(None, lambda: console.input(fallback))
+        return await _read_console_line(fallback)
 
 
 @app.callback(invoke_without_command=True)

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -167,9 +167,11 @@ def main_callback(
 
 
 def _resolve_one_shot_prompt(prompt: str | None, prompt_file: str | None) -> str | None:
-    if prompt and prompt_file:
+    if prompt is not None and prompt_file is not None:
         raise typer.BadParameter("--prompt and --prompt-file are mutually exclusive.")
-    if prompt_file:
+    if prompt_file is not None:
+        if not prompt_file.strip():
+            raise typer.BadParameter("--prompt-file path must not be empty.")
         try:
             text = read_regular_text(
                 prompt_file,
@@ -180,7 +182,9 @@ def _resolve_one_shot_prompt(prompt: str | None, prompt_file: str | None) -> str
         if not text.strip():
             raise typer.BadParameter(f"--prompt-file is empty: {prompt_file}")
         return text
-    if prompt:
+    if prompt is not None:
+        if not prompt.strip():
+            raise typer.BadParameter("--prompt must not be empty.")
         return prompt
     return None
 

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -27,6 +27,7 @@ import typer
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.styles import Style
 from rich.console import Console
+from rich.text import Text
 
 from opencollab.adapters.cli.config_resolve import (
     missing_api_key_for,
@@ -262,7 +263,15 @@ def _dispatch_repl_command(line: str, lead: Any) -> bool:
     if command in _EXIT_COMMANDS:
         return False
     if command == "/save":
-        _save_session(lead)
+        try:
+            _save_session(lead)
+        except Exception as exc:
+            console.print(
+                Text(
+                    f"Session save failed: {type(exc).__name__}: {exc}",
+                    style="red",
+                )
+            )
         return True
     raise KeyError(line)
 

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -346,9 +346,11 @@ async def _run(
 
     event_sink = TuiEventSink(tui)
     events_file = os.environ.get("OPENCOLLAB_EVENTS_FILE")
+    file_event_sink: JsonlEventSink | None = None
     if events_file:
         bus = EventBus(event_sink)
-        bus.subscribe(JsonlEventSink(events_file))
+        file_event_sink = JsonlEventSink(events_file)
+        bus.subscribe(file_event_sink)
         event_sink = bus
 
     ctx = build_runtime_context(
@@ -441,6 +443,27 @@ async def _run(
                     )
                 except BaseException as exc:
                     tracer_failure = exc
+    if file_event_sink is not None:
+        try:
+            event_write_error = file_event_sink.write_error
+            dropped_events = file_event_sink.dropped_events
+        except BaseException as exc:
+            event_write_error = (
+                "event sink diagnostics unavailable: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            dropped_events = 0
+        if event_write_error is not None or dropped_events:
+            safe_error = " ".join(str(event_write_error or "unknown error").splitlines())
+            try:
+                print(
+                    "Warning: event log persistence degraded for "
+                    f"{events_file!r}; first error: {safe_error[:1000]}; "
+                    f"dropped events: {dropped_events}",
+                    file=sys.stderr,
+                )
+            except BaseException:
+                pass
     if primary_failure is not None:
         if repeated_cancellation is not None:
             add_exception_note(

--- a/opencollab/adapters/cli/prompt_view.py
+++ b/opencollab/adapters/cli/prompt_view.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import Any
 
 from prompt_toolkit.formatted_text import ANSI, to_formatted_text
 from prompt_toolkit.key_binding import KeyBindings
+
+HISTORY_CACHE_MAX_ENTRIES = 16
 
 
 def build_agent_prompt(tui: Any, base_prompt: Any) -> Any:
@@ -15,7 +18,7 @@ def build_agent_prompt(tui: Any, base_prompt: Any) -> Any:
     switching focus replaces the prior agent instead of adding terminal scrollback.
     The revision-aware cache avoids re-rendering Rich history on every keystroke.
     """
-    history_cache: dict[tuple[int, int, int], str] = {}
+    history_cache: OrderedDict[tuple[int, int, int], str] = OrderedDict()
 
     def prompt() -> list[tuple[str, str]]:
         key = tui.selected_history_cache_key
@@ -24,6 +27,10 @@ def build_agent_prompt(tui: Any, base_prompt: Any) -> Any:
                 history_cache[key] = tui.render_selected_history()
             except Exception:
                 history_cache[key] = ""
+            while len(history_cache) > HISTORY_CACHE_MAX_ENTRIES:
+                history_cache.popitem(last=False)
+        else:
+            history_cache.move_to_end(key)
         history = history_cache[key]
 
         fragments = []

--- a/opencollab/adapters/cli/workflow.py
+++ b/opencollab/adapters/cli/workflow.py
@@ -36,13 +36,15 @@ console = Console()
 DEFAULT_WORKFLOWS_DIR = "workflows"
 
 
-def load_registry() -> Registry:
+def load_registry(workspace: str = ".") -> Registry:
     """Discover workflows from the workflows directory.
 
-    The directory is ``OPENCOLLAB_WORKFLOWS_DIR`` when set, else ``workflows/``
-    relative to the current working directory.
+    Relative paths, including the default ``workflows/``, are resolved from
+    ``workspace``. An absolute ``OPENCOLLAB_WORKFLOWS_DIR`` remains absolute.
     """
     directory = os.environ.get("OPENCOLLAB_WORKFLOWS_DIR", DEFAULT_WORKFLOWS_DIR)
+    if not os.path.isabs(directory):
+        directory = os.path.join(workspace, directory)
     return discover_workflows(directory)
 
 
@@ -60,9 +62,11 @@ class _ConsoleEventSink:
 
 
 @app.command(name="list")
-def list_cmd() -> None:
+def list_cmd(
+    workspace: str = typer.Option(".", "--workspace", "-w", help="Working directory"),
+) -> None:
     """List the registered workflows with their descriptions."""
-    registry = load_registry()
+    registry = load_registry(workspace)
     specs = registry.list_specs()
     if not specs:
         console.print("[dim]No workflows found.[/dim]")
@@ -99,7 +103,7 @@ def run_cmd(
     ),
 ) -> None:
     """Run a workflow and print its result as JSON."""
-    registry = load_registry()
+    registry = load_registry(workspace)
     try:
         spec = registry.get(name)
     except KeyError:

--- a/opencollab/adapters/cli/workflow.py
+++ b/opencollab/adapters/cli/workflow.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 
 import typer
 from rich.console import Console
+from rich.text import Text
 
 from opencollab.adapters.cli.config_resolve import (
     missing_api_key_for,
@@ -58,7 +59,7 @@ class _ConsoleEventSink:
         kind = getattr(event, "kind", "log")
         message = getattr(event, "message", str(event))
         marker = "==" if kind == "phase" else "--"
-        self._console.print(f"[dim]{marker} {message}[/dim]")
+        self._console.print(Text(f"{marker} {message}", style="dim"))
 
 
 @app.command(name="list")
@@ -153,7 +154,7 @@ def run_cmd(
         if trace:
             trace_path = os.path.join(save_dir, "orchestration.jsonl")
             console.print(f"[dim]== orchestration at {trace_path}[/dim]")
-    console.print(json.dumps(result, indent=2, default=str))
+    typer.echo(json.dumps(result, indent=2, default=str))
 
 
 __all__ = ["app", "load_registry", "run_workflow"]

--- a/opencollab/adapters/event_log.py
+++ b/opencollab/adapters/event_log.py
@@ -20,7 +20,6 @@ class JsonlEventSink(EventPublisherPort):
     def __init__(self, path: str):
         self._path = path
         self._write_error: str | None = None
-        self._initialization_error: str | None = None
         self._dropped_events = 0
         self._write_lock = asyncio.Lock()
         parent = os.path.dirname(path)
@@ -30,10 +29,9 @@ class JsonlEventSink(EventPublisherPort):
             except Exception as exc:
                 error = f"{type(exc).__name__}: {exc}"
                 self._write_error = error
-                self._initialization_error = error
 
     async def emit(self, event: Any) -> None:
-        if self._initialization_error is not None:
+        if self._write_error is not None:
             self._dropped_events += 1
             return
         try:

--- a/opencollab/adapters/event_log.py
+++ b/opencollab/adapters/event_log.py
@@ -39,6 +39,8 @@ class JsonlEventSink(EventPublisherPort):
         try:
             if is_dataclass(event):
                 payload = asdict(event)
+            elif isinstance(event, dict):
+                payload = dict(event)
             else:
                 payload = {
                     "type": getattr(event, "type", type(event).__name__),

--- a/opencollab/adapters/event_log.py
+++ b/opencollab/adapters/event_log.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import time
+from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
@@ -37,7 +38,7 @@ class JsonlEventSink(EventPublisherPort):
         try:
             if is_dataclass(event):
                 payload = asdict(event)
-            elif isinstance(event, dict):
+            elif isinstance(event, Mapping):
                 payload = dict(event)
             else:
                 payload = {

--- a/opencollab/adapters/event_log.py
+++ b/opencollab/adapters/event_log.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import time
@@ -9,6 +10,7 @@ from dataclasses import asdict, is_dataclass
 from typing import Any
 
 from opencollab.adapters.safe_files import append_regular_text, ensure_directory_no_symlinks
+from opencollab.application.async_timeout import await_owned_operation
 from opencollab.application.ports import EventPublisherPort
 
 
@@ -20,6 +22,7 @@ class JsonlEventSink(EventPublisherPort):
         self._write_error: str | None = None
         self._initialization_error: str | None = None
         self._dropped_events = 0
+        self._write_lock = asyncio.Lock()
         parent = os.path.dirname(path)
         if parent:
             try:
@@ -42,10 +45,12 @@ class JsonlEventSink(EventPublisherPort):
                     "data": getattr(event, "data", {}),
                 }
             payload.setdefault("timestamp", time.time())
-            append_regular_text(
-                self._path,
-                json.dumps(payload, ensure_ascii=False, default=str) + "\n",
-            )
+            line = json.dumps(payload, ensure_ascii=False, default=str) + "\n"
+            async with self._write_lock:
+                await await_owned_operation(
+                    asyncio.to_thread(append_regular_text, self._path, line),
+                    propagate_cancellation=True,
+                )
         except Exception as exc:
             if self._write_error is None:
                 self._write_error = f"{type(exc).__name__}: {exc}"

--- a/opencollab/adapters/git_patch.py
+++ b/opencollab/adapters/git_patch.py
@@ -57,6 +57,13 @@ def guarded_staged_diff_command(
         f'{git_index_command} add -f --pathspec-from-file="$untracked" '
         '--pathspec-file-nul; fi && '
     )
+    ignored_guard = (
+        f'{git_index_command} ls-files --others --ignored '
+        '--exclude-per-directory=.gitignore -z > "$ignored" && '
+        'if [ -s "$ignored" ]; then '
+        "echo 'ignored untracked files cannot be included in patch evidence' >&2; "
+        "exit 125; fi; "
+    )
     reserved_guard = (
         f'if {git_index_command} diff --no-ext-diff --no-textconv --cached --quiet '
         f"{shlex.quote(base_revision)} -- "
@@ -72,10 +79,12 @@ def guarded_staged_diff_command(
     return (
         'idx=$(mktemp) || exit 125; '
         'untracked=$(mktemp) || { rm -f -- "$idx"; exit 125; }; '
-        'trap \'rm -f -- "$idx" "$untracked"\' EXIT; '
+        'ignored=$(mktemp) || { rm -f -- "$idx" "$untracked"; exit 125; }; '
+        'trap \'rm -f -- "$idx" "$untracked" "$ignored"\' EXIT; '
         f"{unsafe_config_guard}"
         f"{git_index_command} read-tree {shlex.quote(base_revision)} && "
         f'{git_index_command} add -u && '
+        f"{ignored_guard}"
         f"{stage_untracked}"
         f"{resets}"
         f"{reserved_guard}"

--- a/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/adapters/llm/anthropic_provider.py
@@ -339,22 +339,42 @@ def convert_to_anthropic_messages(messages: list[dict]) -> tuple[list[str], list
     system_parts: list[str] = []
     anthropic_messages: list[dict] = []
 
-    for message in messages:
+    for message_index, message in enumerate(messages):
         role = message.get("role", "")
 
-        if role == "system" and message.get("compacted"):
-            # A compaction record is chronological conversation context, not a
-            # global instruction. Keep it at its original position instead of
-            # hoisting it into Anthropic's top-level system field.
-            anthropic_messages.append(
-                {"role": "user", "content": message.get("content", "")}
+        if role == "system":
+            content = message.get("content", "")
+            blocks = _normalize_openai_content(
+                content,
+                message_index=message_index,
+                role=role,
             )
-        elif role == "system":
-            system_parts.append(message.get("content", ""))
+            if message.get("compacted"):
+                # A compaction record is chronological conversation context, not a
+                # global instruction. Keep it at its original position instead of
+                # hoisting it into Anthropic's top-level system field.
+                anthropic_messages.append(
+                    {
+                        "role": "user",
+                        "content": content if isinstance(content, str) else blocks,
+                    }
+                )
+            else:
+                system_parts.append("".join(block["text"] for block in blocks))
         elif role == "user":
-            anthropic_messages.append({"role": "user", "content": message.get("content", "")})
+            content = message.get("content", "")
+            normalized = (
+                content
+                if isinstance(content, str)
+                else _normalize_openai_content(
+                    content,
+                    message_index=message_index,
+                    role=role,
+                )
+            )
+            anthropic_messages.append({"role": "user", "content": normalized})
         elif role == "assistant":
-            content_blocks = _convert_assistant_content(message)
+            content_blocks = _convert_assistant_content(message, message_index=message_index)
             if content_blocks:
                 anthropic_messages.append({"role": "assistant", "content": content_blocks})
         elif role == "tool":
@@ -363,16 +383,51 @@ def convert_to_anthropic_messages(messages: list[dict]) -> tuple[list[str], list
     return system_parts, anthropic_messages
 
 
-def _convert_assistant_content(message: dict) -> list[dict]:
+def _normalize_openai_content(
+    content: Any,
+    *,
+    message_index: int,
+    role: str,
+) -> list[dict[str, str]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if not isinstance(content, list):
+        raise ValueError(
+            f"message {message_index} ({role}) content must be text or a content block list"
+        )
+
+    normalized: list[dict[str, str]] = []
+    for block_index, block in enumerate(content):
+        if not isinstance(block, dict):
+            raise ValueError(
+                f"message {message_index} ({role}) content block {block_index} must be an object"
+            )
+        block_type = block.get("type")
+        if block_type not in {"text", "input_text"}:
+            raise ValueError(
+                f"message {message_index} ({role}) unsupported content block type: {block_type}"
+            )
+        text = block.get("text")
+        if not isinstance(text, str):
+            raise ValueError(
+                f"message {message_index} ({role}) content block {block_index} requires text"
+            )
+        normalized.append({"type": "text", "text": text})
+    return normalized
+
+
+def _convert_assistant_content(message: dict, *, message_index: int) -> list[dict]:
     """Build Anthropic content blocks (text + tool_use) from an assistant message."""
     provider_state = message.get("provider_state")
     if isinstance(provider_state, dict):
         provider_content = provider_state.get("anthropic_content")
         if isinstance(provider_content, list):
             return copy.deepcopy(provider_content)
-    content_blocks: list[dict] = []
-    if message.get("content"):
-        content_blocks.append({"type": "text", "text": message["content"]})
+    content_blocks: list[dict] = _normalize_openai_content(
+        message.get("content", ""),
+        message_index=message_index,
+        role="assistant",
+    )
     for tool_call in message.get("tool_calls") or []:
         content_blocks.append(_convert_tool_call(tool_call))
     return content_blocks

--- a/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/adapters/llm/anthropic_provider.py
@@ -429,22 +429,32 @@ def _convert_assistant_content(message: dict, *, message_index: int) -> list[dic
         role="assistant",
     )
     for tool_call in message.get("tool_calls") or []:
-        content_blocks.append(_convert_tool_call(tool_call))
+        content_blocks.append(_convert_tool_call(tool_call, message_index=message_index))
     return content_blocks
 
 
-def _convert_tool_call(tool_call: dict) -> dict:
+def _convert_tool_call(tool_call: dict, *, message_index: int) -> dict:
     """Convert one OpenAI tool call to an Anthropic tool_use block."""
     func = tool_call["function"]
-    try:
-        arguments = func["arguments"]
-        tool_input = json.loads(arguments) if isinstance(arguments, str) else arguments
-    except (json.JSONDecodeError, TypeError):
-        tool_input = {}
+    name = func["name"]
+    call_id = tool_call["id"]
+    arguments = func.get("arguments")
+    location = f"message {message_index} (assistant) tool {name} ({call_id})"
+    if isinstance(arguments, str):
+        try:
+            tool_input = json.loads(arguments)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{location} has invalid JSON arguments: {exc.msg}") from exc
+    elif isinstance(arguments, dict):
+        tool_input = copy.deepcopy(arguments)
+    else:
+        raise ValueError(f"{location} arguments must be JSON text or an object")
+    if not isinstance(tool_input, dict):
+        raise ValueError(f"{location} arguments must decode to a JSON object")
     return {
         "type": "tool_use",
-        "id": tool_call["id"],
-        "name": func["name"],
+        "id": call_id,
+        "name": name,
         "input": tool_input,
     }
 

--- a/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/adapters/llm/anthropic_provider.py
@@ -342,7 +342,14 @@ def convert_to_anthropic_messages(messages: list[dict]) -> tuple[list[str], list
     for message in messages:
         role = message.get("role", "")
 
-        if role == "system":
+        if role == "system" and message.get("compacted"):
+            # A compaction record is chronological conversation context, not a
+            # global instruction. Keep it at its original position instead of
+            # hoisting it into Anthropic's top-level system field.
+            anthropic_messages.append(
+                {"role": "user", "content": message.get("content", "")}
+            )
+        elif role == "system":
             system_parts.append(message.get("content", ""))
         elif role == "user":
             anthropic_messages.append({"role": "user", "content": message.get("content", "")})

--- a/opencollab/adapters/llm/client.py
+++ b/opencollab/adapters/llm/client.py
@@ -60,6 +60,7 @@ class LLMClient:
             anthropic_kwargs: dict[str, Any] = {
                 "api_key": api_key or os.environ.get("ANTHROPIC_API_KEY"),
                 "timeout": request_timeout,
+                "max_retries": 0,
             }
             if self.base_url:
                 anthropic_kwargs["base_url"] = self.base_url
@@ -71,6 +72,7 @@ class LLMClient:
                 api_key=api_key or os.environ.get("OPENAI_API_KEY"),
                 base_url=self.base_url,
                 timeout=request_timeout,
+                max_retries=0,
             )
             self._anthropic = None
 

--- a/opencollab/adapters/llm/errors.py
+++ b/opencollab/adapters/llm/errors.py
@@ -57,6 +57,9 @@ def _error_code_of(error: Exception) -> str:
         return code.lower()
     body = getattr(error, "body", None)
     if isinstance(body, dict):
+        body_code = body.get("code")
+        if isinstance(body_code, str):
+            return body_code.lower()
         inner = body.get("error")
         if isinstance(inner, dict):
             inner_code = inner.get("code")

--- a/opencollab/adapters/llm/openai_provider.py
+++ b/opencollab/adapters/llm/openai_provider.py
@@ -153,33 +153,46 @@ def _extract_markup_tool_calls(
     if not content or _MARKUP_SECTION_BEGIN not in content:
         return [], content
 
+    if (
+        content.count(_MARKUP_SECTION_BEGIN) != 1
+        or content.count(_MARKUP_SECTION_END) != 1
+    ):
+        return [], content
+    start = content.index(_MARKUP_SECTION_BEGIN)
+    section_start = start + len(_MARKUP_SECTION_BEGIN)
+    end_idx = content.index(_MARKUP_SECTION_END, section_start)
+    section = content[section_start:end_idx]
+
     tool_calls: list[dict[str, Any]] = []
-    for match in _MARKUP_CALL_RE.finditer(content):
+    seen_ids: set[str] = set()
+    cursor = 0
+    for match in _MARKUP_CALL_RE.finditer(section):
+        if section[cursor:match.start()].strip():
+            return [], content
         raw_args = match.group("args").strip()
         try:
             json.loads(raw_args)
         except (ValueError, TypeError):
-            continue  # not valid JSON args -> skip this malformed block
+            return [], content
+        call_id = match.group("id")
+        if call_id in seen_ids:
+            return [], content
+        seen_ids.add(call_id)
         tool_calls.append({
-            "id": match.group("id"),
+            "id": call_id,
             "type": "function",
             "function": {
                 "name": match.group("name"),
                 "arguments": raw_args,
             },
         })
+        cursor = match.end()
 
-    if not tool_calls:
-        return [], content  # no well-formed block found -> fall back
+    if not tool_calls or section[cursor:].strip():
+        return [], content
 
-    # Strip the whole markup section (begin..end inclusive) from the prose. The
-    # end marker may be absent on a truncated stream; strip from begin onward.
-    start = content.index(_MARKUP_SECTION_BEGIN)
-    end_idx = content.find(_MARKUP_SECTION_END)
-    if end_idx == -1:
-        cleaned = content[:start]
-    else:
-        cleaned = content[:start] + content[end_idx + len(_MARKUP_SECTION_END):]
+    # Strip the validated markup section while preserving surrounding prose.
+    cleaned = content[:start] + content[end_idx + len(_MARKUP_SECTION_END):]
     cleaned = cleaned.strip()
     return tool_calls, (cleaned or None)
 

--- a/opencollab/adapters/llm/openai_provider.py
+++ b/opencollab/adapters/llm/openai_provider.py
@@ -35,6 +35,7 @@ _FRAMEWORK_CONTROLLED_THINKING_FIELDS = frozenset({
     "tools",
     "top_p",
 })
+_OPENAI_REASONING_MODEL_RE = re.compile(r"^o(?:1|3)(?:$|[-.])")
 
 
 def _validated_thinking_params(thinking_params: dict | None) -> dict:
@@ -50,6 +51,11 @@ def _validated_thinking_params(thinking_params: dict | None) -> dict:
     return dict(thinking_params)
 
 
+def _uses_reasoning_request_fields(model: str) -> bool:
+    leaf = model.strip().lower().rsplit("/", 1)[-1]
+    return _OPENAI_REASONING_MODEL_RE.match(leaf) is not None
+
+
 def _build_request_kwargs(
     model: str,
     messages: list[dict],
@@ -61,17 +67,20 @@ def _build_request_kwargs(
     top_p: float | None = None,
     max_output_tokens: int | None = None,
 ) -> dict[str, Any]:
+    reasoning_model = _uses_reasoning_request_fields(model)
     kwargs: dict[str, Any] = {
         "model": model,
         "messages": _normalize_request_messages(messages),
-        "temperature": temperature,
     }
+    if not reasoning_model:
+        kwargs["temperature"] = temperature
     # Nucleus sampling rides along ONLY when explicitly set; when None the key is
     # omitted so the request is byte-for-byte identical to today's behavior.
-    if top_p is not None:
+    if top_p is not None and not reasoning_model:
         kwargs["top_p"] = top_p
     if max_output_tokens is not None:
-        kwargs["max_tokens"] = int(max_output_tokens)
+        token_field = "max_completion_tokens" if reasoning_model else "max_tokens"
+        kwargs[token_field] = int(max_output_tokens)
     if tools:
         kwargs["tools"] = tools
         choice = tool_choice or "auto"

--- a/opencollab/adapters/llm/openai_provider.py
+++ b/opencollab/adapters/llm/openai_provider.py
@@ -20,6 +20,35 @@ from opencollab.adapters.llm.types import (
     rescue_empty_turn,
 )
 
+# ``extra_body`` is merged into the OpenAI SDK's request payload after the
+# explicit keyword arguments. Provider-native thinking settings must therefore
+# not replace fields whose values are set by OpenCollab for this request.
+_FRAMEWORK_CONTROLLED_THINKING_FIELDS = frozenset({
+    "max_completion_tokens",
+    "max_tokens",
+    "messages",
+    "model",
+    "stream",
+    "stream_options",
+    "temperature",
+    "tool_choice",
+    "tools",
+    "top_p",
+})
+
+
+def _validated_thinking_params(thinking_params: dict | None) -> dict:
+    """Reject provider extensions that overwrite OpenCollab request fields."""
+    if not isinstance(thinking_params, dict):
+        raise ValueError("thinking_params must be an object")
+    protected = sorted(_FRAMEWORK_CONTROLLED_THINKING_FIELDS & thinking_params.keys())
+    if protected:
+        raise ValueError(
+            "thinking_params cannot override framework-controlled request field(s): "
+            + ", ".join(protected)
+        )
+    return dict(thinking_params)
+
 
 def _build_request_kwargs(
     model: str,
@@ -59,7 +88,7 @@ def _build_request_kwargs(
     # extra_body rather than clobbering it.
     if thinking and thinking_params:
         extra_body = dict(kwargs.get("extra_body") or {})
-        extra_body.update(thinking_params)
+        extra_body.update(_validated_thinking_params(thinking_params))
         kwargs["extra_body"] = extra_body
     return kwargs
 

--- a/opencollab/adapters/llm/types.py
+++ b/opencollab/adapters/llm/types.py
@@ -92,11 +92,11 @@ class ModelCapabilities:
     honors_workflow_thinking_override: bool = True
 
 
-# Best-effort context-window sizes (tokens), keyed by a substring of the model
-# id. Used to derive history-compaction triggers (see
-# ``shaping.history_trigger_target``); an unrecognised model returns ``None`` and
-# the caller falls back to fixed defaults. Substring match keeps this resilient
-# to version/date suffixes (e.g. ``claude-opus-4-8-2026...`` matches ``claude``).
+# Best-effort context-window sizes (tokens), keyed by a model family. Used to
+# derive history-compaction triggers (see ``shaping.history_trigger_target``);
+# an unrecognised model returns ``None`` and the caller falls back to fixed
+# defaults. Family matching accepts provider prefixes and hyphenated
+# version/date suffixes without treating unrelated substrings as a known model.
 MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "claude": 200_000,
     "gpt-4o": 128_000,
@@ -127,6 +127,17 @@ _EXACT_MODEL_CAPABILITIES: dict[str, ModelCapabilities] = {
 DEFAULT_MAX_OUTPUT_TOKENS = DEFAULT_MAX_TOKENS_PER_STEP
 
 
+def model_matches_family(model: str | None, family: str) -> bool:
+    """Whether ``model`` is an exact or hyphen-suffixed family identifier."""
+    if not model:
+        return False
+    normalized = model.strip().lower().rsplit("/", 1)[-1]
+    normalized_family = family.strip().lower()
+    return normalized == normalized_family or normalized.startswith(
+        f"{normalized_family}-"
+    )
+
+
 def model_capabilities(model: str | None) -> ModelCapabilities:
     """Return exact capability metadata plus a best-effort context window."""
     if not model:
@@ -135,7 +146,7 @@ def model_capabilities(model: str | None) -> ModelCapabilities:
     if lowered in _EXACT_MODEL_CAPABILITIES:
         return _EXACT_MODEL_CAPABILITIES[lowered]
     for key, window in MODEL_CONTEXT_WINDOWS.items():
-        if key in lowered:
+        if model_matches_family(model, key):
             return ModelCapabilities(context_window=window)
     return ModelCapabilities()
 

--- a/opencollab/adapters/llm/types.py
+++ b/opencollab/adapters/llm/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -138,13 +139,23 @@ def model_matches_family(model: str | None, family: str) -> bool:
     )
 
 
+def _canonical_model_id(model: str) -> str:
+    leaf = model.strip().lower().rsplit("/", 1)[-1]
+    if leaf in _EXACT_MODEL_CAPABILITIES:
+        return leaf
+    for known in _EXACT_MODEL_CAPABILITIES:
+        if re.fullmatch(rf"{re.escape(known)}-\d{{4}}(?:-\d{{2}}){{0,2}}", leaf):
+            return known
+    return leaf
+
+
 def model_capabilities(model: str | None) -> ModelCapabilities:
     """Return exact capability metadata plus a best-effort context window."""
     if not model:
         return ModelCapabilities()
-    lowered = model.lower()
-    if lowered in _EXACT_MODEL_CAPABILITIES:
-        return _EXACT_MODEL_CAPABILITIES[lowered]
+    canonical = _canonical_model_id(model)
+    if canonical in _EXACT_MODEL_CAPABILITIES:
+        return _EXACT_MODEL_CAPABILITIES[canonical]
     for key, window in MODEL_CONTEXT_WINDOWS.items():
         if model_matches_family(model, key):
             return ModelCapabilities(context_window=window)

--- a/opencollab/adapters/llm/usage_ledger.py
+++ b/opencollab/adapters/llm/usage_ledger.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from opencollab.adapters.llm.types import LLMResponse, Usage
+from opencollab.adapters.llm.types import LLMResponse, Usage, model_matches_family
 
 DEFAULT_GLM52_INPUT_USD_PER_MTOK = 1.4
 DEFAULT_GLM52_CACHED_INPUT_USD_PER_MTOK = 0.26
@@ -48,8 +48,7 @@ def _float_env(name: str, default: float) -> float:
 
 
 def pricing_for_model(model: str | None) -> dict[str, float | str]:
-    lowered = (model or "").lower()
-    if "glm" in lowered:
+    if model_matches_family(model, "glm-5.2"):
         input_price = _float_env("GLM_INPUT_USD_PER_MTOK", DEFAULT_GLM52_INPUT_USD_PER_MTOK)
         return {
             "mode": "glm-5.2-default",

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -351,9 +351,35 @@ async def build_repo_map_via_env(
         for value in (max_depth, max_chars, max_entries)
     ):
         raise ValueError("repo-map budgets must be positive integers")
-    cmd = (
+    find_cmd = (
         rf"find . -mindepth 1 -maxdepth {max_depth} "
-        rf"\( {prunes} \) -prune -o -print | head -n {max_entries + 1}"
+        rf"\( {prunes} \) -prune -o -print"
+    )
+    cmd = (
+        'repo_map_tmp=$(mktemp -d "${TMPDIR:-/tmp}/'
+        'opencollab-repo-map.XXXXXX") || exit 70\n'
+        'repo_map_fifo="$repo_map_tmp/paths"\n'
+        'repo_map_err="$repo_map_tmp/find.err"\n'
+        "repo_map_cleanup() {\n"
+        '  rm -f "$repo_map_fifo" "$repo_map_err"\n'
+        '  rmdir "$repo_map_tmp" 2>/dev/null || :\n'
+        "}\n"
+        "trap repo_map_cleanup 0 1 2 15\n"
+        'mkfifo "$repo_map_fifo" || exit 70\n'
+        f'{find_cmd} >"$repo_map_fifo" 2>"$repo_map_err" &\n'
+        "repo_map_find_pid=$!\n"
+        f'head -n {max_entries + 1} <"$repo_map_fifo"\n'
+        "repo_map_head_status=$?\n"
+        'wait "$repo_map_find_pid"\n'
+        "repo_map_find_status=$?\n"
+        'cat "$repo_map_err" >&2\n'
+        'if [ "$repo_map_head_status" -ne 0 ]; then\n'
+        '  exit "$repo_map_head_status"\n'
+        "fi\n"
+        'case "$repo_map_find_status" in\n'
+        "  0|141) exit 0 ;;\n"
+        '  *) exit "$repo_map_find_status" ;;\n'
+        "esac"
     )
     try:
         result = await env.exec_cmd(cmd)

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -14,7 +14,6 @@ import os
 from dataclasses import dataclass, field
 
 from opencollab.adapters.env import Environment
-from opencollab.adapters.tools._output import truncate
 
 MAX_MAP_CHARS = 4_000
 MAX_MAP_DEPTH = 3
@@ -44,6 +43,37 @@ _TRUNCATED_MARKER = "... (repository map truncated; traversal budget reached)"
 
 def _keep(name: str) -> bool:
     return not name.startswith(".") and name not in SKIP_DIR_NAMES
+
+
+def _render_bounded_lines(lines: list[str], max_chars: int) -> str:
+    if isinstance(max_chars, bool) or not isinstance(max_chars, int) or max_chars <= 0:
+        raise ValueError("max_chars must be a positive integer")
+    body = "\n".join(lines)
+    if len(body) <= max_chars:
+        return body
+
+    selected: list[str] = []
+    for line in lines:
+        omitted = len(lines) - len(selected) - 1
+        suffix = (
+            [f"... ({omitted} entries omitted; repository map truncated)"]
+            if omitted
+            else []
+        )
+        candidate = "\n".join([*selected, line, *suffix])
+        if len(candidate) > max_chars:
+            break
+        selected.append(line)
+
+    omitted = len(lines) - len(selected)
+    marker = f"... ({omitted} entries omitted; repository map truncated)"
+    while selected and len("\n".join([*selected, marker])) > max_chars:
+        selected.pop()
+        omitted += 1
+        marker = f"... ({omitted} entries omitted; repository map truncated)"
+    if len(marker) > max_chars:
+        return ""
+    return "\n".join([*selected, marker])
 
 
 def build_repo_map(
@@ -116,10 +146,10 @@ class _WalkBudget:
 
 
 def _render_map(lines: list[str], *, max_chars: int, truncated: bool) -> str:
-    body = "\n".join(lines)
+    rendered_lines = list(lines)
     if truncated:
-        body = f"{body}\n{_TRUNCATED_MARKER}" if body else _TRUNCATED_MARKER
-    return f"{MAP_HEADER}\n\n" + truncate(body, max_chars)
+        rendered_lines.append(_TRUNCATED_MARKER)
+    return f"{MAP_HEADER}\n\n" + _render_bounded_lines(rendered_lines, max_chars)
 
 
 def _walk(path: str, depth: int, budget: _WalkBudget) -> None:

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -194,11 +194,8 @@ def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
     def root_key(entry: os.DirEntry[str]) -> tuple[bool, bool, str]:
         is_directory = entry.is_dir(follow_symlinks=False)
         return (
-            not (
-                entry.name in ROOT_PRIORITY_FILES
-                and not is_directory
-            ),
-            not is_directory,
+            is_directory,
+            not is_directory and entry.name not in ROOT_PRIORITY_FILES,
             entry.name,
         )
 
@@ -273,26 +270,58 @@ def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
         )
         candidates.sort(key=root_key)
     indent = "  " * depth
-    for entry in candidates:
-        if entry.is_dir(follow_symlinks=False):
-            if not budget.append(f"{indent}{entry.name}/"):
-                return
-            if depth + 1 < budget.max_depth:
-                _walk(entry.path, depth + 1, budget)
-        else:
-            if not budget.append(f"{indent}{entry.name}"):
-                return
     omitted = kept_entries - len(candidates)
+    omission_line: str | None = None
     if completed_scan and omitted > 0:
         shown_directories = sum(
             entry.is_dir(follow_symlinks=False) for entry in candidates
         )
         shown_files = len(candidates) - shown_directories
-        budget.append(
+        omission_line = (
             f"{indent}... ({omitted} more) — "
             f"{kept_directories - shown_directories} directories, "
             f"{kept_files - shown_files} files omitted"
         )
+
+    def entry_line(entry: os.DirEntry[str]) -> str:
+        suffix = "/" if entry.is_dir(follow_symlinks=False) else ""
+        return f"{indent}{entry.name}{suffix}"
+
+    for index, entry in enumerate(candidates):
+        if entry.is_dir(follow_symlinks=False):
+            if not budget.append(entry_line(entry)):
+                return
+            if depth + 1 < budget.max_depth:
+                if depth == 0:
+                    reserved_lines = [
+                        entry_line(candidate)
+                        for candidate in candidates[index + 1 :]
+                    ]
+                    if omission_line is not None:
+                        reserved_lines.append(omission_line)
+                    prior_max_entries = budget.max_entries
+                    prior_max_chars = budget.max_chars
+                    budget.max_entries = max(
+                        budget.shown_entries,
+                        prior_max_entries - len(reserved_lines),
+                    )
+                    budget.max_chars = max(
+                        budget.body_chars,
+                        prior_max_chars
+                        - sum(len(line) + 1 for line in reserved_lines),
+                    )
+                    try:
+                        _walk(entry.path, depth + 1, budget)
+                    finally:
+                        budget.max_entries = prior_max_entries
+                        budget.max_chars = prior_max_chars
+                else:
+                    _walk(entry.path, depth + 1, budget)
+        else:
+            if not budget.append(entry_line(entry)):
+                return
+    if omission_line is not None:
+        budget.append(omission_line)
 
 
 async def build_repo_map_via_env(

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -23,6 +23,21 @@ MAX_ENTRIES_PER_DIR = 30
 # Bulky generated/vendored dirs that never help orientation. Hidden entries
 # (".git", ".venv", ...) are skipped by their dot prefix.
 SKIP_DIR_NAMES = frozenset({"__pycache__", "node_modules", "dist", "build", "venv"})
+VISIBLE_DOT_NAMES = frozenset(
+    {
+        ".devcontainer",
+        ".dockerignore",
+        ".editorconfig",
+        ".env.example",
+        ".gitattributes",
+        ".github",
+        ".gitignore",
+        ".pre-commit-config.yaml",
+        ".python-version",
+        ".ruby-version",
+        ".tool-versions",
+    }
+)
 ROOT_PRIORITY_FILES = frozenset(
     {
         "Cargo.toml",
@@ -42,7 +57,13 @@ _TRUNCATED_MARKER = "... (repository map truncated; traversal budget reached)"
 
 
 def _keep(name: str) -> bool:
-    return not name.startswith(".") and name not in SKIP_DIR_NAMES
+    if name in SKIP_DIR_NAMES:
+        return False
+    return not name.startswith(".") or name in VISIBLE_DOT_NAMES
+
+
+def _keep_relative_path(path: str) -> bool:
+    return all(_keep(part) for part in path.split("/") if part and part != ".")
 
 
 def _render_bounded_lines(lines: list[str], max_chars: int) -> str:
@@ -253,8 +274,13 @@ async def build_repo_map_via_env(
     Uses one ``find`` so it works wherever the workspace actually lives
     (e.g. inside a Docker container with no local mount).
     """
+    allowed_hidden = " ".join(
+        f"! -name '{name}'" for name in sorted(VISIBLE_DOT_NAMES)
+    )
+    hidden_prune = rf"\( -name '.*' {allowed_hidden} \)"
     prunes = " -o ".join(
-        ["-name '.*'"] + [f"-name '{name}'" for name in sorted(SKIP_DIR_NAMES)]
+        [hidden_prune]
+        + [f"-name '{name}'" for name in sorted(SKIP_DIR_NAMES)]
     )
     # -mindepth 1 keeps "." itself out of the prune tests — without it the
     # '.*' pattern matches the root and prunes the entire tree.
@@ -277,6 +303,7 @@ async def build_repo_map_via_env(
         line[2:] if line.startswith("./") else line
         for line in result.stdout.splitlines()
         if line.strip() and line.strip() != "."
+        and _keep_relative_path(line)
     )
     if not paths:
         return ""

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from typing import Any
 
 from opencollab.adapters.env import Environment
 
@@ -20,6 +21,8 @@ MAX_MAP_DEPTH = 3
 MAX_MAP_ENTRIES = 300
 MAX_MAP_DIRS = 100
 MAX_ENTRIES_PER_DIR = 30
+MIN_ROOT_FILE_ENTRIES = 5
+MIN_ROOT_DIR_ENTRIES = 5
 # Bulky generated/vendored dirs that never help orientation. Hidden entries
 # (".git", ".venv", ...) are skipped by their dot prefix.
 SKIP_DIR_NAMES = frozenset({"__pycache__", "node_modules", "dist", "build", "venv"})
@@ -181,8 +184,34 @@ def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
         return
     budget.scanned_dirs += 1
     candidates: list[os.DirEntry[str]] = []
+    root_directories: list[os.DirEntry[str]] = []
+    root_files: list[os.DirEntry[str]] = []
     kept_entries = 0
+    kept_directories = 0
+    kept_files = 0
     completed_scan = True
+
+    def root_key(entry: os.DirEntry[str]) -> tuple[bool, bool, str]:
+        is_directory = entry.is_dir(follow_symlinks=False)
+        return (
+            not (
+                entry.name in ROOT_PRIORITY_FILES
+                and not is_directory
+            ),
+            not is_directory,
+            entry.name,
+        )
+
+    def retain(
+        entries: list[os.DirEntry[str]],
+        entry: os.DirEntry[str],
+        *,
+        key: Any,
+    ) -> None:
+        entries.append(entry)
+        entries.sort(key=key)
+        del entries[MAX_ENTRIES_PER_DIR:]
+
     try:
         with os.scandir(path) as it:
             iterator = iter(it)
@@ -195,58 +224,54 @@ def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
                 if not _keep(entry.name):
                     continue
                 kept_entries += 1
-                entry_key = (
-                    not (
-                        depth == 0
-                        and entry.name in ROOT_PRIORITY_FILES
-                        and not entry.is_dir(follow_symlinks=False)
-                    ),
-                    not entry.is_dir(follow_symlinks=False),
-                    entry.name,
-                )
-                if len(candidates) < MAX_ENTRIES_PER_DIR:
-                    candidates.append(entry)
+                is_directory = entry.is_dir(follow_symlinks=False)
+                if is_directory:
+                    kept_directories += 1
                 else:
-                    worst_index = max(
-                        range(len(candidates)),
-                        key=lambda index: (
-                            not (
-                                depth == 0
-                                and candidates[index].name in ROOT_PRIORITY_FILES
-                                and not candidates[index].is_dir(follow_symlinks=False)
-                            ),
-                            not candidates[index].is_dir(follow_symlinks=False),
-                            candidates[index].name,
+                    kept_files += 1
+                if depth == 0:
+                    bucket = root_directories if is_directory else root_files
+                    retain(
+                        bucket,
+                        entry,
+                        key=(
+                            (lambda candidate: candidate.name)
+                            if is_directory
+                            else (
+                                lambda candidate: (
+                                    candidate.name not in ROOT_PRIORITY_FILES,
+                                    candidate.name,
+                                )
+                            )
                         ),
                     )
-                    worst = candidates[worst_index]
-                    worst_key = (
-                        not (
-                            depth == 0
-                            and worst.name in ROOT_PRIORITY_FILES
-                            and not worst.is_dir(follow_symlinks=False)
+                else:
+                    retain(
+                        candidates,
+                        entry,
+                        key=lambda candidate: (
+                            not candidate.is_dir(follow_symlinks=False),
+                            candidate.name,
                         ),
-                        not worst.is_dir(follow_symlinks=False),
-                        worst.name,
                     )
-                    if entry_key < worst_key:
-                        candidates[worst_index] = entry
             else:
                 budget.truncated = True
                 completed_scan = False
     except OSError:
         return
-    candidates.sort(
-        key=lambda entry: (
-            not (
-                depth == 0
-                and entry.name in ROOT_PRIORITY_FILES
-                and not entry.is_dir(follow_symlinks=False)
-            ),
-            not entry.is_dir(follow_symlinks=False),
-            entry.name,
+    if depth == 0:
+        required_files = root_files[:MIN_ROOT_FILE_ENTRIES]
+        required_directories = root_directories[:MIN_ROOT_DIR_ENTRIES]
+        candidates = [*required_files, *required_directories]
+        remaining = [
+            *root_files[len(required_files):],
+            *root_directories[len(required_directories):],
+        ]
+        remaining.sort(key=root_key)
+        candidates.extend(
+            remaining[:MAX_ENTRIES_PER_DIR - len(candidates)]
         )
-    )
+        candidates.sort(key=root_key)
     indent = "  " * depth
     for entry in candidates:
         if entry.is_dir(follow_symlinks=False):
@@ -259,7 +284,15 @@ def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
                 return
     omitted = kept_entries - len(candidates)
     if completed_scan and omitted > 0:
-        budget.append(f"{indent}... ({omitted} more)")
+        shown_directories = sum(
+            entry.is_dir(follow_symlinks=False) for entry in candidates
+        )
+        shown_files = len(candidates) - shown_directories
+        budget.append(
+            f"{indent}... ({omitted} more) — "
+            f"{kept_directories - shown_directories} directories, "
+            f"{kept_files - shown_files} files omitted"
+        )
 
 
 async def build_repo_map_via_env(
@@ -297,7 +330,12 @@ async def build_repo_map_via_env(
         result = await env.exec_cmd(cmd)
     except Exception:
         return ""
-    if result.returncode != 0 or result.stderr.strip():
+    if (
+        result.returncode != 0
+        or result.stderr.strip()
+        or result.stdout_truncated
+        or result.stderr_truncated
+    ):
         return ""
     paths = sorted(
         line[2:] if line.startswith("./") else line
@@ -307,7 +345,7 @@ async def build_repo_map_via_env(
     )
     if not paths:
         return ""
-    truncated = len(paths) > max_entries or result.stdout_truncated
+    truncated = len(paths) > max_entries
     return _render_map(
         paths[:max_entries],
         max_chars=max_chars,

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -24,6 +24,19 @@ MAX_ENTRIES_PER_DIR = 30
 # Bulky generated/vendored dirs that never help orientation. Hidden entries
 # (".git", ".venv", ...) are skipped by their dot prefix.
 SKIP_DIR_NAMES = frozenset({"__pycache__", "node_modules", "dist", "build", "venv"})
+ROOT_PRIORITY_FILES = frozenset(
+    {
+        "Cargo.toml",
+        "README",
+        "README.md",
+        "go.mod",
+        "package.json",
+        "pyproject.toml",
+        "setup.py",
+        "team.yaml",
+        "team.yml",
+    }
+)
 
 MAP_HEADER = "## Repository layout"
 _TRUNCATED_MARKER = "... (repository map truncated; traversal budget reached)"
@@ -131,14 +144,58 @@ def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
                 if not _keep(entry.name):
                     continue
                 kept_entries += 1
+                entry_key = (
+                    not (
+                        depth == 0
+                        and entry.name in ROOT_PRIORITY_FILES
+                        and not entry.is_dir(follow_symlinks=False)
+                    ),
+                    not entry.is_dir(follow_symlinks=False),
+                    entry.name,
+                )
                 if len(candidates) < MAX_ENTRIES_PER_DIR:
                     candidates.append(entry)
+                else:
+                    worst_index = max(
+                        range(len(candidates)),
+                        key=lambda index: (
+                            not (
+                                depth == 0
+                                and candidates[index].name in ROOT_PRIORITY_FILES
+                                and not candidates[index].is_dir(follow_symlinks=False)
+                            ),
+                            not candidates[index].is_dir(follow_symlinks=False),
+                            candidates[index].name,
+                        ),
+                    )
+                    worst = candidates[worst_index]
+                    worst_key = (
+                        not (
+                            depth == 0
+                            and worst.name in ROOT_PRIORITY_FILES
+                            and not worst.is_dir(follow_symlinks=False)
+                        ),
+                        not worst.is_dir(follow_symlinks=False),
+                        worst.name,
+                    )
+                    if entry_key < worst_key:
+                        candidates[worst_index] = entry
             else:
                 budget.truncated = True
                 completed_scan = False
     except OSError:
         return
-    candidates.sort(key=lambda entry: (not entry.is_dir(), entry.name))
+    candidates.sort(
+        key=lambda entry: (
+            not (
+                depth == 0
+                and entry.name in ROOT_PRIORITY_FILES
+                and not entry.is_dir(follow_symlinks=False)
+            ),
+            not entry.is_dir(follow_symlinks=False),
+            entry.name,
+        )
+    )
     indent = "  " * depth
     for entry in candidates:
         if entry.is_dir(follow_symlinks=False):

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -11,18 +11,22 @@ useful can be produced — callers inject the map only when non-empty.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass, field
 
 from opencollab.adapters.env import Environment
 from opencollab.adapters.tools._output import truncate
 
 MAX_MAP_CHARS = 4_000
 MAX_MAP_DEPTH = 3
+MAX_MAP_ENTRIES = 300
+MAX_MAP_DIRS = 100
 MAX_ENTRIES_PER_DIR = 30
 # Bulky generated/vendored dirs that never help orientation. Hidden entries
 # (".git", ".venv", ...) are skipped by their dot prefix.
 SKIP_DIR_NAMES = frozenset({"__pycache__", "node_modules", "dist", "build", "venv"})
 
 MAP_HEADER = "## Repository layout"
+_TRUNCATED_MARKER = "... (repository map truncated; traversal budget reached)"
 
 
 def _keep(name: str) -> bool:
@@ -34,35 +38,120 @@ def build_repo_map(
     *,
     max_depth: int = MAX_MAP_DEPTH,
     max_chars: int = MAX_MAP_CHARS,
+    max_entries: int = MAX_MAP_ENTRIES,
+    max_dirs: int = MAX_MAP_DIRS,
+    max_scanned_entries: int | None = None,
 ) -> str:
     """A depth- and size-bounded tree of ``workspace``, or ``""``."""
     if not workspace or not os.path.isdir(workspace):
         return ""
-    lines: list[str] = []
-    _walk(workspace, 0, max_depth, lines)
-    if not lines:
+    scanned_limit = (
+        max_scanned_entries
+        if max_scanned_entries is not None
+        else max(MAX_ENTRIES_PER_DIR + 2, max_entries * 4)
+    )
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+        for value in (
+            max_depth,
+            max_chars,
+            max_entries,
+            max_dirs,
+            scanned_limit,
+        )
+    ):
+        raise ValueError("repo-map budgets must be positive integers")
+    budget = _WalkBudget(
+        max_depth=max_depth,
+        max_chars=max_chars,
+        max_entries=max_entries,
+        max_dirs=max_dirs,
+        max_scanned_entries=scanned_limit,
+    )
+    _walk(workspace, 0, budget)
+    if not budget.lines and not budget.truncated:
         return ""
-    return f"{MAP_HEADER}\n\n" + truncate("\n".join(lines), max_chars)
+    return _render_map(budget.lines, max_chars=max_chars, truncated=budget.truncated)
 
 
-def _walk(path: str, depth: int, max_depth: int, lines: list[str]) -> None:
+@dataclass(slots=True)
+class _WalkBudget:
+    max_depth: int
+    max_chars: int
+    max_entries: int
+    max_dirs: int
+    max_scanned_entries: int
+    lines: list[str] = field(default_factory=list)
+    shown_entries: int = 0
+    scanned_entries: int = 0
+    scanned_dirs: int = 0
+    body_chars: int = 0
+    truncated: bool = False
+
+    def append(self, line: str) -> bool:
+        separator = 1 if self.lines else 0
+        if (
+            self.shown_entries >= self.max_entries
+            or self.body_chars + separator + len(line) > self.max_chars
+        ):
+            self.truncated = True
+            return False
+        self.lines.append(line)
+        self.shown_entries += 1
+        self.body_chars += separator + len(line)
+        return True
+
+
+def _render_map(lines: list[str], *, max_chars: int, truncated: bool) -> str:
+    body = "\n".join(lines)
+    if truncated:
+        body = f"{body}\n{_TRUNCATED_MARKER}" if body else _TRUNCATED_MARKER
+    return f"{MAP_HEADER}\n\n" + truncate(body, max_chars)
+
+
+def _walk(path: str, depth: int, budget: _WalkBudget) -> None:
+    if budget.truncated:
+        return
+    if budget.scanned_dirs >= budget.max_dirs:
+        budget.truncated = True
+        return
+    budget.scanned_dirs += 1
+    candidates: list[os.DirEntry[str]] = []
+    kept_entries = 0
+    completed_scan = True
     try:
         with os.scandir(path) as it:
-            entries = sorted(it, key=lambda e: (not e.is_dir(), e.name))
+            iterator = iter(it)
+            while budget.scanned_entries < budget.max_scanned_entries:
+                try:
+                    entry = next(iterator)
+                except StopIteration:
+                    break
+                budget.scanned_entries += 1
+                if not _keep(entry.name):
+                    continue
+                kept_entries += 1
+                if len(candidates) < MAX_ENTRIES_PER_DIR:
+                    candidates.append(entry)
+            else:
+                budget.truncated = True
+                completed_scan = False
     except OSError:
         return
-    entries = [e for e in entries if _keep(e.name)]
-    shown = entries[:MAX_ENTRIES_PER_DIR]
+    candidates.sort(key=lambda entry: (not entry.is_dir(), entry.name))
     indent = "  " * depth
-    for entry in shown:
+    for entry in candidates:
         if entry.is_dir(follow_symlinks=False):
-            lines.append(f"{indent}{entry.name}/")
-            if depth + 1 < max_depth:
-                _walk(entry.path, depth + 1, max_depth, lines)
+            if not budget.append(f"{indent}{entry.name}/"):
+                return
+            if depth + 1 < budget.max_depth:
+                _walk(entry.path, depth + 1, budget)
         else:
-            lines.append(f"{indent}{entry.name}")
-    if len(entries) > len(shown):
-        lines.append(f"{indent}... ({len(entries) - len(shown)} more)")
+            if not budget.append(f"{indent}{entry.name}"):
+                return
+    omitted = kept_entries - len(candidates)
+    if completed_scan and omitted > 0:
+        budget.append(f"{indent}... ({omitted} more)")
 
 
 async def build_repo_map_via_env(
@@ -70,6 +159,7 @@ async def build_repo_map_via_env(
     *,
     max_depth: int = MAX_MAP_DEPTH,
     max_chars: int = MAX_MAP_CHARS,
+    max_entries: int = MAX_MAP_ENTRIES,
 ) -> str:
     """A bounded path listing of the environment's workspace, or ``""``.
 
@@ -81,9 +171,14 @@ async def build_repo_map_via_env(
     )
     # -mindepth 1 keeps "." itself out of the prune tests — without it the
     # '.*' pattern matches the root and prunes the entire tree.
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+        for value in (max_depth, max_chars, max_entries)
+    ):
+        raise ValueError("repo-map budgets must be positive integers")
     cmd = (
         rf"find . -mindepth 1 -maxdepth {max_depth} "
-        rf"\( {prunes} \) -prune -o -print | sort"
+        rf"\( {prunes} \) -prune -o -print | head -n {max_entries + 1}"
     )
     try:
         result = await env.exec_cmd(cmd)
@@ -98,13 +193,20 @@ async def build_repo_map_via_env(
     ]
     if not paths:
         return ""
-    return f"{MAP_HEADER}\n\n" + truncate("\n".join(paths), max_chars)
+    truncated = len(paths) > max_entries or result.stdout_truncated
+    return _render_map(
+        paths[:max_entries],
+        max_chars=max_chars,
+        truncated=truncated,
+    )
 
 
 __all__ = [
     "MAP_HEADER",
     "MAX_MAP_CHARS",
     "MAX_MAP_DEPTH",
+    "MAX_MAP_DIRS",
+    "MAX_MAP_ENTRIES",
     "build_repo_map",
     "build_repo_map_via_env",
 ]

--- a/opencollab/adapters/repo_map.py
+++ b/opencollab/adapters/repo_map.py
@@ -271,13 +271,13 @@ async def build_repo_map_via_env(
         result = await env.exec_cmd(cmd)
     except Exception:
         return ""
-    if result.returncode != 0:
+    if result.returncode != 0 or result.stderr.strip():
         return ""
-    paths = [
+    paths = sorted(
         line[2:] if line.startswith("./") else line
         for line in result.stdout.splitlines()
         if line.strip() and line.strip() != "."
-    ]
+    )
     if not paths:
         return ""
     truncated = len(paths) > max_entries or result.stdout_truncated

--- a/opencollab/adapters/safe_files.py
+++ b/opencollab/adapters/safe_files.py
@@ -6,6 +6,7 @@ import errno
 import fcntl
 import os
 import stat
+import sys
 import time
 import uuid
 from collections.abc import Callable
@@ -14,13 +15,30 @@ from typing import BinaryIO, TextIO
 
 _LOCK_TIMEOUT_SECONDS = 10.0
 _READ_CHUNK_BYTES = 1024 * 1024
+_MACOS_SYSTEM_ALIASES = (
+    (Path("/tmp"), Path("/private/tmp")),
+    (Path("/var"), Path("/private/var")),
+)
+
+
+def _canonicalize_system_alias(path: Path) -> Path:
+    if sys.platform != "darwin":
+        return path
+    for alias, canonical in _MACOS_SYSTEM_ALIASES:
+        try:
+            relative = path.relative_to(alias)
+        except ValueError:
+            continue
+        if Path(os.path.realpath(alias)) == canonical and canonical.is_dir():
+            return canonical / relative
+    return path
 
 
 def _absolute(path: str | os.PathLike[str]) -> Path:
     value = os.fspath(path)
     if not value or "\0" in value:
         raise ValueError("path must be non-empty text without NUL bytes")
-    return Path(os.path.abspath(value))
+    return _canonicalize_system_alias(Path(os.path.abspath(value)))
 
 
 def _require_limit(max_bytes: int) -> int:

--- a/opencollab/adapters/safe_files.py
+++ b/opencollab/adapters/safe_files.py
@@ -13,8 +13,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import BinaryIO, TextIO
 
+from opencollab.adapters._env_base import TextFileRange
+
 _LOCK_TIMEOUT_SECONDS = 10.0
 _READ_CHUNK_BYTES = 1024 * 1024
+_RANGE_READ_CHUNK_CHARS = 64 * 1024
+_RANGE_TOTAL_COUNT_LIMIT_BYTES = 256 * 1024
 _MACOS_SYSTEM_ALIASES = (
     (Path("/tmp"), Path("/private/tmp")),
     (Path("/var"), Path("/private/var")),
@@ -117,6 +121,159 @@ def read_regular_text(
     encoding: str = "utf-8",
 ) -> str:
     return read_regular_bytes(path, max_bytes=max_bytes).decode(encoding)
+
+
+def _read_text_line(
+    handle: TextIO,
+    *,
+    collect_limit: int | None,
+) -> tuple[str | None, bool, bool]:
+    parts: list[str] = []
+    seen_content = False
+    remaining = collect_limit
+    while True:
+        chunk = handle.readline(_RANGE_READ_CHUNK_CHARS)
+        if chunk == "":
+            if not seen_content:
+                return None, True, False
+            return "".join(parts), True, False
+        seen_content = True
+        ended = chunk.endswith("\n")
+        content = chunk[:-1] if ended else chunk
+        if remaining is not None:
+            if len(content) > remaining:
+                parts.append(content[:remaining])
+                return "".join(parts), False, True
+            parts.append(content)
+            remaining -= len(content)
+        if ended:
+            return "".join(parts), False, False
+
+
+def read_regular_text_range(
+    path: str | os.PathLike[str],
+    *,
+    offset: int,
+    limit: int,
+    max_chars: int,
+    encoding: str = "utf-8",
+) -> TextFileRange:
+    """Read a bounded logical-line window without loading the full file."""
+    if (
+        isinstance(offset, bool)
+        or not isinstance(offset, int)
+        or offset < 1
+        or isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or limit < 1
+        or isinstance(max_chars, bool)
+        or not isinstance(max_chars, int)
+        or max_chars < 1
+    ):
+        raise ValueError("offset, limit, and max_chars must be positive integers")
+    target = _absolute(path)
+    _check_directory_components(target.parent, create=False)
+    fd = os.open(
+        target,
+        os.O_RDONLY
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"read target is not a regular file: {target}")
+        count_to_eof = opened.st_size <= _RANGE_TOTAL_COUNT_LIMIT_BYTES
+        with os.fdopen(fd, "r", encoding=encoding, errors="strict", newline=None) as handle:
+            fd = -1
+            line_number = 0
+            while line_number < offset - 1:
+                line, at_eof, _truncated = _read_text_line(
+                    handle,
+                    collect_limit=None,
+                )
+                if line is None:
+                    return TextFileRange([], offset, line_number, False)
+                line_number += 1
+                if at_eof:
+                    return TextFileRange([], offset, line_number, False)
+
+            selected: list[str] = []
+            chars_used = 0
+            while len(selected) < limit:
+                separator_chars = 1 if selected else 0
+                remaining = max_chars - chars_used - separator_chars
+                if remaining < 1:
+                    return TextFileRange(
+                        selected,
+                        offset,
+                        None,
+                        True,
+                        chars_truncated=True,
+                    )
+                line, at_eof, truncated = _read_text_line(
+                    handle,
+                    collect_limit=remaining,
+                )
+                if line is None:
+                    return TextFileRange(
+                        selected,
+                        offset,
+                        line_number,
+                        False,
+                    )
+                selected.append(line)
+                line_number += 1
+                chars_used += separator_chars + len(line)
+                if truncated:
+                    return TextFileRange(
+                        selected,
+                        offset,
+                        None,
+                        True,
+                        chars_truncated=True,
+                    )
+                if at_eof:
+                    return TextFileRange(
+                        selected,
+                        offset,
+                        line_number,
+                        False,
+                    )
+
+            if count_to_eof:
+                shown_end = offset - 1 + len(selected)
+                while True:
+                    line, at_eof, _truncated = _read_text_line(
+                        handle,
+                        collect_limit=None,
+                    )
+                    if line is None:
+                        return TextFileRange(
+                            selected,
+                            offset,
+                            line_number,
+                            line_number > shown_end,
+                        )
+                    line_number += 1
+                    if at_eof:
+                        return TextFileRange(
+                            selected,
+                            offset,
+                            line_number,
+                            line_number > shown_end,
+                        )
+            has_more = handle.read(1) != ""
+            return TextFileRange(
+                selected,
+                offset,
+                None if has_more else line_number,
+                has_more,
+            )
+    finally:
+        if fd >= 0:
+            os.close(fd)
 
 
 def open_regular_text_append(path: str | os.PathLike[str]) -> TextIO:
@@ -308,6 +465,7 @@ __all__ = [
     "open_regular_text_append",
     "read_regular_bytes",
     "read_regular_text",
+    "read_regular_text_range",
     "unlink_regular_file_durable",
     "write_locked_text",
     "write_regular_bytes_atomic",

--- a/opencollab/adapters/safe_files.py
+++ b/opencollab/adapters/safe_files.py
@@ -164,6 +164,22 @@ def _current_regular(path: Path, *, context: str) -> os.stat_result | None:
     return info
 
 
+def _fsync_directory(path: Path) -> None:
+    fd = os.open(
+        path,
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        if not stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(f"fsync target is not a directory: {path}")
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 def write_regular_file_atomic(
     path: str | os.PathLike[str],
     writer: Callable[[BinaryIO], None],
@@ -206,6 +222,7 @@ def write_regular_file_atomic(
             os.unlink(temporary)
         else:
             os.replace(temporary, target)
+        _fsync_directory(target.parent)
     finally:
         if fd >= 0:
             os.close(fd)
@@ -262,6 +279,7 @@ def unlink_regular_file_durable(path: str | os.PathLike[str]) -> bool:
     if current is None:
         return False
     os.unlink(target)
+    _fsync_directory(target.parent)
     return True
 
 

--- a/opencollab/adapters/skills/file_skill_store.py
+++ b/opencollab/adapters/skills/file_skill_store.py
@@ -19,6 +19,8 @@ import os
 import stat
 from pathlib import Path
 
+import yaml
+
 from opencollab.adapters.safe_files import read_regular_text
 from opencollab.adapters.tools._output import truncate
 from opencollab.domain.skill import SkillManifest
@@ -56,17 +58,16 @@ def _parse_skill(text: str) -> tuple[str, str, str] | None:
     if close_idx is None:
         return None
 
-    frontmatter: dict[str, str] = {}
-    for raw in lines[1:close_idx]:
-        key, sep, value = raw.partition(":")
-        if not sep:
-            continue
-        frontmatter[key.strip().lower()] = value.strip()
+    frontmatter = yaml.safe_load("\n".join(lines[1:close_idx]))
+    if not isinstance(frontmatter, dict):
+        return None
 
     name = frontmatter.get("name", "")
-    if not name:
+    if not isinstance(name, str) or not name:
         return None
     description = frontmatter.get("description", "")
+    if not isinstance(description, str):
+        return None
     body = "\n".join(lines[close_idx + 1 :]).strip()
     return name, description, body
 

--- a/opencollab/adapters/skills/file_skill_store.py
+++ b/opencollab/adapters/skills/file_skill_store.py
@@ -77,6 +77,7 @@ class FileSkillStore:
     def __init__(self, root: Path) -> None:
         self._manifests: list[SkillManifest] = []
         self._bodies: dict[str, str] = {}
+        self._load_diagnostics: list[str] = []
         self._load(Path(root))
 
     def _load(self, root: Path) -> None:
@@ -129,12 +130,12 @@ class FileSkillStore:
             return
         name, description, body = parsed
         if len(body) > SKILL_BODY_MAX_CHARS:
-            logger.debug(
-                "skipping skill %r at %s: body exceeds %s characters",
-                name,
-                skill_md,
-                SKILL_BODY_MAX_CHARS,
+            diagnostic = (
+                f"skill {name!r} rejected: body exceeds "
+                f"{SKILL_BODY_MAX_CHARS} characters"
             )
+            self._load_diagnostics.append(diagnostic)
+            logger.warning("%s (%s)", diagnostic, skill_md)
             return
         if name in self._bodies:
             logger.debug("skipping duplicate skill name %r at %s", name, skill_md)
@@ -152,6 +153,11 @@ class FileSkillStore:
 
     def get_body(self, name: str) -> str | None:
         return self._bodies.get(name)
+
+    @property
+    def load_diagnostics(self) -> tuple[str, ...]:
+        """Explicit reasons that otherwise valid skill packages were rejected."""
+        return tuple(self._load_diagnostics)
 
 
 __all__ = ["FileSkillStore", "SKILL_BODY_MAX_CHARS", "SKILL_DESCRIPTION_MAX_CHARS"]

--- a/opencollab/adapters/skills/file_skill_store.py
+++ b/opencollab/adapters/skills/file_skill_store.py
@@ -27,13 +27,12 @@ from opencollab.domain.skill import SkillManifest
 
 logger = logging.getLogger(__name__)
 
-# Single cap site for skills. No global tool-guardrails char-cap constant exists
-# on this branch (each tool defines its own, e.g. ``MAX_OUTPUT_CHARS``), so this
-# is a local default in the spirit of those. The shared ``truncate`` helper
-# (head+tail with a "… truncated …" marker) does the actual capping.
+# Single cap site for skills. A skill body is either available in full or is
+# skipped: returning a silently truncated instruction set would violate the
+# ``use_skill`` tool contract.
 SKILL_BODY_MAX_CHARS = 8000
 SKILL_DESCRIPTION_MAX_CHARS = 500
-MAX_SKILL_FILE_BYTES = 4 * 1024 * 1024
+MAX_SKILL_FILE_BYTES = 64 * 1024
 MAX_SKILL_PACKAGES = 256
 MAX_SKILL_ROOT_ENTRIES = 4_096
 
@@ -129,6 +128,14 @@ class FileSkillStore:
             logger.debug("skipping malformed skill %s: bad frontmatter", skill_md)
             return
         name, description, body = parsed
+        if len(body) > SKILL_BODY_MAX_CHARS:
+            logger.debug(
+                "skipping skill %r at %s: body exceeds %s characters",
+                name,
+                skill_md,
+                SKILL_BODY_MAX_CHARS,
+            )
+            return
         if name in self._bodies:
             logger.debug("skipping duplicate skill name %r at %s", name, skill_md)
             return
@@ -138,7 +145,7 @@ class FileSkillStore:
                 description=truncate(description, SKILL_DESCRIPTION_MAX_CHARS),
             )
         )
-        self._bodies[name] = truncate(body, SKILL_BODY_MAX_CHARS)
+        self._bodies[name] = body
 
     def list_manifests(self) -> tuple[SkillManifest, ...]:
         return tuple(self._manifests)

--- a/opencollab/adapters/tools/_output.py
+++ b/opencollab/adapters/tools/_output.py
@@ -9,10 +9,16 @@ stream in the marker when given (e.g. ``stdout``).
 from __future__ import annotations
 
 
+def require_positive_int(value: int, name: str) -> int:
+    """Validate one public output budget before a tool can perform work."""
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
 def truncate(text: str, max_chars: int, label: str | None = None) -> str:
     """Keep head + tail, drop the middle to avoid context explosion."""
-    if isinstance(max_chars, bool) or not isinstance(max_chars, int) or max_chars <= 0:
-        raise ValueError("max_chars must be a positive integer")
+    require_positive_int(max_chars, "max_chars")
     if len(text) <= max_chars:
         return text
     dropped = len(text) - max_chars
@@ -32,4 +38,4 @@ def truncate(text: str, max_chars: int, label: str | None = None) -> str:
     return result
 
 
-__all__ = ["truncate"]
+__all__ = ["require_positive_int", "truncate"]

--- a/opencollab/adapters/tools/apply_patch.py
+++ b/opencollab/adapters/tools/apply_patch.py
@@ -135,3 +135,5 @@ class ApplyPatchTool(Tool):
 
         except PermissionError as e:
             return f"Error: {e}"
+        except UnicodeDecodeError as e:
+            return f"Error: refusing to edit non-UTF-8 file: invalid UTF-8 at byte {e.start}."

--- a/opencollab/adapters/tools/apply_patch.py
+++ b/opencollab/adapters/tools/apply_patch.py
@@ -130,6 +130,10 @@ class ApplyPatchTool(Tool):
                     return f"Error applying patch to {path}: {err}"
 
                 assert updated is not None
+                if updated == current:
+                    return (
+                        f"Error applying patch to {path}: patch produced no changes."
+                    )
                 await env.write_file(path, updated)
                 return _summary(path, mode, current, updated)
 

--- a/opencollab/adapters/tools/apply_patch_engine.py
+++ b/opencollab/adapters/tools/apply_patch_engine.py
@@ -188,15 +188,23 @@ def _find_block(
             return None
         return expected_idx
     n = len(old_block)
-    matches = [
-        start
-        for start in range(min_idx, len(src_lines) - n + 1)
-        if src_lines[start : start + n] == old_block
-    ]
-    if not matches:
-        return None
-    matches.sort(key=lambda s: abs(s - expected_idx))
-    return matches[0]
+    best_start: int | None = None
+    best_distance: int | None = None
+    for start in range(min_idx, len(src_lines) - n + 1):
+        if src_lines[start] != old_block[0]:
+            continue
+        if any(
+            src_lines[start + offset] != old_block[offset]
+            for offset in range(1, n)
+        ):
+            continue
+        distance = abs(start - expected_idx)
+        if best_distance is None or distance < best_distance:
+            best_start = start
+            best_distance = distance
+            if distance == 0:
+                break
+    return best_start
 
 
 def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:

--- a/opencollab/adapters/tools/apply_patch_engine.py
+++ b/opencollab/adapters/tools/apply_patch_engine.py
@@ -135,6 +135,7 @@ def _parse_hunks(patch: str) -> tuple[list[dict] | None, str]:
                 "new_start": new_start,
                 "new_len": new_len,
                 "lines": [],
+                "no_newline_after": set(),
             }
             hunks.append(cur)
             continue
@@ -147,8 +148,14 @@ def _parse_hunks(patch: str) -> tuple[list[dict] | None, str]:
         if tag in " +-":
             cur["lines"].append(raw)
         elif tag == "\\":
-            # "\ No newline at end of file" — metadata, not content.
-            continue
+            if raw != "\\ No newline at end of file":
+                return None, f"hunk on patch line {line_number} has unknown metadata."
+            if not cur["lines"]:
+                return None, f"hunk on patch line {line_number} has orphan newline metadata."
+            previous = len(cur["lines"]) - 1
+            if previous in cur["no_newline_after"]:
+                return None, f"hunk on patch line {line_number} repeats newline metadata."
+            cur["no_newline_after"].add(previous)
         else:
             return None, f"hunk on patch line {line_number} has an unknown line prefix."
     if not seen_header:
@@ -220,11 +227,14 @@ def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:
     src_lines, ended_nl = _split_lines(source)
     result: list[str] = []
     src_idx = 0  # how far through src_lines we've consumed
+    target_ended_nl = ended_nl
 
     for n, hunk in enumerate(hunks, 1):
         old_block: list[str] = []
         new_block: list[str] = []
-        for line in hunk["lines"]:
+        old_no_newline_positions: list[int] = []
+        new_no_newline_positions: list[int] = []
+        for line_index, line in enumerate(hunk["lines"]):
             tag, content = line[0], line[1:]
             if tag == " ":
                 old_block.append(content)
@@ -233,6 +243,11 @@ def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:
                 old_block.append(content)
             elif tag == "+":
                 new_block.append(content)
+            if line_index in hunk["no_newline_after"]:
+                if tag in " -":
+                    old_no_newline_positions.append(len(old_block) - 1)
+                if tag in " +":
+                    new_no_newline_positions.append(len(new_block) - 1)
 
         expected_idx = hunk["old_start"] if hunk["old_len"] == 0 else hunk["old_start"] - 1
         pos = _find_block(src_lines, old_block, expected_idx, src_idx)
@@ -242,9 +257,29 @@ def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:
                 f"hunk #{n} (near line {hunk['old_start']}) did not match the file. "
                 f"The context/removed lines were not found:\n{snippet}"
             )
+        if hunk["no_newline_after"]:
+            if n != len(hunks) or pos + len(old_block) != len(src_lines):
+                return None, (
+                    f"hunk #{n} has 'No newline at end of file' metadata away from EOF."
+                )
+            if (
+                len(old_no_newline_positions) > 1
+                or old_no_newline_positions
+                and old_no_newline_positions[0] != len(old_block) - 1
+                or len(new_no_newline_positions) > 1
+                or new_no_newline_positions
+                and new_no_newline_positions[0] != len(new_block) - 1
+            ):
+                return None, f"hunk #{n} has newline metadata on a non-final line."
+            old_has_no_newline = bool(old_no_newline_positions)
+            if ended_nl == old_has_no_newline:
+                return None, (
+                    f"hunk #{n} newline metadata does not match the source EOF."
+                )
+            target_ended_nl = not bool(new_no_newline_positions)
         result.extend(src_lines[src_idx:pos])
         result.extend(new_block)
         src_idx = pos + len(old_block)
 
     result.extend(src_lines[src_idx:])
-    return _join_lines(result, ended_nl if result else False), ""
+    return _join_lines(result, target_ended_nl if result else False), ""

--- a/opencollab/adapters/tools/apply_patch_engine.py
+++ b/opencollab/adapters/tools/apply_patch_engine.py
@@ -123,8 +123,6 @@ def _parse_hunks(patch: str) -> tuple[list[dict] | None, str]:
         if cur is None:
             # Lines before the first @@ (e.g. ---/+++ headers) are ignored.
             continue
-        if raw.startswith("---") or raw.startswith("+++"):
-            continue
         if raw == "":
             # A blank line inside a hunk is a blank context line.
             cur["lines"].append(" ")

--- a/opencollab/adapters/tools/apply_patch_engine.py
+++ b/opencollab/adapters/tools/apply_patch_engine.py
@@ -104,7 +104,7 @@ def _apply_line_replace(source: str, params: dict[str, Any]) -> tuple[str | None
 
 
 def _parse_hunks(patch: str) -> tuple[list[dict] | None, str]:
-    """Parse ``@@`` hunks out of a unified diff into {old_start, lines} dicts."""
+    """Parse and structurally validate ``@@`` hunks from a unified diff."""
     hunks: list[dict] = []
     cur: dict | None = None
     seen_header = False
@@ -113,20 +113,36 @@ def _parse_hunks(patch: str) -> tuple[list[dict] | None, str]:
     # context line in a unified diff is " " (a lone space), not "".
     if raw_lines and raw_lines[-1] == "":
         raw_lines.pop()
-    for raw in raw_lines:
+    for line_number, raw in enumerate(raw_lines, 1):
         m = _HUNK_RE.match(raw)
         if m:
+            if cur is not None:
+                err = _validate_hunk_counts(cur)
+                if err:
+                    return None, err
             seen_header = True
-            cur = {"old_start": int(m.group(1)), "lines": []}
+            old_start = int(m.group(1))
+            old_len = int(m.group(2) or 1)
+            new_start = int(m.group(3))
+            new_len = int(m.group(4) or 1)
+            if old_start == 0 and old_len != 0:
+                return None, f"hunk header on patch line {line_number} has invalid old range."
+            if new_start == 0 and new_len != 0:
+                return None, f"hunk header on patch line {line_number} has invalid new range."
+            cur = {
+                "old_start": old_start,
+                "old_len": old_len,
+                "new_start": new_start,
+                "new_len": new_len,
+                "lines": [],
+            }
             hunks.append(cur)
             continue
         if cur is None:
             # Lines before the first @@ (e.g. ---/+++ headers) are ignored.
             continue
         if raw == "":
-            # A blank line inside a hunk is a blank context line.
-            cur["lines"].append(" ")
-            continue
+            return None, f"hunk on patch line {line_number} has an untagged blank line."
         tag = raw[0]
         if tag in " +-":
             cur["lines"].append(raw)
@@ -134,13 +150,29 @@ def _parse_hunks(patch: str) -> tuple[list[dict] | None, str]:
             # "\ No newline at end of file" — metadata, not content.
             continue
         else:
-            # Unexpected content ends the current hunk (trailing prose, etc.).
-            cur = None
+            return None, f"hunk on patch line {line_number} has an unknown line prefix."
     if not seen_header:
         return None, "no @@ hunk headers found in patch."
     if not hunks:
         return None, "patch contains no applicable hunks."
+    assert cur is not None
+    err = _validate_hunk_counts(cur)
+    if err:
+        return None, err
     return hunks, ""
+
+
+def _validate_hunk_counts(hunk: dict) -> str:
+    """Return an error unless hunk body counts match its header exactly."""
+    old_count = sum(line[0] in " -" for line in hunk["lines"])
+    new_count = sum(line[0] in " +" for line in hunk["lines"])
+    if old_count != hunk["old_len"] or new_count != hunk["new_len"]:
+        return (
+            f"hunk near line {hunk['old_start']} declares {hunk['old_len']} old lines and "
+            f"{hunk['new_len']} new lines, but contains {old_count} old lines and "
+            f"{new_count} new lines."
+        )
+    return ""
 
 
 def _find_block(
@@ -152,8 +184,9 @@ def _find_block(
     resolve to the intended one. Returns None if the block isn't found.
     """
     if not old_block:
-        # Pure insertion: clamp the stated position into the valid range.
-        return max(min_idx, min(expected_idx, len(src_lines)))
+        if expected_idx < min_idx or expected_idx > len(src_lines):
+            return None
+        return expected_idx
     n = len(old_block)
     matches = [
         start
@@ -193,7 +226,8 @@ def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:
             elif tag == "+":
                 new_block.append(content)
 
-        pos = _find_block(src_lines, old_block, hunk["old_start"] - 1, src_idx)
+        expected_idx = hunk["old_start"] if hunk["old_len"] == 0 else hunk["old_start"] - 1
+        pos = _find_block(src_lines, old_block, expected_idx, src_idx)
         if pos is None:
             snippet = "\n".join(old_block[:6]) or "(empty context)"
             return None, (

--- a/opencollab/adapters/tools/apply_patch_engine.py
+++ b/opencollab/adapters/tools/apply_patch_engine.py
@@ -12,11 +12,30 @@ from typing import Any
 
 # A hunk header: @@ -<old_start>[,<old_len>] +<new_start>[,<new_len>] @@ [heading]
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_NEWLINE_RE = re.compile(r"\r\n|\r|\n")
+_MIXED_NEWLINES = "mixed"
 
 
 # ---------------------------------------------------------------------------
 # Line helpers — split/join while preserving a trailing-newline flag.
 # ---------------------------------------------------------------------------
+
+
+def _detect_newline_style(text: str) -> str:
+    styles = set(_NEWLINE_RE.findall(text))
+    if len(styles) > 1:
+        return _MIXED_NEWLINES
+    return next(iter(styles), "\n")
+
+
+def _normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _restore_newlines(text: str, style: str) -> str:
+    if style == "\n":
+        return text
+    return text.replace("\n", style)
 
 
 def _split_lines(text: str) -> tuple[list[str], bool]:
@@ -55,6 +74,17 @@ def _apply_line_replace(source: str, params: dict[str, Any]) -> tuple[str | None
 
     Returns ``(updated_text, "")`` on success or ``(None, error)`` on failure.
     """
+    newline_style = _detect_newline_style(source)
+    if newline_style == _MIXED_NEWLINES:
+        return None, (
+            "source uses mixed newline styles; refusing to normalize it implicitly."
+        )
+    source = _normalize_newlines(source)
+    params = dict(params)
+    for key in ("new_str", "expected_str"):
+        if key in params and params[key] is not None:
+            params[key] = _normalize_newlines(params[key])
+
     if "start_line" not in params or "end_line" not in params:
         return None, "start_line and end_line are required for line_replace mode."
     start_line = params["start_line"]
@@ -95,7 +125,8 @@ def _apply_line_replace(source: str, params: dict[str, Any]) -> tuple[str | None
     # newline is normalised away since we re-split it into lines.
     new_lines, _ = _split_lines(new_str if new_str.endswith("\n") or new_str == "" else new_str + "\n")
     result = lines[:start_idx] + new_lines + lines[end_idx:]
-    return _join_lines(result, ended_nl if result else False), ""
+    updated = _join_lines(result, ended_nl if result else False)
+    return _restore_newlines(updated, newline_style), ""
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +250,13 @@ def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:
 
     Returns ``(updated_text, "")`` on success or ``(None, error)`` on failure.
     """
+    newline_style = _detect_newline_style(source)
+    if newline_style == _MIXED_NEWLINES:
+        return None, (
+            "source uses mixed newline styles; refusing to normalize it implicitly."
+        )
+    source = _normalize_newlines(source)
+    patch = _normalize_newlines(patch)
     hunks, err = _parse_hunks(patch)
     if err:
         return None, err
@@ -282,4 +320,5 @@ def _apply_unified_diff(source: str, patch: str) -> tuple[str | None, str]:
         src_idx = pos + len(old_block)
 
     result.extend(src_lines[src_idx:])
-    return _join_lines(result, target_ended_nl if result else False), ""
+    updated = _join_lines(result, target_ended_nl if result else False)
+    return _restore_newlines(updated, newline_style), ""

--- a/opencollab/adapters/tools/bash.py
+++ b/opencollab/adapters/tools/bash.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from opencollab.adapters.tools._output import truncate
+from opencollab.adapters.tools._output import require_positive_int, truncate
 from opencollab.adapters.tools.base import Tool
 from opencollab.application.tool_execution import ToolRuntime
 
@@ -86,13 +86,9 @@ class BashTool(Tool):
         *,
         require_process_isolation: bool = False,
     ):
-        if (
-            isinstance(max_output_chars, bool)
-            or not isinstance(max_output_chars, int)
-            or max_output_chars <= 0
-        ):
-            raise ValueError("max_output_chars must be a positive integer")
-        self.max_output_chars = max_output_chars
+        self.max_output_chars = require_positive_int(
+            max_output_chars, "max_output_chars"
+        )
         self.require_process_isolation = require_process_isolation
 
     async def execute_with_runtime(

--- a/opencollab/adapters/tools/bash.py
+++ b/opencollab/adapters/tools/bash.py
@@ -20,6 +20,29 @@ MAX_OUTPUT_CHARS = 8_000
 DEFAULT_TIMEOUT = 120.0
 
 
+def _format_captured_stream(
+    text: str,
+    max_chars: int,
+    label: str,
+    dropped_bytes: int,
+) -> str:
+    if dropped_bytes <= 0:
+        return truncate(text, max_chars, label)
+    marker = (
+        f"\n\n... [{dropped_bytes} bytes of {label} dropped during capture] ...\n\n"
+    )
+    if len(marker) >= max_chars:
+        return marker[:max_chars]
+    source_budget = max_chars - len(marker)
+    head_budget = (source_budget + 1) // 2
+    tail_budget = source_budget - head_budget
+    captured_split = (len(text) + 1) // 2
+    captured_head = text[:captured_split]
+    captured_tail = text[captured_split:]
+    tail = captured_tail[-tail_budget:] if tail_budget else ""
+    return captured_head[:head_budget] + marker + tail
+
+
 class BashTool(Tool):
     """Execute a shell command in the workspace.
 
@@ -93,8 +116,18 @@ class BashTool(Tool):
         result = await env.exec_cmd(cmd, timeout=timeout)
 
         # Format output with truncation (ref: user blind spot #1)
-        stdout = truncate(result.stdout, self.max_output_chars, "stdout")
-        stderr = truncate(result.stderr, self.max_output_chars, "stderr")
+        stdout = _format_captured_stream(
+            result.stdout,
+            self.max_output_chars,
+            "stdout",
+            getattr(result, "stdout_dropped_bytes", 0),
+        )
+        stderr = _format_captured_stream(
+            result.stderr,
+            self.max_output_chars,
+            "stderr",
+            getattr(result, "stderr_dropped_bytes", 0),
+        )
 
         parts = [f"Exit code: {result.returncode}"]
         if stdout:

--- a/opencollab/adapters/tools/bash.py
+++ b/opencollab/adapters/tools/bash.py
@@ -86,6 +86,12 @@ class BashTool(Tool):
         *,
         require_process_isolation: bool = False,
     ):
+        if (
+            isinstance(max_output_chars, bool)
+            or not isinstance(max_output_chars, int)
+            or max_output_chars <= 0
+        ):
+            raise ValueError("max_output_chars must be a positive integer")
         self.max_output_chars = max_output_chars
         self.require_process_isolation = require_process_isolation
 

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
+from opencollab.adapters._env_base import TextFileRange
 from opencollab.adapters.tools._output import truncate
 from opencollab.adapters.tools._paths import checked_path
 from opencollab.adapters.tools.apply_patch_engine import (
@@ -98,7 +99,25 @@ class FileReadTool(Tool):
         path = checked_path(runtime, path)
 
         try:
-            content = await env.read_file(path)
+            range_reader = getattr(env, "read_text_range", None)
+            if callable(range_reader):
+                window = await range_reader(
+                    path,
+                    offset=offset,
+                    limit=limit,
+                    max_chars=self.max_read_chars,
+                )
+            else:
+                content = await env.read_file(path)
+                lines = content.splitlines()
+                start = max(0, offset - 1)
+                end = min(len(lines), start + limit)
+                window = TextFileRange(
+                    lines=lines[start:end],
+                    start_line=start + 1,
+                    total_lines=len(lines),
+                    has_more=end < len(lines),
+                )
         except FileNotFoundError:
             return f"Error: file not found: {path}"
         except PermissionError as e:
@@ -106,25 +125,36 @@ class FileReadTool(Tool):
         except UnicodeDecodeError as e:
             return f"Error: file is not valid UTF-8: invalid UTF-8 at byte {e.start}."
 
-        lines = content.splitlines()
-        total = len(lines)
-
-        # Apply line range
-        start = max(0, offset - 1)
-        end = min(total, start + limit)
-        selected = lines[start:end]
+        selected = window.lines
+        start = window.start_line - 1
+        end = start + len(selected)
 
         # Format with line numbers (ref: claude-code cat -n format)
         numbered = [f"{start + i + 1}\t{line}" for i, line in enumerate(selected)]
-        header = f"File: {params['path']} ({total} lines total, showing {start + 1}-{end})"
+        if window.total_lines is None:
+            total_description = "total not scanned"
+        else:
+            total_description = f"{window.total_lines} lines total"
+        header = (
+            f"File: {params['path']} ({total_description}, "
+            f"showing {start + 1}-{end})"
+        )
         body = header + "\n" + truncate("\n".join(numbered), self.max_read_chars)
+        if window.chars_truncated:
+            body += (
+                f"\n... requested content reached the {self.max_read_chars}-character "
+                "read limit."
+            )
         # Loud footer when lines remain below the shown range — otherwise a
         # default read silently stops at the limit and the tail is lost.
-        if end < total:
+        if window.has_more:
+            if window.total_lines is None:
+                remaining = "more lines below (total not scanned)"
+            else:
+                remaining = f"{window.total_lines - end} more lines below"
             body += (
-                f"\n... {total - end} more lines below (showing {start + 1}-{end} "
-                f"of {total}). Continue with offset={end + 1}, or use the grep "
-                f"tool to jump to a symbol."
+                f"\n... {remaining} (showing {start + 1}-{end}). Continue with "
+                f"offset={end + 1}, or use the grep tool to jump to a symbol."
             )
         return body
 

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -350,7 +350,7 @@ class GrepTool(Tool):
 
         quoted_pattern = shlex.quote(pattern)
         quoted_search_path = shlex.quote(search_path)
-        rg_cmd = f"rg -n --max-count {max_results} "
+        rg_cmd = "rg -n "
         if glob_pattern:
             rg_cmd += f"-g {shlex.quote(glob_pattern)} "
         rg_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null"
@@ -369,5 +369,6 @@ class GrepTool(Tool):
 
         result = await env.exec_cmd(rg_cmd, timeout=30)
         if result.stdout.strip():
-            return truncate(result.stdout.strip(), self.max_grep_chars)
+            matches = result.stdout.strip().splitlines()[:max_results]
+            return truncate("\n".join(matches), self.max_grep_chars)
         return f"No matches found for pattern: {pattern}"

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -15,7 +15,7 @@ import shlex
 from typing import Any
 
 from opencollab.adapters._env_base import TextFileRange
-from opencollab.adapters.tools._output import truncate
+from opencollab.adapters.tools._output import require_positive_int, truncate
 from opencollab.adapters.tools._paths import checked_path
 from opencollab.adapters.tools.apply_patch_engine import (
     _MIXED_NEWLINES,
@@ -81,7 +81,9 @@ class FileReadTool(Tool):
     }
 
     def __init__(self, max_read_chars: int = MAX_READ_CHARS):
-        self.max_read_chars = max_read_chars
+        self.max_read_chars = require_positive_int(
+            max_read_chars, "max_read_chars"
+        )
 
     async def execute_with_runtime(
         self,
@@ -383,7 +385,9 @@ class GrepTool(Tool):
     }
 
     def __init__(self, max_grep_chars: int = MAX_GREP_CHARS):
-        self.max_grep_chars = max_grep_chars
+        self.max_grep_chars = require_positive_int(
+            max_grep_chars, "max_grep_chars"
+        )
 
     async def execute_with_runtime(
         self,

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -350,7 +350,11 @@ class GrepTool(Tool):
 
         quoted_pattern = shlex.quote(pattern)
         quoted_search_path = shlex.quote(search_path)
-        rg_cmd = "rg -n "
+        rg_cmd = (
+            "rg -n --hidden "
+            "-g '!.git/**' -g '!.venv/**' -g '!.opencollab/**' "
+            "-g '!**/.git/**' -g '!**/.venv/**' -g '!**/.opencollab/**' "
+        )
         if glob_pattern:
             rg_cmd += f"-g {shlex.quote(glob_pattern)} "
         rg_cmd += f"-- {quoted_pattern} {quoted_search_path}"

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -30,6 +30,17 @@ OVERWRITE_GUARD_MIN_CHARS = 1_000
 OVERWRITE_GUARD_SHRINK_RATIO = 0.5
 
 
+def _count_overlapping(text: str, needle: str) -> int:
+    count = 0
+    start = 0
+    while True:
+        match = text.find(needle, start)
+        if match < 0:
+            return count
+        count += 1
+        start = match + 1
+
+
 class FileReadTool(Tool):
     """Read file content with optional line range."""
 
@@ -254,7 +265,7 @@ class FileWriteTool(Tool):
         current = await env.read_file(path)
 
         # Check uniqueness (ref: claude-code Edit — must be unique)
-        count = current.count(old_str)
+        count = _count_overlapping(current, old_str)
         if count == 0:
             return (
                 f"Error: old_str not found in {path}. Make sure the text matches "

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -354,20 +354,19 @@ class GrepTool(Tool):
         if glob_pattern:
             rg_cmd += f"-g {shlex.quote(glob_pattern)} "
         rg_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null"
-        # Fallback when rg is missing from PATH: grep MUST use -E (ERE) so that
-        # `a|b|c` alternation works. Plain grep is BRE, where `|` is a literal
-        # character — an alternation pattern then silently matches nothing. Also
-        # exclude VCS/venv and the .opencollab session dir so the fallback can't
-        # "match" its own logged pattern strings instead of real source.
-        rg_cmd += (
-            " || grep -rEn"
-            " --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.opencollab "
-        )
-        if glob_pattern:
-            rg_cmd += f"--include={shlex.quote(glob_pattern)} "
-        rg_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null | head -n {max_results}"
 
         result = await env.exec_cmd(rg_cmd, timeout=30)
+        if result.returncode == 127:
+            # Fallback only when rg is unavailable. A normal rg no-match uses
+            # return code 1 and must not scan the same tree a second time.
+            grep_cmd = (
+                "grep -rEn"
+                " --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.opencollab "
+            )
+            if glob_pattern:
+                grep_cmd += f"--include={shlex.quote(glob_pattern)} "
+            grep_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null"
+            result = await env.exec_cmd(grep_cmd, timeout=30)
         if result.stdout.strip():
             matches = result.stdout.strip().splitlines()[:max_results]
             return truncate("\n".join(matches), self.max_grep_chars)

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -16,6 +16,12 @@ from typing import Any
 
 from opencollab.adapters.tools._output import truncate
 from opencollab.adapters.tools._paths import checked_path
+from opencollab.adapters.tools.apply_patch_engine import (
+    _MIXED_NEWLINES,
+    _detect_newline_style,
+    _normalize_newlines,
+    _restore_newlines,
+)
 from opencollab.adapters.tools.base import Tool, host_write_lock
 from opencollab.application.tool_execution import ToolRuntime
 
@@ -263,9 +269,29 @@ class FileWriteTool(Tool):
             )
 
         current = await env.read_file(path)
+        newline_style = _detect_newline_style(current)
+        if newline_style == _MIXED_NEWLINES:
+            if any(character in old_str + new_str for character in ("\r", "\n")):
+                return (
+                    f"Error: {path} uses mixed newline styles; refusing to "
+                    "normalize a multiline replacement implicitly."
+                )
+            normalized_current = current
+            normalized_old = old_str
+            normalized_new = new_str
+        else:
+            normalized_current = _normalize_newlines(current)
+            normalized_old = _normalize_newlines(old_str)
+            normalized_new = _normalize_newlines(new_str)
+
+        if normalized_new == normalized_old:
+            return (
+                f"Error: str_replace was a no-op — old_str and new_str are "
+                f"logically identical; nothing changed in {path}."
+            )
 
         # Check uniqueness (ref: claude-code Edit — must be unique)
-        count = _count_overlapping(current, old_str)
+        count = _count_overlapping(normalized_current, normalized_old)
         if count == 0:
             return (
                 f"Error: old_str not found in {path}. Make sure the text matches "
@@ -275,7 +301,9 @@ class FileWriteTool(Tool):
         if count > 1:
             return f"Error: old_str found {count} times in {path}. Provide more context to make it unique."
 
-        updated = current.replace(old_str, new_str, 1)
+        updated = normalized_current.replace(normalized_old, normalized_new, 1)
+        if newline_style != _MIXED_NEWLINES:
+            updated = _restore_newlines(updated, newline_style)
         if updated == current:
             # Defensive: old_str matched but the resulting content is byte-for-byte
             # identical (e.g. a degenerate overlap). Report no change rather than a

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -86,6 +86,8 @@ class FileReadTool(Tool):
             return f"Error: file not found: {path}"
         except PermissionError as e:
             return f"Error: {e}"
+        except UnicodeDecodeError as e:
+            return f"Error: file is not valid UTF-8: invalid UTF-8 at byte {e.start}."
 
         lines = content.splitlines()
         total = len(lines)
@@ -200,6 +202,8 @@ class FileWriteTool(Tool):
                 return f"Error: unknown mode '{mode}'. Use 'create' or 'str_replace'."
         except PermissionError as e:
             return f"Error: {e}"
+        except UnicodeDecodeError as e:
+            return f"Error: refusing to edit non-UTF-8 file: invalid UTF-8 at byte {e.start}."
 
     async def _create(
         self, env: Any, path: str, content: str, *, overwrite: bool = False

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -353,8 +353,9 @@ class GrepTool(Tool):
         rg_cmd = "rg -n "
         if glob_pattern:
             rg_cmd += f"-g {shlex.quote(glob_pattern)} "
-        rg_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null"
+        rg_cmd += f"-- {quoted_pattern} {quoted_search_path}"
 
+        backend = "rg"
         result = await env.exec_cmd(rg_cmd, timeout=30)
         if result.returncode == 127:
             # Fallback only when rg is unavailable. A normal rg no-match uses
@@ -365,8 +366,18 @@ class GrepTool(Tool):
             )
             if glob_pattern:
                 grep_cmd += f"--include={shlex.quote(glob_pattern)} "
-            grep_cmd += f"-- {quoted_pattern} {quoted_search_path} 2>/dev/null"
+            grep_cmd += f"-- {quoted_pattern} {quoted_search_path}"
+            backend = "grep"
             result = await env.exec_cmd(grep_cmd, timeout=30)
+        if result.returncode == 1:
+            return f"No matches found for pattern: {pattern}"
+        if result.returncode != 0:
+            diagnostic = (result.stderr or result.stdout).strip()
+            if not diagnostic:
+                diagnostic = f"exit code {result.returncode}"
+            if getattr(result, "stderr_truncated", False):
+                diagnostic += " (stderr truncated)"
+            return f"Error: {backend} search failed: {truncate(diagnostic, 1000)}"
         if result.stdout.strip():
             matches = result.stdout.strip().splitlines()[:max_results]
             return truncate("\n".join(matches), self.max_grep_chars)

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -232,6 +232,8 @@ class FileWriteTool(Tool):
                 "Error: file creation disabled in this phase; edit the existing "
                 "target via str_replace (or apply_patch for a content-anchored diff)."
             )
+        if mode == "create" and "content" not in params:
+            return "Error: content is required for create mode."
 
         path = checked_path(runtime, path)
 

--- a/opencollab/adapters/tools/git_diff.py
+++ b/opencollab/adapters/tools/git_diff.py
@@ -95,10 +95,10 @@ class GitDiffTool(Tool):
         diff_cmd = "git --no-pager diff"
         if staged:
             diff_cmd += " --cached"
+        else:
+            diff_cmd += " HEAD"
         if stat_only:
             diff_cmd += " --stat"
-        else:
-            diff_cmd += " HEAD" if not staged else ""
         diff_cmd += pathspec
 
         diff_result = await env.exec_cmd(diff_cmd, timeout=30)

--- a/opencollab/adapters/tools/git_diff.py
+++ b/opencollab/adapters/tools/git_diff.py
@@ -26,6 +26,7 @@ from opencollab.application.tool_execution import ToolRuntime
 # Diffs can be enormous; keep a bounded head+tail (ref: bash.py truncation).
 MAX_DIFF_CHARS = 8_000
 MAX_STATUS_CHARS = 2_000
+MAX_UNTRACKED_DIFF_FILES = 50
 
 
 class GitDiffTool(Tool):
@@ -131,6 +132,52 @@ class GitDiffTool(Tool):
                 return "Error: not a git repository."
             return f"Error running '{diff_cmd}':\n{truncate(err, self.max_status_chars)}"
 
+        untracked_parts: list[str] = []
+        if not staged:
+            untracked_cmd = (
+                "git --no-pager status --porcelain=v1 -z --untracked-files=all"
+                + pathspec
+            )
+            untracked_result = await env.exec_cmd(untracked_cmd, timeout=30)
+            if untracked_result.returncode != 0:
+                error = (untracked_result.stderr or untracked_result.stdout).strip()
+                return "Error enumerating untracked files:\n" + truncate(
+                    error,
+                    self.max_status_chars,
+                )
+            untracked_paths = [
+                entry[3:]
+                for entry in untracked_result.stdout.split("\0")
+                if entry.startswith("?? ")
+            ]
+            for untracked_path in untracked_paths[:MAX_UNTRACKED_DIFF_FILES]:
+                untracked_diff_cmd = "git --no-pager diff --no-index"
+                if stat_only:
+                    untracked_diff_cmd += " --stat"
+                untracked_diff_cmd += (
+                    f" -- /dev/null {shlex.quote(untracked_path)}"
+                )
+                untracked_diff = await env.exec_cmd(untracked_diff_cmd, timeout=30)
+                if untracked_diff.returncode not in {0, 1}:
+                    error = (untracked_diff.stderr or untracked_diff.stdout).strip()
+                    untracked_parts.append(
+                        f"{untracked_path}: untracked diff unavailable"
+                        + (f" ({truncate(error, 200)})" if error else "")
+                    )
+                    continue
+                text = untracked_diff.stdout.strip()
+                if text:
+                    untracked_parts.append(text)
+                if getattr(untracked_diff, "stdout_truncated", False):
+                    untracked_parts.append(
+                        f"{untracked_path}: untracked diff output was truncated"
+                    )
+            if len(untracked_paths) > MAX_UNTRACKED_DIFF_FILES:
+                untracked_parts.append(
+                    f"... {len(untracked_paths) - MAX_UNTRACKED_DIFF_FILES} "
+                    "additional untracked files omitted"
+                )
+
         parts: list[str] = []
         if include_status:
             status_result = await env.exec_cmd("git --no-pager status --short", timeout=30)
@@ -141,7 +188,12 @@ class GitDiffTool(Tool):
                 else "Status: working tree clean."
             )
 
-        diff = diff_result.stdout.strip()
+        diff_sections = [diff_result.stdout.strip()]
+        if untracked_parts:
+            diff_sections.append(
+                "Untracked files:\n" + "\n".join(untracked_parts)
+            )
+        diff = "\n".join(section for section in diff_sections if section)
         if stat_only:
             label = (
                 "diff --stat"

--- a/opencollab/adapters/tools/git_diff.py
+++ b/opencollab/adapters/tools/git_diff.py
@@ -93,10 +93,33 @@ class GitDiffTool(Tool):
         pathspec = f" -- {shlex.quote(path)}" if path else ""
 
         diff_cmd = "git --no-pager diff"
+        baseline_label = "HEAD"
         if staged:
             diff_cmd += " --cached"
         else:
-            diff_cmd += " HEAD"
+            head = await env.exec_cmd("git rev-parse --verify HEAD", timeout=30)
+            if head.returncode == 0:
+                baseline = "HEAD"
+            else:
+                inside = await env.exec_cmd(
+                    "git rev-parse --is-inside-work-tree",
+                    timeout=30,
+                )
+                if inside.returncode != 0 or inside.stdout.strip() != "true":
+                    return "Error: not a git repository."
+                empty_tree = await env.exec_cmd(
+                    "git hash-object -t tree /dev/null",
+                    timeout=30,
+                )
+                baseline = empty_tree.stdout.strip()
+                if empty_tree.returncode != 0 or not baseline:
+                    error = (empty_tree.stderr or empty_tree.stdout).strip()
+                    return (
+                        "Error: could not determine Git empty-tree baseline: "
+                        + truncate(error, self.max_status_chars)
+                    )
+                baseline_label = "empty tree"
+            diff_cmd += f" {baseline}"
         if stat_only:
             diff_cmd += " --stat"
         diff_cmd += pathspec
@@ -119,7 +142,14 @@ class GitDiffTool(Tool):
             )
 
         diff = diff_result.stdout.strip()
-        label = "diff --stat" if stat_only else ("staged diff" if staged else "diff vs HEAD")
+        if stat_only:
+            label = (
+                "diff --stat"
+                if staged or baseline_label == "HEAD"
+                else "diff vs empty tree --stat"
+            )
+        else:
+            label = "staged diff" if staged else f"diff vs {baseline_label}"
         if diff:
             parts.append(f"{label}:\n" + truncate(diff, self.max_diff_chars))
         else:

--- a/opencollab/adapters/tools/git_diff.py
+++ b/opencollab/adapters/tools/git_diff.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
-from opencollab.adapters.tools._output import truncate
+from opencollab.adapters.tools._output import require_positive_int, truncate
 from opencollab.adapters.tools.base import Tool
 from opencollab.application.tool_execution import ToolRuntime
 
@@ -74,8 +74,12 @@ class GitDiffTool(Tool):
         max_diff_chars: int = MAX_DIFF_CHARS,
         max_status_chars: int = MAX_STATUS_CHARS,
     ):
-        self.max_diff_chars = max_diff_chars
-        self.max_status_chars = max_status_chars
+        self.max_diff_chars = require_positive_int(
+            max_diff_chars, "max_diff_chars"
+        )
+        self.max_status_chars = require_positive_int(
+            max_status_chars, "max_status_chars"
+        )
 
     async def execute_with_runtime(
         self,

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -171,6 +171,8 @@ class RunTestsTool(Tool):
         runtime: ToolRuntime,
     ) -> str:
         target = params.get("target", "")
+        if target:
+            self._verified_targets.discard(target)
         pinned_runner = params.get("runner")
         extra_args = params.get("extra_args", "")
         timeout = params.get("timeout", DEFAULT_TIMEOUT)

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -24,6 +24,7 @@ Ref:
 
 from __future__ import annotations
 
+import posixpath
 import re
 import shlex
 from typing import Any
@@ -99,6 +100,34 @@ _PYTEST_MISSING_RE = re.compile(
 )
 
 
+def _normalize_verification_target(target: str) -> str:
+    path, separator, selectors = target.partition("::")
+    normalized_path = posixpath.normpath(path)
+    if separator:
+        return f"{normalized_path}::{selectors}"
+    return normalized_path
+
+
+def _verification_target_covers(parent: str, child: str) -> bool:
+    normalized_parent = _normalize_verification_target(parent)
+    normalized_child = _normalize_verification_target(child)
+    if normalized_parent == ".":
+        return True
+    if normalized_parent == normalized_child:
+        return True
+    if normalized_child.startswith(f"{normalized_parent}::"):
+        return True
+    parent_path, parent_separator, _ = normalized_parent.partition("::")
+    child_path, _, _ = normalized_child.partition("::")
+    return not parent_separator and child_path.startswith(f"{parent_path}/")
+
+
+def _verification_targets_overlap(left: str, right: str) -> bool:
+    return _verification_target_covers(
+        left, right
+    ) or _verification_target_covers(right, left)
+
+
 class RunTestsTool(Tool):
     """Run tests and return a structured pass/fail summary (not raw output).
 
@@ -169,14 +198,21 @@ class RunTestsTool(Tool):
         # the eval toolset), so this survives across run_tests calls.
         self._consecutive_fail: dict[str, int] = {}
 
+    def _invalidate_verification_scope(self, target: str) -> None:
+        stale = {
+            verified
+            for verified in self._verified_targets
+            if _verification_targets_overlap(target, verified)
+        }
+        self._verified_targets.difference_update(stale)
+
     async def execute_with_runtime(
         self,
         params: dict[str, Any],
         runtime: ToolRuntime,
     ) -> str:
         target = params.get("target", "")
-        if target:
-            self._verified_targets.discard(target)
+        self._invalidate_verification_scope(target)
         pinned_runner = params.get("runner")
         extra_args = params.get("extra_args", "")
         timeout = params.get("timeout", DEFAULT_TIMEOUT)

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -93,6 +93,10 @@ _PYTEST_NO_TESTS_RE = re.compile(
     r"no tests ran in \d+(?:\.\d+)?s(?:\s+\([^)]+\))?",
     re.IGNORECASE,
 )
+_PYTEST_MISSING_RE = re.compile(
+    r"(?:(?:\S*/)?(?:python(?:\d+(?:\.\d+)*)?|pypy\d*): )?"
+    r"No module named pytest"
+)
 
 
 class RunTestsTool(Tool):
@@ -466,7 +470,12 @@ async def _native_fallback_candidate(
 
 def _pytest_missing(returncode: int, output: str) -> bool:
     """Whether the run failed because pytest itself is absent."""
-    return returncode == 127 or "No module named pytest" in output
+    if returncode == 0:
+        return False
+    if returncode == 127:
+        return True
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    return len(lines) == 1 and _PYTEST_MISSING_RE.fullmatch(lines[0]) is not None
 
 
 def _pytest_no_tests(returncode: int, output: str) -> bool:

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -29,7 +29,7 @@ import re
 import shlex
 from typing import Any
 
-from opencollab.adapters.tools._output import truncate
+from opencollab.adapters.tools._output import require_positive_int, truncate
 from opencollab.adapters.tools._run_tests_go import (
     GO_PATH_PREFIX as GO_PATH_PREFIX,
 )
@@ -188,7 +188,9 @@ class RunTestsTool(Tool):
         allow_extra_args: bool = True,
         require_process_isolation: bool = False,
     ):
-        self.max_traceback_chars = max_traceback_chars
+        self.max_traceback_chars = require_positive_int(
+            max_traceback_chars, "max_traceback_chars"
+        )
         self.allow_runner_override = allow_runner_override
         self.allow_extra_args = allow_extra_args
         self.require_process_isolation = require_process_isolation

--- a/opencollab/adapters/trace.py
+++ b/opencollab/adapters/trace.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import json
 import os
+import queue
+import threading
 import time
 import unicodedata
+from dataclasses import dataclass, field
 from typing import Any
 
 from opencollab.adapters.safe_files import (
@@ -19,6 +22,78 @@ from opencollab.adapters.safe_files import (
     open_regular_text_append,
     write_locked_text,
 )
+
+_TRACE_QUEUE_MAX_RECORDS = 1024
+_CLOSE_WRITER = object()
+
+
+@dataclass(slots=True)
+class _FlushRequest:
+    done: threading.Event = field(default_factory=threading.Event)
+
+
+@dataclass(slots=True)
+class _TraceWriterState:
+    handle: Any
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    write_error: str | None = None
+    dropped_steps: int = 0
+    close_error: BaseException | None = None
+
+
+def _latch_write_error(
+    state: _TraceWriterState,
+    exc: BaseException,
+    *,
+    dropped: int = 0,
+) -> None:
+    with state.lock:
+        if state.write_error is None:
+            state.write_error = f"{type(exc).__name__}: {exc}"
+        state.dropped_steps += dropped
+
+
+def _trace_writer_loop(
+    records: queue.Queue[object],
+    state: _TraceWriterState,
+) -> None:
+    while True:
+        item = records.get()
+        try:
+            if item is _CLOSE_WRITER:
+                try:
+                    if not state.handle.closed:
+                        state.handle.close()
+                except BaseException as exc:
+                    state.close_error = exc
+                    _latch_write_error(state, exc)
+                return
+            if isinstance(item, _FlushRequest):
+                try:
+                    if not state.handle.closed:
+                        state.handle.flush()
+                except BaseException as exc:
+                    _latch_write_error(state, exc)
+                finally:
+                    item.done.set()
+                continue
+            assert isinstance(item, str)
+            with state.lock:
+                failed = state.write_error is not None
+                if failed:
+                    state.dropped_steps += 1
+            if failed:
+                continue
+            try:
+                write_locked_text(state.handle, item)
+            except BaseException as exc:
+                _latch_write_error(state, exc, dropped=1)
+                try:
+                    state.handle.close()
+                except BaseException:
+                    pass
+        finally:
+            records.task_done()
 
 
 class Tracer:
@@ -69,8 +144,20 @@ class Tracer:
         ensure_directory_no_symlinks(output_dir)
         self._file = open_regular_text_append(self._path)
         self._step_counter = 0
-        self._write_error: str | None = None
-        self._dropped_steps = 0
+        self._state = _TraceWriterState(self._file)
+        self._state_lock = self._state.lock
+        self._lifecycle_lock = threading.Lock()
+        self._records: queue.Queue[object] = queue.Queue(
+            maxsize=_TRACE_QUEUE_MAX_RECORDS
+        )
+        self._closed = False
+        self._writer = threading.Thread(
+            target=_trace_writer_loop,
+            args=(self._records, self._state),
+            name=f"opencollab-tracer-{run_id}",
+            daemon=True,
+        )
+        self._writer.start()
 
     def log_step(
         self,
@@ -80,18 +167,17 @@ class Tracer:
         latency: float = 0.0,
     ) -> None:
         """Record a single step. step_type: llm_call | tool_exec | delegate | compaction | error."""
-        self._step_counter += 1
+        with self._state_lock:
+            self._step_counter += 1
+            step = self._step_counter
         record = {
             "timestamp": time.time(),
-            "step": self._step_counter,
+            "step": step,
             "run_id": self.run_id,
             "type": step_type,
             "payload": payload,
             "metrics": {"tokens": tokens, "latency_s": round(latency, 4)},
         }
-        if self._write_error is not None:
-            self._dropped_steps += 1
-            return
         try:
             line = json.dumps(record, ensure_ascii=False, default=str) + "\n"
         except Exception as exc:
@@ -100,29 +186,40 @@ class Tracer:
                 "payload_type": type(payload).__name__,
             }
             line = json.dumps(record, ensure_ascii=False) + "\n"
-        try:
-            write_locked_text(self._file, line)
-        except Exception as exc:
-            self._write_error = f"{type(exc).__name__}: {exc}"
-            self._dropped_steps += 1
+        with self._state_lock:
+            if self._closed or self._state.write_error is not None:
+                self._state.dropped_steps += 1
+                return
             try:
-                self._file.close()
-            except Exception:
-                pass
+                self._records.put_nowait(line)
+            except queue.Full:
+                self._state.write_error = "BufferError: trajectory queue is full"
+                self._state.dropped_steps += 1
 
     def flush(self) -> None:
         """Force flush to disk."""
-        f = getattr(self, "_file", None)
-        if f and not f.closed:
-            try:
-                f.flush()
-            except Exception as exc:
-                self._write_error = f"{type(exc).__name__}: {exc}"
+        with self._lifecycle_lock:
+            self._records.join()
+            with self._state_lock:
+                if self._closed:
+                    return
+            request = _FlushRequest()
+            self._records.put(request)
+            request.done.wait()
 
     def close(self) -> None:
-        f = getattr(self, "_file", None)
-        if f and not f.closed:
-            f.close()
+        with self._lifecycle_lock:
+            with self._state_lock:
+                if self._closed:
+                    error = self._state.close_error
+                    if error is not None:
+                        raise error
+                    return
+                self._closed = True
+            self._records.put(_CLOSE_WRITER)
+            self._writer.join()
+            if self._state.close_error is not None:
+                raise self._state.close_error
 
     @property
     def path(self) -> str:
@@ -130,11 +227,13 @@ class Tracer:
 
     @property
     def write_error(self) -> str | None:
-        return self._write_error
+        with self._state_lock:
+            return self._state.write_error
 
     @property
     def dropped_steps(self) -> int:
-        return self._dropped_steps
+        with self._state_lock:
+            return self._state.dropped_steps
 
     def __del__(self):
         try:

--- a/opencollab/adapters/trace.py
+++ b/opencollab/adapters/trace.py
@@ -8,6 +8,9 @@ Ref: tracer design with fine-grained steps for debugging agent failures.
 
 from __future__ import annotations
 
+import errno
+import fcntl
+import hashlib
 import json
 import os
 import queue
@@ -28,6 +31,29 @@ _TRACE_QUEUE_MAX_RECORDS = 1024
 _CLOSE_WRITER = object()
 
 
+def _acquire_trace_lease(output_dir: str, trace_filename: str) -> Any:
+    digest = hashlib.sha256(trace_filename.encode("utf-8")).hexdigest()
+    lease_path = os.path.join(output_dir, f".trace-{digest}.lock")
+    handle = open_regular_text_append(lease_path)
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        handle.close()
+        if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK}:
+            raise RuntimeError(
+                f"trace {trace_filename!r} already has an active writer"
+            ) from exc
+        raise
+    return handle
+
+
+def _release_trace_lease(handle: Any) -> None:
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
 def _recover_trace_tail(path: str) -> tuple[int, bool]:
     """Return the largest recent step and whether append needs a line boundary."""
     fd = os.open(
@@ -41,15 +67,20 @@ def _recover_trace_tail(path: str) -> tuple[int, bool]:
         if size == 0:
             return 0, False
         start = max(0, size - _TRACE_RECOVERY_TAIL_BYTES)
+        starts_at_boundary = True
+        if start:
+            os.lseek(fd, start - 1, os.SEEK_SET)
+            starts_at_boundary = os.read(fd, 1) == b"\n"
         os.lseek(fd, start, os.SEEK_SET)
         tail = os.read(fd, size - start)
     finally:
         os.close(fd)
 
     lines = tail.splitlines()
-    if start and lines:
+    if start and not starts_at_boundary and lines:
         lines = lines[1:]
     latest_step = 0
+    found_step = False
     for line in lines:
         try:
             record = json.loads(line)
@@ -58,6 +89,11 @@ def _recover_trace_tail(path: str) -> tuple[int, bool]:
         step = record.get("step") if isinstance(record, dict) else None
         if isinstance(step, int) and not isinstance(step, bool) and step > latest_step:
             latest_step = step
+            found_step = True
+    if not found_step:
+        raise OSError(
+            "cannot safely recover trace step from the bounded file tail"
+        )
     return latest_step, not tail.endswith(b"\n")
 
 
@@ -176,10 +212,18 @@ class Tracer:
             raise ValueError("trace filename must be one safe path component")
         self._path = os.path.join(output_dir, trace_filename)
         ensure_directory_no_symlinks(output_dir)
-        self._file = open_regular_text_append(self._path)
-        self._step_counter, needs_line_boundary = _recover_trace_tail(self._path)
-        if needs_line_boundary:
-            write_locked_text(self._file, "\n")
+        self._lease = _acquire_trace_lease(output_dir, trace_filename)
+        try:
+            self._file = open_regular_text_append(self._path)
+            self._step_counter, needs_line_boundary = _recover_trace_tail(self._path)
+            if needs_line_boundary:
+                write_locked_text(self._file, "\n")
+        except BaseException:
+            file_handle = getattr(self, "_file", None)
+            if file_handle is not None:
+                file_handle.close()
+            _release_trace_lease(self._lease)
+            raise
         self._state = _TraceWriterState(self._file)
         self._state_lock = self._state.lock
         self._lifecycle_lock = threading.Lock()
@@ -254,8 +298,15 @@ class Tracer:
                 self._closed = True
             self._records.put(_CLOSE_WRITER)
             self._writer.join()
-            if self._state.close_error is not None:
-                raise self._state.close_error
+            error = self._state.close_error
+            try:
+                _release_trace_lease(self._lease)
+            except BaseException as exc:
+                if error is None:
+                    error = exc
+                    self._state.close_error = exc
+            if error is not None:
+                raise error
 
     @property
     def path(self) -> str:

--- a/opencollab/adapters/trace.py
+++ b/opencollab/adapters/trace.py
@@ -23,8 +23,42 @@ from opencollab.adapters.safe_files import (
     write_locked_text,
 )
 
+_TRACE_RECOVERY_TAIL_BYTES = 1024 * 1024
 _TRACE_QUEUE_MAX_RECORDS = 1024
 _CLOSE_WRITER = object()
+
+
+def _recover_trace_tail(path: str) -> tuple[int, bool]:
+    """Return the largest recent step and whether append needs a line boundary."""
+    fd = os.open(
+        path,
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        size = os.fstat(fd).st_size
+        if size == 0:
+            return 0, False
+        start = max(0, size - _TRACE_RECOVERY_TAIL_BYTES)
+        os.lseek(fd, start, os.SEEK_SET)
+        tail = os.read(fd, size - start)
+    finally:
+        os.close(fd)
+
+    lines = tail.splitlines()
+    if start and lines:
+        lines = lines[1:]
+    latest_step = 0
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        step = record.get("step") if isinstance(record, dict) else None
+        if isinstance(step, int) and not isinstance(step, bool) and step > latest_step:
+            latest_step = step
+    return latest_step, not tail.endswith(b"\n")
 
 
 @dataclass(slots=True)
@@ -143,7 +177,9 @@ class Tracer:
         self._path = os.path.join(output_dir, trace_filename)
         ensure_directory_no_symlinks(output_dir)
         self._file = open_regular_text_append(self._path)
-        self._step_counter = 0
+        self._step_counter, needs_line_boundary = _recover_trace_tail(self._path)
+        if needs_line_boundary:
+            write_locked_text(self._file, "\n")
         self._state = _TraceWriterState(self._file)
         self._state_lock = self._state.lock
         self._lifecycle_lock = threading.Lock()

--- a/opencollab/adapters/trace.py
+++ b/opencollab/adapters/trace.py
@@ -93,10 +93,15 @@ class Tracer:
             self._dropped_steps += 1
             return
         try:
-            write_locked_text(
-                self._file,
-                json.dumps(record, ensure_ascii=False) + "\n",
-            )
+            line = json.dumps(record, ensure_ascii=False, default=str) + "\n"
+        except Exception as exc:
+            record["payload"] = {
+                "serialization_error": type(exc).__name__,
+                "payload_type": type(payload).__name__,
+            }
+            line = json.dumps(record, ensure_ascii=False) + "\n"
+        try:
+            write_locked_text(self._file, line)
         except Exception as exc:
             self._write_error = f"{type(exc).__name__}: {exc}"
             self._dropped_steps += 1

--- a/opencollab/adapters/trace.py
+++ b/opencollab/adapters/trace.py
@@ -54,8 +54,8 @@ def _release_trace_lease(handle: Any) -> None:
         handle.close()
 
 
-def _recover_trace_tail(path: str) -> tuple[int, bool]:
-    """Return the largest recent step and whether append needs a line boundary."""
+def _recover_trace_tail(path: str) -> tuple[int, bool, bool]:
+    """Return the latest step, boundary need, and damaged-record status."""
     fd = os.open(
         path,
         os.O_RDONLY
@@ -65,7 +65,7 @@ def _recover_trace_tail(path: str) -> tuple[int, bool]:
     try:
         size = os.fstat(fd).st_size
         if size == 0:
-            return 0, False
+            return 0, False, False
         start = max(0, size - _TRACE_RECOVERY_TAIL_BYTES)
         starts_at_boundary = True
         if start:
@@ -81,20 +81,33 @@ def _recover_trace_tail(path: str) -> tuple[int, bool]:
         lines = lines[1:]
     latest_step = 0
     found_step = False
+    damaged = False
     for line in lines:
         try:
             record = json.loads(line)
         except (TypeError, ValueError):
+            damaged = True
             continue
         step = record.get("step") if isinstance(record, dict) else None
         if isinstance(step, int) and not isinstance(step, bool) and step > latest_step:
             latest_step = step
             found_step = True
+        else:
+            damaged = True
     if not found_step:
         raise OSError(
             "cannot safely recover trace step from the bounded file tail"
         )
-    return latest_step, not tail.endswith(b"\n")
+    return latest_step, not tail.endswith(b"\n"), damaged
+
+
+def _quarantine_damaged_trace(path: str) -> str:
+    """Move a damaged trace aside so the active JSONL remains parseable."""
+    quarantine_path = f"{path}.corrupt-{time.time_ns()}-{os.getpid()}"
+    while os.path.lexists(quarantine_path):
+        quarantine_path += "-retry"
+    os.replace(path, quarantine_path)
+    return quarantine_path
 
 
 @dataclass(slots=True)
@@ -215,8 +228,16 @@ class Tracer:
         self._lease = _acquire_trace_lease(output_dir, trace_filename)
         try:
             self._file = open_regular_text_append(self._path)
-            self._step_counter, needs_line_boundary = _recover_trace_tail(self._path)
-            if needs_line_boundary:
+            (
+                self._step_counter,
+                needs_line_boundary,
+                damaged,
+            ) = _recover_trace_tail(self._path)
+            if damaged:
+                self._file.close()
+                _quarantine_damaged_trace(self._path)
+                self._file = open_regular_text_append(self._path)
+            elif needs_line_boundary:
                 write_locked_text(self._file, "\n")
         except BaseException:
             file_handle = getattr(self, "_file", None)

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -30,6 +30,7 @@ from opencollab.adapters.tui.renderer_events import _RendererEventsMixin
 
 MAX_HISTORY_BLOCKS_PER_AGENT = 400
 MAX_TERMINAL_AGENT_STATES = 128
+MAX_TERMINAL_AGENT_SUMMARIES = 256
 _TERMINAL_RENDER_STATES = frozenset({"idle", "failed", "cancelled"})
 
 
@@ -41,6 +42,7 @@ class _AgentRenderState:
     active_tools: dict[str, dict] = field(default_factory=dict)
     status_lines: list[Text] = field(default_factory=list)
     history_blocks: list[Any] = field(default_factory=list)
+    history_omitted_blocks: int = 0
     timeline_blocks: list[Any] = field(default_factory=list)
     turn_history_start: int = 0
     history_revision: int = 0
@@ -72,6 +74,9 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         # aid -> {"role": str, "state": str} for the live team roster panel.
         self._roster: dict[int, dict] = {}
         self._terminal_agent_order: list[int] = []
+        self._terminal_agent_summaries: dict[int, dict[str, Any]] = {}
+        self._terminal_summary_order: list[int] = []
+        self._terminal_summaries_omitted = 0
         # Brand motion (single pulsing dot). ``_motion`` is the shared,
         # seconds-less tool-execution spinner. Each agent owns its own LLM-wait
         # indicator so hidden streams remain intact while another agent is selected.
@@ -103,9 +108,13 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         overflow = len(state.history_blocks) - MAX_HISTORY_BLOCKS_PER_AGENT
         if overflow > 0:
             del state.history_blocks[:overflow]
+            state.history_omitted_blocks += overflow
             state.turn_history_start = max(0, state.turn_history_start - overflow)
 
     def _track_agent_render_lifecycle(self, aid: int, state: str) -> None:
+        if aid in self._terminal_summary_order:
+            self._terminal_summary_order.remove(aid)
+        self._terminal_agent_summaries.pop(aid, None)
         if aid in self._terminal_agent_order:
             self._terminal_agent_order.remove(aid)
         if aid != 0 and state in _TERMINAL_RENDER_STATES:
@@ -122,8 +131,27 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             if victim is None:
                 break
             self._terminal_agent_order.remove(victim)
-            self._agent_states.pop(victim, None)
-            self._roster.pop(victim, None)
+            render_state = self._agent_states.pop(victim, None)
+            roster = self._roster.pop(victim, {})
+            self._terminal_agent_summaries[victim] = {
+                "aid": victim,
+                "role": str(roster.get("role", "agent")),
+                "state": str(roster.get("state", "idle")),
+                "step": render_state.step if render_state is not None else 0,
+                "retained_history_blocks": (
+                    len(render_state.history_blocks) if render_state is not None else 0
+                ),
+                "omitted_history_blocks": (
+                    render_state.history_omitted_blocks
+                    if render_state is not None
+                    else 0
+                ),
+            }
+            self._terminal_summary_order.append(victim)
+            while len(self._terminal_summary_order) > MAX_TERMINAL_AGENT_SUMMARIES:
+                forgotten = self._terminal_summary_order.pop(0)
+                self._terminal_agent_summaries.pop(forgotten, None)
+                self._terminal_summaries_omitted += 1
 
     def _event_aid(self, aid: Any) -> int:
         """Normalize legacy events without an aid to agent 0, independent of focus."""
@@ -184,9 +212,11 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
     @_timeline_blocks.setter
     def _timeline_blocks(self, value: list[Any]) -> None:
         self._selected_state.timeline_blocks = value
-        self._selected_state.history_blocks = list(value)[
-            -MAX_HISTORY_BLOCKS_PER_AGENT:
-        ]
+        blocks = list(value)
+        self._selected_state.history_blocks = blocks[-MAX_HISTORY_BLOCKS_PER_AGENT:]
+        self._selected_state.history_omitted_blocks = max(
+            0, len(blocks) - MAX_HISTORY_BLOCKS_PER_AGENT
+        )
         self._selected_state.history_revision += 1
 
     @property
@@ -217,6 +247,19 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
     @property
     def selected_aid(self) -> int:
         return self._selected_aid
+
+    @property
+    def terminal_agent_summaries(self) -> tuple[dict[str, Any], ...]:
+        """Bounded summaries for terminal agents evicted from detailed TUI state."""
+        return tuple(
+            dict(self._terminal_agent_summaries[aid])
+            for aid in self._terminal_summary_order
+        )
+
+    @property
+    def terminal_agent_summaries_omitted(self) -> int:
+        """Number of oldest summaries omitted to retain a stable memory bound."""
+        return self._terminal_summaries_omitted
 
     @property
     def selected_role(self) -> str | None:
@@ -380,11 +423,13 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         self._keyboard_resume_pending = False
 
     def stop_live(self, *, persist: bool = False, aid: int | None = None) -> None:
-        """Stop the live HUD while retaining every agent transcript in memory.
+        """Stop the live HUD while retaining each bounded recent transcript.
 
-        Interactive transcripts stay inside the redrawable Prompt Toolkit view so
-        Tab can replace them cleanly. One-shot callers opt into ``persist`` to
-        print the target's settled turn to ordinary terminal scrollback.
+        Interactive transcripts stay inside the redrawable Prompt Toolkit view
+        with an explicit marker when older blocks were omitted. Full history
+        remains owned by the persistent transcript/trace. One-shot callers opt
+        into ``persist`` to print the target's settled turn to ordinary terminal
+        scrollback.
         """
         set_quit_callback = getattr(self._keyboard_controller, "set_quit_callback", None)
         if callable(set_quit_callback):

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -30,11 +30,19 @@ from opencollab.adapters.tui.renderer_events import (
     MAX_TIMELINE_BLOCKS,
     _RendererEventsMixin,
 )
+from opencollab.domain.session import TERMINAL_PHASES
 
 MAX_HISTORY_BLOCKS_PER_AGENT = 400
 MAX_TERMINAL_AGENT_STATES = 128
 MAX_TERMINAL_AGENT_SUMMARIES = 256
-_TERMINAL_RENDER_STATES = frozenset({"idle", "failed", "cancelled"})
+_TERMINAL_RENDER_STATES = frozenset(
+    {
+        "idle",
+        "failed",
+        "cancelled",
+        *(phase.value for phase in TERMINAL_PHASES),
+    }
+)
 
 
 @dataclass

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -28,6 +28,10 @@ from opencollab.adapters.tui.keyboard import TabKeyNavigator
 from opencollab.adapters.tui.renderer_display import _RendererDisplayMixin
 from opencollab.adapters.tui.renderer_events import _RendererEventsMixin
 
+MAX_HISTORY_BLOCKS_PER_AGENT = 400
+MAX_TERMINAL_AGENT_STATES = 128
+_TERMINAL_RENDER_STATES = frozenset({"idle", "failed", "cancelled"})
+
 
 @dataclass
 class _AgentRenderState:
@@ -67,6 +71,7 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         self._agent_states: dict[int, _AgentRenderState] = {}
         # aid -> {"role": str, "state": str} for the live team roster panel.
         self._roster: dict[int, dict] = {}
+        self._terminal_agent_order: list[int] = []
         # Brand motion (single pulsing dot). ``_motion`` is the shared,
         # seconds-less tool-execution spinner. Each agent owns its own LLM-wait
         # indicator so hidden streams remain intact while another agent is selected.
@@ -92,6 +97,33 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
     def _state_for(self, aid: int) -> _AgentRenderState:
         """Return one agent's render state, creating it on first observation."""
         return self._agent_states.setdefault(aid, _AgentRenderState())
+
+    def _append_history_block(self, state: _AgentRenderState, block: Any) -> None:
+        state.history_blocks.append(block)
+        overflow = len(state.history_blocks) - MAX_HISTORY_BLOCKS_PER_AGENT
+        if overflow > 0:
+            del state.history_blocks[:overflow]
+            state.turn_history_start = max(0, state.turn_history_start - overflow)
+
+    def _track_agent_render_lifecycle(self, aid: int, state: str) -> None:
+        if aid in self._terminal_agent_order:
+            self._terminal_agent_order.remove(aid)
+        if aid != 0 and state in _TERMINAL_RENDER_STATES:
+            self._terminal_agent_order.append(aid)
+        while len(self._terminal_agent_order) > MAX_TERMINAL_AGENT_STATES:
+            victim = next(
+                (
+                    candidate
+                    for candidate in self._terminal_agent_order
+                    if candidate != self._selected_aid
+                ),
+                None,
+            )
+            if victim is None:
+                break
+            self._terminal_agent_order.remove(victim)
+            self._agent_states.pop(victim, None)
+            self._roster.pop(victim, None)
 
     def _event_aid(self, aid: Any) -> int:
         """Normalize legacy events without an aid to agent 0, independent of focus."""
@@ -152,7 +184,9 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
     @_timeline_blocks.setter
     def _timeline_blocks(self, value: list[Any]) -> None:
         self._selected_state.timeline_blocks = value
-        self._selected_state.history_blocks = list(value)
+        self._selected_state.history_blocks = list(value)[
+            -MAX_HISTORY_BLOCKS_PER_AGENT:
+        ]
         self._selected_state.history_revision += 1
 
     @property
@@ -262,7 +296,7 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         state = self._state_for(aid)
         self._flush_current_text_to_timeline(state)
         block = self._user_block(content)
-        state.history_blocks.append(block)
+        self._append_history_block(state, block)
         state.timeline_blocks.append(block)
         state.history_revision += 1
 

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -26,7 +26,10 @@ from rich.text import Text
 from opencollab.adapters.tui.brand_motion import MARK_HEX, PulseDot
 from opencollab.adapters.tui.keyboard import TabKeyNavigator
 from opencollab.adapters.tui.renderer_display import _RendererDisplayMixin
-from opencollab.adapters.tui.renderer_events import _RendererEventsMixin
+from opencollab.adapters.tui.renderer_events import (
+    MAX_TIMELINE_BLOCKS,
+    _RendererEventsMixin,
+)
 
 MAX_HISTORY_BLOCKS_PER_AGENT = 400
 MAX_TERMINAL_AGENT_STATES = 128
@@ -110,6 +113,12 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             del state.history_blocks[:overflow]
             state.history_omitted_blocks += overflow
             state.turn_history_start = max(0, state.turn_history_start - overflow)
+
+    def _append_timeline_block(self, state: _AgentRenderState, block: Any) -> None:
+        state.timeline_blocks.append(block)
+        overflow = len(state.timeline_blocks) - MAX_TIMELINE_BLOCKS
+        if overflow > 0:
+            del state.timeline_blocks[:overflow]
 
     def _track_agent_render_lifecycle(self, aid: int, state: str) -> None:
         if aid in self._terminal_summary_order:
@@ -211,8 +220,8 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
 
     @_timeline_blocks.setter
     def _timeline_blocks(self, value: list[Any]) -> None:
-        self._selected_state.timeline_blocks = value
         blocks = list(value)
+        self._selected_state.timeline_blocks = blocks[-MAX_TIMELINE_BLOCKS:]
         self._selected_state.history_blocks = blocks[-MAX_HISTORY_BLOCKS_PER_AGENT:]
         self._selected_state.history_omitted_blocks = max(
             0, len(blocks) - MAX_HISTORY_BLOCKS_PER_AGENT
@@ -280,9 +289,15 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         """
         live_roles: dict[int, str] = {}
 
-        for aid, role, _state in self._team_entries():
+        for aid, role, state in self._team_entries():
             role = str(role)
-            if isinstance(aid, int) and aid >= 0:
+            if not isinstance(aid, int) or aid < 0:
+                continue
+            if (
+                aid == 0
+                or aid in self._agent_states
+                or state not in _TERMINAL_RENDER_STATES
+            ):
                 live_roles.setdefault(aid, role)
 
         for aid in self._agent_states:
@@ -340,7 +355,7 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         self._flush_current_text_to_timeline(state)
         block = self._user_block(content)
         self._append_history_block(state, block)
-        state.timeline_blocks.append(block)
+        self._append_timeline_block(state, block)
         state.history_revision += 1
 
     def _refresh(self) -> None:

--- a/opencollab/adapters/tui/renderer_display.py
+++ b/opencollab/adapters/tui/renderer_display.py
@@ -318,6 +318,15 @@ class _RendererDisplayMixin:
     def _build_history_display(self, state: Any, *, start: int = 0) -> Any | None:
         """Build the requested slice of one agent's history without live chrome."""
         blocks = list(state.history_blocks[start:])
+        if start == 0 and state.history_omitted_blocks:
+            blocks.insert(
+                0,
+                Text(
+                    f"... {state.history_omitted_blocks} older history blocks "
+                    "omitted; full history remains in the run trace.",
+                    style=self._STYLE_MUTED,
+                ),
+            )
         if state.current_text:
             blocks.append(self._assistant_block(Markdown(state.current_text)))
         if not blocks:

--- a/opencollab/adapters/tui/renderer_events.py
+++ b/opencollab/adapters/tui/renderer_events.py
@@ -15,6 +15,7 @@ from opencollab.domain.events import SchedulerEvent
 
 # Cap on retained timeline blocks so long sessions don't grow render cost.
 MAX_TIMELINE_BLOCKS = 80
+MAX_STATUS_LINES = 40
 
 
 class _RendererEventsMixin:
@@ -123,7 +124,7 @@ class _RendererEventsMixin:
         if etype == "agent_spawned":
             state = self._state_for(aid)
             self._clear_thinking_status(state)
-            self._roster[aid] = {"role": role or "agent", "state": "running"}
+            self._mark_roster(aid, role, "running")
             # aid 0 is the lead/turn itself, not a spawned teammate — no chrome.
             if aid != 0:
                 label = f"{agent_label}:spawn"
@@ -250,6 +251,7 @@ class _RendererEventsMixin:
         entry["state"] = state
         if role:
             entry["role"] = role
+        self._track_agent_render_lifecycle(aid, state)
 
     def _emit_status(
         self,
@@ -263,10 +265,13 @@ class _RendererEventsMixin:
         target = state or self._selected_state
         if preserve:
             self._flush_current_text_to_timeline(target)
-            target.history_blocks.append(status)
+            self._append_history_block(target, status)
             target.history_revision += 1
         if self._live or self._live_paused:
             target.status_lines.append(status)
+            overflow = len(target.status_lines) - MAX_STATUS_LINES
+            if overflow > 0:
+                del target.status_lines[:overflow]
             self._refresh()
             return
         self.console.print(status)
@@ -284,7 +289,7 @@ class _RendererEventsMixin:
         styled_segments: list[tuple[str, str]] = [marker or self._MARK_DOT]
         styled_segments.extend((text, style) for text, style in segments if text)
         line = Text.assemble(*styled_segments)
-        target.history_blocks.append(line)
+        self._append_history_block(target, line)
         target.timeline_blocks.append(line)
         target.history_revision += 1
         # Keep recent timeline blocks bounded.
@@ -298,7 +303,7 @@ class _RendererEventsMixin:
         if not target.current_text:
             return
         block = self._assistant_block(Markdown(target.current_text))
-        target.history_blocks.append(block)
+        self._append_history_block(target, block)
         target.timeline_blocks.append(block)
         target.current_text = ""
         target.history_revision += 1

--- a/opencollab/adapters/tui/renderer_events.py
+++ b/opencollab/adapters/tui/renderer_events.py
@@ -290,12 +290,8 @@ class _RendererEventsMixin:
         styled_segments.extend((text, style) for text, style in segments if text)
         line = Text.assemble(*styled_segments)
         self._append_history_block(target, line)
-        target.timeline_blocks.append(line)
+        self._append_timeline_block(target, line)
         target.history_revision += 1
-        # Keep recent timeline blocks bounded.
-        overflow = len(target.timeline_blocks) - MAX_TIMELINE_BLOCKS
-        if overflow > 0:
-            target.timeline_blocks = target.timeline_blocks[overflow:]
 
     def _flush_current_text_to_timeline(self, state: Any | None = None) -> None:
         """Commit accumulated assistant text so later events appear in-order."""
@@ -304,7 +300,7 @@ class _RendererEventsMixin:
             return
         block = self._assistant_block(Markdown(target.current_text))
         self._append_history_block(target, block)
-        target.timeline_blocks.append(block)
+        self._append_timeline_block(target, block)
         target.current_text = ""
         target.history_revision += 1
 

--- a/opencollab/adapters/working_tree.py
+++ b/opencollab/adapters/working_tree.py
@@ -14,6 +14,30 @@ import shlex
 from collections.abc import Sequence
 from typing import Any
 
+MAX_WORKING_TREE_DIFF_CHARS = 1_000_000
+
+
+def _require_complete_result(
+    result: Any,
+    operation: str,
+    *,
+    allowed_returncodes: tuple[int, ...] = (0,),
+) -> None:
+    if (
+        bool(getattr(result, "stdout_truncated", False))
+        or bool(getattr(result, "stderr_truncated", False))
+        or int(getattr(result, "stdout_dropped_bytes", 0) or 0) > 0
+        or int(getattr(result, "stderr_dropped_bytes", 0) or 0) > 0
+    ):
+        raise RuntimeError(f"{operation} exceeded capture limit")
+    returncode = int(getattr(result, "returncode", 0))
+    if returncode not in allowed_returncodes:
+        detail = str(getattr(result, "stderr", "") or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(
+            f"{operation} failed with git status {returncode}{suffix}"
+        )
+
 
 class EnvWorkingTreeProbe:
     """``WorkingTreeProbe`` backed by an :class:`Environment`.
@@ -34,6 +58,7 @@ class EnvWorkingTreeProbe:
     async def changed(self) -> bool:
         cmd = f"git -C {shlex.quote(self._workspace)} status --porcelain"
         result = await self._env.exec_cmd(cmd, timeout=30)
+        _require_complete_result(result, "working-tree status")
         return bool(result.stdout.strip())
 
     async def changed_excluding(self, paths: Sequence[str]) -> bool:
@@ -54,12 +79,73 @@ class EnvWorkingTreeProbe:
             f"--untracked-files=all -- . {excludes}"
         )
         result = await self._env.exec_cmd(cmd, timeout=30)
+        _require_complete_result(result, "working-tree status")
         return bool(result.stdout.strip())
 
     async def diff(self) -> str:
-        cmd = f"git -C {shlex.quote(self._workspace)} diff"
-        result = await self._env.exec_cmd(cmd, timeout=30)
-        return result.stdout
+        workspace = shlex.quote(self._workspace)
+        status_result = await self._env.exec_cmd(
+            f"git -C {workspace} status --porcelain=v1 --untracked-files=all",
+            timeout=30,
+        )
+        _require_complete_result(status_result, "working-tree status")
+
+        tracked_result = await self._env.exec_cmd(
+            f"git -C {workspace} --no-pager diff HEAD --binary --no-ext-diff --",
+            timeout=30,
+        )
+        _require_complete_result(tracked_result, "tracked diff")
+
+        untracked_result = await self._env.exec_cmd(
+            f"git -C {workspace} ls-files --others --exclude-standard -z --",
+            timeout=30,
+        )
+        _require_complete_result(untracked_result, "untracked file listing")
+        untracked_paths = [
+            path
+            for path in untracked_result.stdout.split("\0")
+            if path
+        ]
+
+        parts: list[str] = []
+        total_chars = 0
+
+        def append_complete(part: str) -> None:
+            nonlocal total_chars
+            separator_chars = 2 if parts else 0
+            if total_chars + separator_chars + len(part) > MAX_WORKING_TREE_DIFF_CHARS:
+                raise RuntimeError(
+                    "working-tree diff exceeded aggregate evidence limit"
+                )
+            parts.append(part)
+            total_chars += separator_chars + len(part)
+
+        status = status_result.stdout.rstrip("\n")
+        append_complete(f"[Working tree status]\n{status or '(clean)'}")
+
+        tracked = tracked_result.stdout.rstrip("\n")
+        if tracked:
+            append_complete(f"[Tracked changes vs HEAD]\n{tracked}")
+
+        for path in untracked_paths:
+            result = await self._env.exec_cmd(
+                "git -C "
+                f"{workspace} --no-pager diff --no-index --binary --no-ext-diff "
+                f"-- /dev/null {shlex.quote(path)}",
+                timeout=30,
+            )
+            _require_complete_result(
+                result,
+                f"untracked diff for {path!r}",
+                allowed_returncodes=(0, 1),
+            )
+            patch = result.stdout.rstrip("\n")
+            append_complete(
+                f"[Untracked file: {path}]\n"
+                f"{patch or '(empty file; no content diff)'}"
+            )
+
+        return "\n\n".join(parts)
 
 
 __all__ = ["EnvWorkingTreeProbe"]

--- a/opencollab/adapters/worktree_pool.py
+++ b/opencollab/adapters/worktree_pool.py
@@ -36,13 +36,15 @@ class WorktreePool:
     def __init__(self, workspace: str, *, use_worktrees: bool):
         self._workspace = workspace
         self._use_worktrees = use_worktrees
-        self._envs: list[WorktreeEnvironment] = []
+        self._envs: list[Environment] = []
 
     async def acquire(self, role: str) -> Environment:
         """Create (and remember) an isolated env for a spawned agent of this role."""
         role = validate_role_identity(role)
         if not self._use_worktrees:
-            return LocalEnvironment(self._workspace)
+            env = LocalEnvironment(self._workspace)
+            self._envs.append(env)
+            return env
 
         branch = f"opencollab-{role_storage_slug(role)}-{uuid.uuid4().hex[:8]}"
         env = WorktreeEnvironment(self._workspace, branch_name=branch)
@@ -64,7 +66,7 @@ class WorktreePool:
         return env
 
     async def release(self) -> None:
-        """Tear down every worktree this pool has handed out.
+        """Tear down every environment this pool has handed out.
 
         One failing teardown must not abort the others, so each is isolated;
         the failure is logged rather than swallowed so it is diagnosable.
@@ -78,22 +80,29 @@ class WorktreePool:
                 await _finish_cleanup(env.cleanup())
             except BaseException as exc:
                 failures.append(f"{env.workspace}: {type(exc).__name__}: {exc}")
-                logger.warning("worktree cleanup failed for %s", env.workspace, exc_info=True)
+                logger.warning(
+                    "environment cleanup failed for %s",
+                    env.workspace,
+                    exc_info=True,
+                )
             else:
                 self._envs.remove(env)
         if failures:
             raise OSError(
-                "worktree pool cleanup failed; retry state retained: " + "; ".join(failures)
+                "environment pool cleanup failed; retry state retained: "
+                + "; ".join(failures)
             )
 
     async def release_env(self, env: Environment) -> None:
         """Release one failed spawn's environment without touching siblings."""
-        if not isinstance(env, WorktreeEnvironment) or env not in self._envs:
+        if env not in self._envs:
             return
         try:
             await _finish_cleanup(env.cleanup())
         except BaseException:
-            logger.warning("worktree cleanup failed for %s", env.workspace, exc_info=True)
+            logger.warning(
+                "environment cleanup failed for %s", env.workspace, exc_info=True
+            )
             raise
         self._envs.remove(env)
 

--- a/tests/test_cli_main_lifecycle.py
+++ b/tests/test_cli_main_lifecycle.py
@@ -348,6 +348,54 @@ async def test_cli_successful_one_shot_holds_before_stopping_and_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_cli_warns_when_event_log_persistence_is_degraded(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("occupied", encoding="utf-8")
+    monkeypatch.setenv(
+        "OPENCOLLAB_EVENTS_FILE",
+        str(blocker / "events.jsonl"),
+    )
+
+    class Scheduler:
+        used_tokens = 0
+        lead_session = SimpleNamespace(auto_save_path=None, step_count=0)
+
+        def team_roster(self):
+            return []
+
+        async def run_turn(self, aid, line):
+            assert (aid, line) == (0, "do work")
+
+        def agent_step_count(self, aid):
+            return 0
+
+        async def cleanup(self):
+            return None
+
+    tracer = FakeTracer()
+    install_cli_fakes(monkeypatch, Scheduler(), tracer)
+
+    await cli_main._run(
+        str(tmp_path),
+        config(),
+        None,
+        True,
+        True,
+        False,
+        one_shot_prompt="do work",
+    )
+
+    warning = capsys.readouterr().err
+    assert "event log persistence degraded" in warning
+    assert "dropped events: 0" in warning
+    assert str(blocker / "events.jsonl") in warning
+
+
+@pytest.mark.asyncio
 async def test_cli_double_cancel_waits_for_cleanup_then_closes_tracer(
     monkeypatch,
     tmp_path,

--- a/tests/test_cli_main_lifecycle.py
+++ b/tests/test_cli_main_lifecycle.py
@@ -78,6 +78,29 @@ def test_cli_prompt_file_rejects_unsafe_or_oversized_input(
         cli_main._resolve_one_shot_prompt(None, str(prompt))
 
 
+@pytest.mark.parametrize("prompt", ["", "   ", "\t\n"])
+def test_cli_rejects_explicit_blank_prompt(prompt):
+    with pytest.raises(typer.BadParameter, match="--prompt must not be empty"):
+        cli_main._resolve_one_shot_prompt(prompt, None)
+
+
+def test_cli_rejects_empty_prompt_file_path():
+    with pytest.raises(typer.BadParameter, match="--prompt-file path must not be empty"):
+        cli_main._resolve_one_shot_prompt(None, "")
+
+
+def test_cli_rejects_both_prompt_inputs_even_when_prompt_is_empty(tmp_path):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("from file", encoding="utf-8")
+
+    with pytest.raises(typer.BadParameter, match="mutually exclusive"):
+        cli_main._resolve_one_shot_prompt("", str(prompt_file))
+
+
+def test_cli_preserves_nonblank_unicode_prompt():
+    assert cli_main._resolve_one_shot_prompt(" 你好，世界 ", None) == " 你好，世界 "
+
+
 class FakeConsole:
     def print(self, *args, **kwargs):
         return None

--- a/tests/test_cli_main_lifecycle.py
+++ b/tests/test_cli_main_lifecycle.py
@@ -98,7 +98,7 @@ def test_cli_rejects_both_prompt_inputs_even_when_prompt_is_empty(tmp_path):
 
 
 def test_cli_preserves_nonblank_unicode_prompt():
-    assert cli_main._resolve_one_shot_prompt(" 你好，世界 ", None) == " 你好，世界 "
+    assert cli_main._resolve_one_shot_prompt(" Grüß dich 🌍 ", None) == " Grüß dich 🌍 "
 
 
 class FakeConsole:

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -84,6 +84,27 @@ def test_agent_prompt_render_failure_falls_back_to_plain_input():
     assert _plain_prompt(prompt) == "> "
 
 
+def test_agent_prompt_history_cache_evicts_old_revisions():
+    tui = _FakeTUI()
+    tui.selected_aid = 1
+    prompt = build_agent_prompt(tui, "> ")
+
+    for revision in range(17):
+        tui.revisions[1] = revision
+        tui.history[1] = f"revision {revision}"
+        assert f"revision {revision}" in _plain_prompt(prompt)
+
+    assert tui.render_calls == 17
+    tui.revisions[1] = 0
+    tui.history[1] = "revision zero rerendered"
+    assert "revision zero rerendered" in _plain_prompt(prompt)
+    assert tui.render_calls == 18
+
+    tui.revisions[1] = 16
+    assert "revision 16" in _plain_prompt(prompt)
+    assert tui.render_calls == 18
+
+
 def test_cli_prompt_session_erases_managed_viewport(monkeypatch):
     captured = {}
     session = object()

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -105,6 +105,48 @@ def test_agent_prompt_history_cache_evicts_old_revisions():
     assert tui.render_calls == 18
 
 
+@pytest.mark.asyncio
+async def test_console_input_fallback_removes_reader_when_cancelled(monkeypatch):
+    class BrokenPromptSession:
+        async def prompt_async(self, *_args, **_kwargs):
+            raise RuntimeError("prompt toolkit unavailable")
+
+    read_fd, write_fd = os.pipe()
+    input_stream = os.fdopen(read_fd, "r", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "_get_prompt_session", lambda: BrokenPromptSession())
+    monkeypatch.setattr(cli_main.sys, "stdin", input_stream)
+    task = asyncio.create_task(cli_main._read_line("> "))
+    await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=0.2)
+
+    assert asyncio.get_running_loop().remove_reader(read_fd) is False
+    input_stream.close()
+    os.close(write_fd)
+
+
+@pytest.mark.asyncio
+async def test_console_input_fallback_reads_selectable_pipe(monkeypatch):
+    class BrokenPromptSession:
+        async def prompt_async(self, *_args, **_kwargs):
+            raise RuntimeError("prompt toolkit unavailable")
+
+    read_fd, write_fd = os.pipe()
+    input_stream = os.fdopen(read_fd, "r", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "_get_prompt_session", lambda: BrokenPromptSession())
+    monkeypatch.setattr(cli_main.sys, "stdin", input_stream)
+    task = asyncio.create_task(cli_main._read_line("> "))
+    await asyncio.sleep(0)
+    os.write(write_fd, b"fallback input\n")
+
+    assert await asyncio.wait_for(task, timeout=0.2) == "fallback input"
+    assert asyncio.get_running_loop().remove_reader(read_fd) is False
+    input_stream.close()
+    os.close(write_fd)
+
+
 def test_cli_prompt_session_erases_managed_viewport(monkeypatch):
     captured = {}
     session = object()

--- a/tests/test_cli_toolbar.py
+++ b/tests/test_cli_toolbar.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from io import StringIO
+
 import pytest
 from prompt_toolkit.formatted_text import to_formatted_text
+from rich.console import Console
 
+from opencollab.adapters.cli import main as cli_main
 from opencollab.adapters.cli.main import _PROMPT_STYLE, _dispatch_repl_command
 from opencollab.adapters.cli.toolbar import format_team_toolbar
 
@@ -111,6 +115,23 @@ def test_repl_save_command_saves_lead_and_continues():
     assert _dispatch_repl_command("/save", lead) is True
     assert lead.saved_to is not None and lead.saved_to.startswith("session-")
     assert lead.saved_to.endswith(".jsonl")
+
+
+def test_repl_save_failure_is_reported_and_keeps_the_session_alive(monkeypatch):
+    output = StringIO()
+    monkeypatch.setattr(
+        cli_main,
+        "console",
+        Console(file=output, color_system=None),
+    )
+
+    class FailingLead:
+        def save(self, _path):
+            raise OSError("disk full")
+
+    assert _dispatch_repl_command("/save", FailingLead()) is True
+    assert "Session save failed" in output.getvalue()
+    assert "disk full" in output.getvalue()
 
 
 def test_repl_non_command_signals_passthrough():

--- a/tests/test_context_overflow_classifier.py
+++ b/tests/test_context_overflow_classifier.py
@@ -87,6 +87,15 @@ def test_overflow_code_in_nested_body_is_overflow():
     assert is_context_overflow_error(err) is True
 
 
+def test_overflow_code_at_top_level_body_is_overflow():
+    err = FakeProviderError(
+        "bad request",
+        status_code=400,
+        body={"code": "context_length_exceeded"},
+    )
+    assert is_context_overflow_error(err) is True
+
+
 def test_status_on_response_object_is_overflow():
     err = FakeErrorWithResponse(
         "input is too long: too many tokens for the context window", 400

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -338,6 +338,145 @@ async def test_verified_write_threads_stdin_and_digest(monkeypatch) -> None:
     await env.write_file("/workspace/result.txt", "hello")
 
 
+async def test_write_half_input_failure_keeps_old_target_and_cleans_temp(monkeypatch) -> None:
+    old = b"old content"
+    files = {"/repo/result.txt": old}
+    partial_temp: list[bytes] = []
+    cleaned: list[str] = []
+
+    async def fake_docker(*args, input_bytes=None, **_kwargs):
+        if docker_module._EXEC_WRAPPER in args:
+            assert input_bytes is not None
+            if 'cat > "$target"' in args[-1]:
+                files["/repo/result.txt"] = input_bytes[:2]
+            else:
+                partial_temp.append(input_bytes[:2])
+                assert 'cat > "$temporary"' in args[-1]
+                assert 'mv -f -- "$temporary" "$target"' in args[-1]
+            return _result(returncode=1, stderr=b"stdin closed")
+        if args[:2] == ("exec", "--"):
+            cleaned.append(args[-1])
+            return _result()
+        raise AssertionError(args)
+
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    env._attached_bound = True
+    monkeypatch.setattr(env, "_docker", fake_docker)
+
+    with pytest.raises(OSError, match="verification failed"):
+        await env.write_file("/repo/result.txt", "new content")
+
+    assert files["/repo/result.txt"] == old
+    assert partial_temp == [b"ne"]
+    assert len(cleaned) == 1
+    assert ".opencollab-write-" in cleaned[0]
+
+
+async def test_write_timeout_keeps_old_target_and_cleans_temp(monkeypatch) -> None:
+    old = b"old content"
+    files = {"/repo/result.txt": old}
+    cleaned: list[str] = []
+
+    async def fake_docker(*args, input_bytes=None, **_kwargs):
+        if docker_module._EXEC_WRAPPER in args:
+            assert input_bytes is not None
+            if 'cat > "$target"' in args[-1]:
+                files["/repo/result.txt"] = input_bytes[:2]
+            raise asyncio.TimeoutError()
+        if docker_module._EXEC_CANCEL in args:
+            return _result()
+        if args[:2] == ("exec", "--"):
+            cleaned.append(args[-1])
+            return _result()
+        raise AssertionError(args)
+
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    env._attached_bound = True
+    monkeypatch.setattr(env, "_docker", fake_docker)
+
+    with pytest.raises(OSError, match="verification failed"):
+        await env.write_file("/repo/result.txt", "new content")
+
+    assert files["/repo/result.txt"] == old
+    assert len(cleaned) == 1
+    assert ".opencollab-write-" in cleaned[0]
+
+
+async def test_cancelled_write_keeps_old_target_and_cleans_temp(monkeypatch) -> None:
+    old = b"old content"
+    files = {"/repo/result.txt": old}
+    started = asyncio.Event()
+    cleaned: list[str] = []
+
+    async def fake_docker(*args, input_bytes=None, **_kwargs):
+        if docker_module._EXEC_WRAPPER in args:
+            assert input_bytes is not None
+            if 'cat > "$target"' in args[-1]:
+                files["/repo/result.txt"] = input_bytes[:2]
+            started.set()
+            await asyncio.Event().wait()
+        if docker_module._EXEC_CANCEL in args:
+            return _result()
+        if args[:2] == ("exec", "--"):
+            cleaned.append(args[-1])
+            return _result()
+        raise AssertionError(args)
+
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    env._attached_bound = True
+    monkeypatch.setattr(env, "_docker", fake_docker)
+    owner = asyncio.create_task(env.write_file("/repo/result.txt", "new content"))
+    await started.wait()
+    owner.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await owner
+
+    assert files["/repo/result.txt"] == old
+    assert len(cleaned) == 1
+    assert ".opencollab-write-" in cleaned[0]
+
+
+async def test_concurrent_same_container_path_writes_are_serialized(monkeypatch) -> None:
+    target = b"old"
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    async def fake_docker(*args, input_bytes=None, **_kwargs):
+        nonlocal target, active, max_active
+        if docker_module._EXEC_WRAPPER not in args:
+            raise AssertionError(args)
+        assert input_bytes is not None
+        active += 1
+        max_active = max(max_active, active)
+        if not first_started.is_set():
+            first_started.set()
+            await release_first.wait()
+        target = input_bytes
+        active -= 1
+        digest = __import__("hashlib").sha256(input_bytes).hexdigest()
+        return _result(stdout=f"{len(input_bytes)}\t{digest}\n".encode())
+
+    first = DockerEnvironment(container_id=CONTAINER_ID)
+    second = DockerEnvironment(container_id=CONTAINER_ID)
+    first._attached_bound = True
+    second._attached_bound = True
+    monkeypatch.setattr(first, "_docker", fake_docker)
+    monkeypatch.setattr(second, "_docker", fake_docker)
+    first_write = asyncio.create_task(first.write_file("/repo/result.txt", "A" * 2000))
+    await first_started.wait()
+    second_write = asyncio.create_task(second.write_file("/repo/./result.txt", "B" * 2000))
+    await asyncio.sleep(0)
+    assert max_active == 1
+    release_first.set()
+    await asyncio.gather(first_write, second_write)
+
+    assert max_active == 1
+    assert target in {b"A" * 2000, b"B" * 2000}
+
+
 async def test_only_docker_declares_os_process_isolation(tmp_path) -> None:
     assert DockerEnvironment().process_isolated
     assert not LocalEnvironment(str(tmp_path)).process_isolated

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 import pytest
 
 from opencollab.adapters import _env_docker as docker_module
+from opencollab.adapters._env_local import LOCAL_FILE_WRITE_LIMIT_BYTES
 from opencollab.adapters._env_process import ProcessCleanupError, ProcessResult
 from opencollab.adapters.env import DockerEnvironment, LocalEnvironment
 
@@ -513,6 +514,32 @@ async def test_concurrent_same_container_path_writes_are_serialized(monkeypatch)
 
     assert max_active == 1
     assert target in {b"A" * 2000, b"B" * 2000}
+
+
+@pytest.mark.parametrize("temporary", [False, True])
+async def test_docker_writes_reject_oversize_utf8_before_transport(
+    monkeypatch,
+    temporary,
+) -> None:
+    calls = 0
+
+    async def fake_docker(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return _result()
+
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    env._attached_bound = True
+    monkeypatch.setattr(env, "_docker", fake_docker)
+    content = "é" * (LOCAL_FILE_WRITE_LIMIT_BYTES // 2 + 1)
+
+    with pytest.raises(OSError, match="write limit"):
+        if temporary:
+            await env.write_temp_file(content, prefix="probe-")
+        else:
+            await env.write_file("/repo/result.txt", content)
+
+    assert calls == 0
 
 
 async def test_only_docker_declares_os_process_isolation(tmp_path) -> None:

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -166,6 +166,42 @@ async def test_start_failure_reports_unproven_inspect_cleanup(monkeypatch) -> No
     assert all(call[0][1] != "rm" for call in fake.calls)
 
 
+@pytest.mark.parametrize("kind", ["missing", "file"])
+async def test_setup_rejects_invalid_mount_before_docker(
+    monkeypatch,
+    tmp_path,
+    kind,
+) -> None:
+    mount = tmp_path / kind
+    if kind == "file":
+        mount.write_text("not a directory", encoding="utf-8")
+    fake = FakeDocker(lambda command, _kwargs: AssertionError(command))
+    _patch(monkeypatch, fake)
+
+    with pytest.raises(NotADirectoryError):
+        await DockerEnvironment().setup(str(mount))
+
+    assert fake.calls == []
+
+
+async def test_setup_mounts_canonical_host_directory(monkeypatch, tmp_path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(target, target_is_directory=True)
+    fake = FakeDocker(
+        lambda command, _kwargs: _result(stdout=f"{CONTAINER_ID}\n".encode())
+    )
+    _patch(monkeypatch, fake)
+    env = DockerEnvironment(workspace="/repo")
+
+    await env.setup(str(alias))
+
+    run_argv = fake.calls[0][0]
+    assert run_argv[run_argv.index("-v") + 1] == f"{target.resolve()}:/repo"
+    assert env.host_workspace == str(target.resolve())
+
+
 async def test_attached_name_binds_once_and_executes_by_full_id(monkeypatch) -> None:
     def respond(command, _kwargs):
         if command[1] == "inspect":

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -236,6 +236,32 @@ async def test_exec_preserves_bounded_output_metadata(monkeypatch) -> None:
     assert result.stderr_dropped_bytes == 3
 
 
+async def test_docker_text_range_requests_only_window_plus_probe(monkeypatch) -> None:
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    commands: list[str] = []
+
+    async def fake_exec(command, timeout=120.0):
+        commands.append(command)
+        return docker_module.ExecResult(0, "first\nsecond\nthird\n", "")
+
+    monkeypatch.setattr(env, "exec_cmd", fake_exec)
+
+    window = await env.read_text_range(
+        "/repo/large.txt",
+        offset=10,
+        limit=2,
+        max_chars=100,
+    )
+
+    assert window.lines == ["first", "second"]
+    assert window.start_line == 10
+    assert window.total_lines is None
+    assert window.has_more
+    assert not window.chars_truncated
+    assert "10,12p;12q" in commands[0]
+    assert "head -c" in commands[0]
+
+
 async def test_user_exit_125_does_not_destroy_owned_container(monkeypatch) -> None:
     exec_attempts = 0
 

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -413,6 +413,36 @@ async def test_attached_abort_cancels_and_waits_for_all_active_execs(monkeypatch
         await env.exec_cmd("echo after-abort")
 
 
+async def test_attached_cleanup_revokes_and_removes_owned_temporary_files(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_docker(*args, **_kwargs):
+        calls.append(args)
+        return _result()
+
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    env._attached_bound = True
+    env._temporary_files = {"/tmp/opencollab-a", "/tmp/opencollab-b"}
+    monkeypatch.setattr(env, "_docker", fake_docker)
+
+    await env.cleanup()
+
+    assert env.revoked
+    assert env._temporary_files == set()
+    assert {call[-1] for call in calls} == {
+        "/tmp/opencollab-a",
+        "/tmp/opencollab-b",
+    }
+    assert all(call[:2] == ("exec", "--") for call in calls)
+    with pytest.raises(RuntimeError, match="aborted"):
+        await env.exec_cmd("echo stale")
+
+    await env.cleanup()
+    assert len(calls) == 2
+
+
 async def test_double_cancellation_cannot_interrupt_container_recovery(monkeypatch) -> None:
     fake = FakeDocker(
         lambda command, _kwargs: _result(stdout=f"{CONTAINER_ID}\n".encode())

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -104,6 +104,38 @@ async def test_owned_setup_is_network_isolated_and_cleanup_uses_full_id(monkeypa
     assert fake.calls[-1][0] == ("docker", "rm", "-f", "--", CONTAINER_ID)
 
 
+async def test_concurrent_setup_reuses_one_owned_container(monkeypatch) -> None:
+    env = DockerEnvironment()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    run_count = 0
+
+    async def fake_docker(*args, **_kwargs):
+        nonlocal run_count
+        if args[0] == "run":
+            run_count += 1
+            started.set()
+            await release.wait()
+            return _result(stdout=f"{CONTAINER_ID}\n".encode())
+        if args[:3] == ("rm", "-f", "--"):
+            return _result()
+        raise AssertionError(args)
+
+    monkeypatch.setattr(env, "_docker", fake_docker)
+    first = asyncio.create_task(env.setup())
+    await started.wait()
+    second = asyncio.create_task(env.setup())
+    try:
+        await asyncio.sleep(0.01)
+        assert run_count == 1
+    finally:
+        release.set()
+        outcomes = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert outcomes == [CONTAINER_ID, CONTAINER_ID]
+    await env.cleanup()
+
+
 async def test_start_failure_never_removes_foreign_name_collision(monkeypatch) -> None:
     def respond(command, _kwargs):
         if command[1] == "run":

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -519,6 +519,32 @@ async def test_double_cancellation_finishes_container_and_backing_cleanup(monkey
     assert backing_cleaned.is_set()
 
 
+async def test_cleanup_preserves_backing_when_container_removal_fails(
+    monkeypatch,
+) -> None:
+    backing_cleanup_calls = 0
+
+    class BackingEnvironment:
+        source_workspace = "/source"
+
+        async def cleanup(self):
+            nonlocal backing_cleanup_calls
+            backing_cleanup_calls += 1
+
+    async def fail_remove():
+        return False
+
+    backing = BackingEnvironment()
+    env = DockerEnvironment(backing_environment=backing)
+    monkeypatch.setattr(env, "_remove_container_if_owned", fail_remove)
+
+    with pytest.raises(RuntimeError, match="container could not be removed"):
+        await env.cleanup()
+
+    assert backing_cleanup_calls == 0
+    assert env._backing_environment is backing
+
+
 async def test_verified_write_threads_stdin_and_digest(monkeypatch) -> None:
     payload = b"hello"
     digest = __import__("hashlib").sha256(payload).hexdigest()

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from collections.abc import Callable
 
 import pytest
@@ -51,6 +52,36 @@ class FakeDocker:
 
 def _patch(monkeypatch, fake: FakeDocker) -> None:
     monkeypatch.setattr(docker_module, "run_process", fake)
+
+
+@pytest.mark.parametrize(
+    ("probe_result", "expected_returncode", "pidfile_retained"),
+    [(0, 125, True), (1, 0, False)],
+    ids=("group-survives", "group-quiesces"),
+)
+def test_exec_cancel_only_succeeds_after_process_group_quiesces(
+    tmp_path,
+    probe_result,
+    expected_returncode,
+    pidfile_retained,
+) -> None:
+    pidfile = tmp_path / "exec.pid"
+    pidfile.write_text("123\n", encoding="utf-8")
+    command = (
+        f'kill() {{ [ "$1" = "-0" ] && return {probe_result}; return 0; }}; '
+        "sleep() { :; }; "
+        f"{docker_module._EXEC_CANCEL}"
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", command, "opencollab-cancel", str(pidfile)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == expected_returncode
+    assert pidfile.exists() is pidfile_retained
 
 
 async def test_owned_setup_is_network_isolated_and_cleanup_uses_full_id(monkeypatch) -> None:

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -243,6 +243,44 @@ async def test_attached_timeout_revokes_when_inner_cancel_fails(monkeypatch) -> 
     assert all(call[0][1] != "rm" for call in fake.calls)
 
 
+async def test_attached_abort_cancels_and_waits_for_all_active_execs(monkeypatch) -> None:
+    started = [asyncio.Event(), asyncio.Event()]
+    release = asyncio.Event()
+    cancellations: list[tuple[str, ...]] = []
+    command_count = 0
+
+    async def fake_docker(*args, **_kwargs):
+        nonlocal command_count
+        if docker_module._EXEC_WRAPPER in args:
+            index = command_count
+            command_count += 1
+            started[index].set()
+            await release.wait()
+            return _result()
+        if docker_module._EXEC_CANCEL in args:
+            cancellations.append(args)
+            if len(cancellations) == 2:
+                release.set()
+            return _result()
+        raise AssertionError(args)
+
+    env = DockerEnvironment(container_id=CONTAINER_ID)
+    env._attached_bound = True
+    monkeypatch.setattr(env, "_docker", fake_docker)
+    first = asyncio.create_task(env.exec_cmd("sleep 20"))
+    second = asyncio.create_task(env.exec_cmd("sleep 20"))
+    await asyncio.gather(*(event.wait() for event in started))
+
+    await env.abort()
+
+    assert env.revoked
+    assert len(cancellations) == 2
+    assert first.done() and second.done()
+    await asyncio.gather(first, second)
+    with pytest.raises(RuntimeError, match="aborted"):
+        await env.exec_cmd("echo after-abort")
+
+
 async def test_double_cancellation_cannot_interrupt_container_recovery(monkeypatch) -> None:
     fake = FakeDocker(
         lambda command, _kwargs: _result(stdout=f"{CONTAINER_ID}\n".encode())

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -309,6 +309,12 @@ async def test_timeout_runs_container_inner_cancel_before_return(monkeypatch) ->
     assert docker_module._EXEC_CANCEL in fake.calls[-1][0]
 
 
+@pytest.mark.parametrize("value", [0, False, "0"])
+def test_timeout_returncode_rejects_success_and_non_integer_values(value) -> None:
+    with pytest.raises(ValueError, match="non-zero integer"):
+        DockerEnvironment(timeout_returncode=value)
+
+
 async def test_attached_timeout_revokes_when_inner_cancel_fails(monkeypatch) -> None:
     exec_attempts = 0
 

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -162,6 +162,36 @@ def test_unified_diff_failed_hunk_writes_nothing(tmp_path):
     assert target.read_text(encoding="utf-8") == original
 
 
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "path": "f.py",
+            "mode": "line_replace",
+            "start_line": 1,
+            "end_line": 1,
+            "new_str": "a",
+        },
+        {
+            "path": "f.py",
+            "mode": "unified_diff",
+            "patch": "@@ -1,2 +1,2 @@\n a\n b\n",
+        },
+    ],
+)
+def test_apply_patch_rejects_successful_noop_without_writing(tmp_path, params):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    target.write_text("a\nb\n", encoding="utf-8")
+
+    result = run(ApplyPatchTool().execute_with_runtime(params, _runtime(ws)))
+
+    assert result.startswith("Error applying patch")
+    assert "no changes" in result
+    assert target.read_text(encoding="utf-8") == "a\nb\n"
+
+
 def test_unified_diff_treats_header_like_hunk_content_as_content(tmp_path):
     ws = tmp_path / "ws"
     ws.mkdir()

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -132,6 +132,27 @@ def test_unified_diff_failed_hunk_writes_nothing(tmp_path):
     assert target.read_text(encoding="utf-8") == original
 
 
+def test_unified_diff_treats_header_like_hunk_content_as_content(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    target.write_text("old\n", encoding="utf-8")
+
+    result = run(
+        ApplyPatchTool().execute_with_runtime(
+            {
+                "path": "f.py",
+                "mode": "unified_diff",
+                "patch": "@@ -1 +1 @@\n-old\n+++value\n",
+            },
+            _runtime(ws),
+        )
+    )
+
+    assert "Applied unified_diff" in result
+    assert target.read_text(encoding="utf-8") == "++value\n"
+
+
 def test_apply_patch_reports_file_and_workspace_errors(tmp_path):
     ws = tmp_path / "ws"
     ws.mkdir()

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -266,6 +266,76 @@ def test_unified_diff_applies_eof_newline_metadata(tmp_path, source, patch, expe
     assert target.read_text(encoding="utf-8") == expected
 
 
+@pytest.mark.parametrize(
+    ("tool", "params"),
+    [
+        (
+            FileWriteTool(),
+            {
+                "path": "f.py",
+                "mode": "str_replace",
+                "old_str": "alpha\ntarget",
+                "new_str": "alpha\nchanged",
+            },
+        ),
+        (
+            ApplyPatchTool(),
+            {
+                "path": "f.py",
+                "mode": "line_replace",
+                "start_line": 2,
+                "end_line": 2,
+                "expected_str": "target",
+                "new_str": "changed",
+            },
+        ),
+        (
+            ApplyPatchTool(),
+            {
+                "path": "f.py",
+                "mode": "unified_diff",
+                "patch": "@@ -1,3 +1,3 @@\n alpha\n-target\n+changed\n omega\n",
+            },
+        ),
+    ],
+    ids=("str-replace", "line-replace", "unified-diff"),
+)
+def test_edit_modes_match_logical_lines_and_preserve_crlf(tmp_path, tool, params):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    target.write_bytes(b"alpha\r\ntarget\r\nomega\r\n")
+
+    result = run(tool.execute_with_runtime(params, _runtime(ws)))
+
+    assert not result.startswith("Error:")
+    assert target.read_bytes() == b"alpha\r\nchanged\r\nomega\r\n"
+
+
+def test_line_edit_rejects_mixed_newlines_without_rewriting_file(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    original = b"alpha\r\ntarget\nomega\r\n"
+    target.write_bytes(original)
+
+    result = run(
+        ApplyPatchTool().execute_with_runtime(
+            {
+                "path": "f.py",
+                "mode": "line_replace",
+                "start_line": 2,
+                "end_line": 2,
+                "new_str": "changed",
+            },
+            _runtime(ws),
+        )
+    )
+
+    assert "mixed newline styles" in result
+    assert target.read_bytes() == original
+
+
 def test_apply_patch_reports_file_and_workspace_errors(tmp_path):
     ws = tmp_path / "ws"
     ws.mkdir()

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+from hashlib import sha256
 
 import pytest
 
@@ -284,3 +285,62 @@ def test_str_replace_success_reports_content_changed(tmp_path):
 
     assert "content changed" in result
     assert target.read_text(encoding="utf-8") == "hello there\n"
+
+
+@pytest.mark.parametrize(
+    ("tool", "params"),
+    [
+        (
+            FileWriteTool(),
+            {
+                "path": "f.py",
+                "mode": "str_replace",
+                "old_str": "target",
+                "new_str": "changed",
+            },
+        ),
+        (
+            ApplyPatchTool(),
+            {
+                "path": "f.py",
+                "mode": "unified_diff",
+                "patch": "@@ -1 +1 @@\n-target\n+changed\n",
+            },
+        ),
+    ],
+)
+def test_non_utf8_edit_attempt_is_explicit_and_preserves_bytes(tmp_path, tool, params):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    original = b"prefix\ntarget\xffkeep\n"
+    target.write_bytes(original)
+    before = sha256(original).hexdigest()
+
+    result = run(tool.execute_with_runtime(params, _runtime(ws)))
+
+    assert result == "Error: refusing to edit non-UTF-8 file: invalid UTF-8 at byte 13."
+    assert target.read_bytes() == original
+    assert sha256(target.read_bytes()).hexdigest() == before
+
+
+def test_str_replace_preserves_legal_utf8_with_cjk(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    target.write_text("\u4f60\u597d\uff0c\u4e16\u754c\n", encoding="utf-8")
+
+    result = run(
+        FileWriteTool().execute_with_runtime(
+            {
+                "path": "f.py",
+                "mode": "str_replace",
+                "old_str": "\u4e16\u754c",
+                "new_str": "OpenCollab",
+            },
+            _runtime(ws),
+        )
+    )
+
+    assert "Replaced in" in result
+    assert target.read_text(encoding="utf-8") == "\u4f60\u597d\uff0cOpenCollab\n"

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -234,6 +234,38 @@ def test_unified_diff_pure_insertions_use_header_position(tmp_path, header, expe
     assert target.read_text(encoding="utf-8") == expected
 
 
+@pytest.mark.parametrize(
+    ("source", "patch", "expected"),
+    [
+        (
+            "old\n",
+            "@@ -1 +1 @@\n-old\n+new\n\\ No newline at end of file\n",
+            "new",
+        ),
+        (
+            "old",
+            "@@ -1 +1 @@\n-old\n\\ No newline at end of file\n+new\n",
+            "new\n",
+        ),
+    ],
+)
+def test_unified_diff_applies_eof_newline_metadata(tmp_path, source, patch, expected):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    target.write_text(source, encoding="utf-8")
+
+    result = run(
+        ApplyPatchTool().execute_with_runtime(
+            {"path": "f.py", "mode": "unified_diff", "patch": patch},
+            _runtime(ws),
+        )
+    )
+
+    assert "Applied unified_diff" in result
+    assert target.read_text(encoding="utf-8") == expected
+
+
 def test_apply_patch_reports_file_and_workspace_errors(tmp_path):
     ws = tmp_path / "ws"
     ws.mkdir()

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import tracemalloc
 from hashlib import sha256
 
 import pytest
@@ -6,6 +7,7 @@ import pytest
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.safety import SandboxInterceptor
 from opencollab.adapters.tools.apply_patch import ApplyPatchTool
+from opencollab.adapters.tools.apply_patch_engine import _find_block
 from opencollab.adapters.tools.fs import FileWriteTool
 from opencollab.application.tool_execution import ToolRuntime
 
@@ -103,6 +105,33 @@ def test_unified_diff_matches_by_content_despite_line_drift(tmp_path):
 
     assert "Applied unified_diff" in result
     assert target.read_text(encoding="utf-8") == "extra0\nextra1\nlineA\nlineB_fixed\nlineC\n"
+
+
+def test_fuzzy_block_search_uses_constant_auxiliary_memory():
+    # Roughly 4 MiB of repeated source text. Every position matches, so the old
+    # collect-and-sort implementation allocated hundreds of thousands of ints.
+    source = ["repeated-line"] * 350_000
+    tracemalloc.start()
+    try:
+        position = _find_block(
+            source,
+            ["repeated-line"],
+            expected_idx=175_000,
+            min_idx=0,
+        )
+        _, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert position == 175_000
+    assert peak_bytes < 1_000_000
+
+
+def test_fuzzy_block_search_preserves_nearest_then_earliest_tie_break():
+    source = ["x", "target", "x", "target", "x"]
+
+    assert _find_block(source, ["target"], expected_idx=2, min_idx=0) == 1
+    assert _find_block(source, ["target"], expected_idx=3, min_idx=0) == 3
 
 
 def test_unified_diff_failed_hunk_writes_nothing(tmp_path):

--- a/tests/test_edit_tool.py
+++ b/tests/test_edit_tool.py
@@ -153,6 +153,57 @@ def test_unified_diff_treats_header_like_hunk_content_as_content(tmp_path):
     assert target.read_text(encoding="utf-8") == "++value\n"
 
 
+def test_unified_diff_rejects_malformed_hunk_without_writing(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    original = "a\nb\nc\n"
+    target.write_text(original, encoding="utf-8")
+
+    result = run(
+        ApplyPatchTool().execute_with_runtime(
+            {
+                "path": "f.py",
+                "mode": "unified_diff",
+                "patch": "@@ -1,3 +1,3 @@\n a\n-b\n+x\n",
+            },
+            _runtime(ws),
+        )
+    )
+
+    assert "declares 3 old lines" in result
+    assert target.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        ("@@ -0,0 +1 @@", "X\na\nb\nc\n"),
+        ("@@ -2,0 +3 @@", "a\nb\nX\nc\n"),
+        ("@@ -3,0 +4 @@", "a\nb\nc\nX\n"),
+    ],
+)
+def test_unified_diff_pure_insertions_use_header_position(tmp_path, header, expected):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = ws / "f.py"
+    target.write_text("a\nb\nc\n", encoding="utf-8")
+
+    result = run(
+        ApplyPatchTool().execute_with_runtime(
+            {
+                "path": "f.py",
+                "mode": "unified_diff",
+                "patch": f"{header}\n+X\n",
+            },
+            _runtime(ws),
+        )
+    )
+
+    assert "Applied unified_diff" in result
+    assert target.read_text(encoding="utf-8") == expected
+
+
 def test_apply_patch_reports_file_and_workspace_errors(tmp_path):
     ws = tmp_path / "ws"
     ws.mkdir()

--- a/tests/test_event_log_observability.py
+++ b/tests/test_event_log_observability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections import UserDict
 from types import SimpleNamespace
 
 import opencollab.adapters.event_log as event_log
@@ -34,6 +35,21 @@ def test_jsonl_event_sink_preserves_plain_mapping_payload(tmp_path):
     assert row["type"] == "custom"
     assert row["data"] == {"value": 7}
     assert row["sequence"] == 3
+
+
+def test_jsonl_event_sink_preserves_generic_mapping_payload(tmp_path):
+    path = tmp_path / "events.jsonl"
+    sink = JsonlEventSink(str(path))
+    event = UserDict(
+        {"type": "custom", "data": {"value": 11}, "sequence": 5}
+    )
+
+    asyncio.run(sink.emit(event))
+
+    row = json.loads(path.read_text(encoding="utf-8"))
+    assert row["type"] == "custom"
+    assert row["data"] == {"value": 11}
+    assert row["sequence"] == 5
 
 
 def test_jsonl_event_sink_remains_passive_when_parent_cannot_be_created(tmp_path):

--- a/tests/test_event_log_observability.py
+++ b/tests/test_event_log_observability.py
@@ -24,6 +24,18 @@ def test_jsonl_event_sink_serializes_custom_event_data(tmp_path):
     assert row["data"]["value"] == "custom-object"
 
 
+def test_jsonl_event_sink_preserves_plain_mapping_payload(tmp_path):
+    path = tmp_path / "events.jsonl"
+    sink = JsonlEventSink(str(path))
+
+    asyncio.run(sink.emit({"type": "custom", "data": {"value": 7}, "sequence": 3}))
+
+    row = json.loads(path.read_text(encoding="utf-8"))
+    assert row["type"] == "custom"
+    assert row["data"] == {"value": 7}
+    assert row["sequence"] == 3
+
+
 def test_jsonl_event_sink_remains_passive_when_parent_cannot_be_created(tmp_path):
     blocker = tmp_path / "not_a_directory"
     blocker.write_text("occupied", encoding="utf-8")

--- a/tests/test_event_log_observability.py
+++ b/tests/test_event_log_observability.py
@@ -76,3 +76,4 @@ def test_jsonl_event_sink_retains_first_write_error(tmp_path, monkeypatch):
 
     assert sink.write_error == "OSError: failure 1"
     assert sink.dropped_events == 2
+    assert attempts == 1

--- a/tests/test_git_diff_tool.py
+++ b/tests/test_git_diff_tool.py
@@ -52,6 +52,16 @@ def test_git_diff_stat_only_summarizes_without_raw_patch(repo):
     assert "-    return 1" not in result
 
 
+def test_git_diff_stat_only_uses_same_head_baseline_for_staged_changes(repo):
+    _git(repo, "add", "app.py")
+
+    result = run(GitDiffTool().execute_with_runtime({"stat_only": True}, _runtime(repo)))
+
+    assert "diff --stat:" in result
+    assert "app.py" in result
+    assert "1 file changed" in result
+
+
 def test_git_diff_path_filter_can_skip_status(repo):
     (repo / "other.py").write_text("x = 1\n", encoding="utf-8")
 

--- a/tests/test_git_diff_tool.py
+++ b/tests/test_git_diff_tool.py
@@ -78,6 +78,25 @@ def test_git_diff_path_filter_can_skip_status(repo):
 
 
 @pytest.mark.parametrize("stat_only", [False, True])
+def test_git_diff_includes_untracked_files_in_default_change_set(repo, stat_only):
+    target = repo / "new file.py"
+    target.write_text("new_value = 3\n", encoding="utf-8")
+
+    result = run(
+        GitDiffTool().execute_with_runtime(
+            {"stat_only": stat_only, "include_status": False},
+            _runtime(repo),
+        )
+    )
+
+    assert "new file.py" in result
+    if stat_only:
+        assert "1 insertion" in result
+    else:
+        assert "+new_value = 3" in result
+
+
+@pytest.mark.parametrize("stat_only", [False, True])
 def test_git_diff_supports_unborn_repository_with_staged_file(tmp_path, stat_only):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_git_diff_tool.py
+++ b/tests/test_git_diff_tool.py
@@ -77,6 +77,29 @@ def test_git_diff_path_filter_can_skip_status(repo):
     assert "other.py" not in result.split("diff vs HEAD:")[1]
 
 
+@pytest.mark.parametrize("stat_only", [False, True])
+def test_git_diff_supports_unborn_repository_with_staged_file(tmp_path, stat_only):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "first.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "first.py")
+
+    result = run(
+        GitDiffTool().execute_with_runtime(
+            {"stat_only": stat_only},
+            _runtime(repo),
+        )
+    )
+
+    assert "diff vs empty tree" in result
+    assert "first.py" in result
+    if stat_only:
+        assert "1 file changed" in result
+    else:
+        assert "+value = 1" in result
+
+
 def test_git_diff_reports_environment_errors(tmp_path):
     no_env = run(
         GitDiffTool().execute_with_runtime(

--- a/tests/test_git_patch.py
+++ b/tests/test_git_patch.py
@@ -52,15 +52,15 @@ def _extract(
     )
 
 
-def test_patch_respects_gitignore_but_keeps_tracked_changes(tmp_path):
+def test_patch_blocks_ignored_untracked_files_without_leaking_content(tmp_path):
     repo = _repo(tmp_path)
     (repo / "tracked.txt").write_text("new\n", encoding="utf-8")
     (repo / "secret.txt").write_text("api-token\n", encoding="utf-8")
 
     result = _extract(repo)
 
-    assert result.returncode == 0, result.stderr
-    assert "tracked.txt" in result.stdout
+    assert result.returncode == 125
+    assert "ignored untracked files" in result.stderr
     assert "secret.txt" not in result.stdout
     assert "api-token" not in result.stdout
     assert _git(repo, "diff", "--cached", "--quiet").returncode == 0

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -686,6 +686,60 @@ def test_anthropic_conversion_rejects_unsupported_content_block_with_location():
         convert_to_anthropic_messages(messages)
 
 
+@pytest.mark.parametrize(
+    ("arguments", "reason"),
+    [
+        ('{"path":', "invalid JSON"),
+        ('"path"', "JSON object"),
+        ("[]", "JSON object"),
+        (b"{}", "text or an object"),
+        (None, "text or an object"),
+    ],
+)
+def test_anthropic_conversion_rejects_invalid_restored_tool_arguments(
+    arguments,
+    reason,
+):
+    messages = [
+        {"role": "user", "content": "before"},
+        {
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call-bad",
+                "type": "function",
+                "function": {"name": "file_read", "arguments": arguments},
+            }],
+        },
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=rf"message 1 .*file_read.*call-bad.*{reason}",
+    ):
+        convert_to_anthropic_messages(messages)
+
+
+def test_anthropic_conversion_preserves_object_tool_arguments():
+    messages = [{
+        "role": "assistant",
+        "tool_calls": [{
+            "id": "call-ok",
+            "type": "function",
+            "function": {
+                "name": "file_read",
+                "arguments": '{"path": "src/a.py", "options": {"line": 2}}',
+            },
+        }],
+    }]
+
+    _, converted = convert_to_anthropic_messages(messages)
+
+    assert converted[0]["content"][0]["input"] == {
+        "path": "src/a.py",
+        "options": {"line": 2},
+    }
+
+
 def test_anthropic_redacted_thinking_is_not_harvested():
     """redacted_thinking holds encrypted data, not text — must not become content."""
     redacted = SimpleNamespace(type="redacted_thinking", data="encrypted-bytes")

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -201,6 +201,34 @@ def test_openai_thinking_on_adds_extra_body():
     assert kwargs["extra_body"] == {"enable_thinking": True}
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "model",
+        "messages",
+        "tools",
+        "tool_choice",
+        "temperature",
+        "top_p",
+        "max_tokens",
+        "max_completion_tokens",
+        "stream",
+        "stream_options",
+    ],
+)
+def test_openai_thinking_rejects_framework_controlled_request_fields(field):
+    with pytest.raises(ValueError, match=field):
+        build_openai_kwargs(
+            "safe-model",
+            [{"role": "user", "content": "keep this message"}],
+            None,
+            0.2,
+            thinking=True,
+            thinking_params={field: "override"},
+            max_output_tokens=10,
+        )
+
+
 def test_openai_preserves_reasoning_content_for_tool_follow_up():
     kwargs = build_openai_kwargs(
         "kimi-for-coding",

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -705,6 +705,24 @@ def test_openai_markup_two_tool_calls_are_synthesized():
     assert result.content is None
 
 
+def test_openai_markup_malformed_group_is_not_partially_executed():
+    content = (
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>functions.file_read:c1"
+        '<|tool_call_argument_begin|>{"path": "safe.txt"}<|tool_call_end|>'
+        "<|tool_call_begin|>functions.file_write:c2"
+        '<|tool_call_argument_begin|>{"path": "target.txt"<|tool_call_end|>'
+        "<|tool_calls_section_end|>"
+    )
+    resp = _openai_resp(usage=None, content=content)
+
+    result = parse_openai_response(resp, [{"role": "user", "content": "q"}])
+
+    assert result.tool_calls == []
+    assert result.content == content
+    assert result.usage.markup_recovered == 0
+
+
 def test_openai_markup_preserves_surrounding_prose():
     """Genuine prose around the markup is preserved; the call is still synthesized."""
     content = "Let me search the repo. " + _markup("grep", "c1", '{"pattern": "foo"}')

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -638,6 +638,54 @@ def test_anthropic_preserves_signed_thinking_for_tool_follow_up():
     assert converted[0]["content"][1]["type"] == "tool_use"
 
 
+def test_anthropic_conversion_normalizes_openai_text_blocks_without_mutation():
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "system "},
+                {"type": "text", "text": "policy"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"},
+            ],
+        },
+    ]
+    original = json.loads(json.dumps(messages))
+
+    system, converted = convert_to_anthropic_messages(messages)
+
+    assert system == ["system policy"]
+    assert converted == [{
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ],
+    }]
+    assert messages == original
+
+
+def test_anthropic_conversion_rejects_unsupported_content_block_with_location():
+    messages = [
+        {"role": "user", "content": "before"},
+        {
+            "role": "assistant",
+            "content": [{"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}],
+        },
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"message 1 .*assistant.* unsupported content block type: image_url",
+    ):
+        convert_to_anthropic_messages(messages)
+
+
 def test_anthropic_redacted_thinking_is_not_harvested():
     """redacted_thinking holds encrypted data, not text — must not become content."""
     redacted = SimpleNamespace(type="redacted_thinking", data="encrypted-bytes")

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -515,6 +515,29 @@ def test_llm_client_forwards_anthropic_base_url(monkeypatch):
     assert captured["base_url"] == "http://proxy.local"
     assert captured["api_key"] == "k"
     assert captured["timeout"] == 12.0
+    assert captured["max_retries"] == 0
+
+
+def test_llm_client_disables_openai_sdk_retries(monkeypatch):
+    captured = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    from opencollab.adapters.llm import client as client_module
+
+    monkeypatch.setattr(client_module.openai, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    client = client_module.LLMClient(
+        provider="openai",
+        model="gpt-4o",
+        api_key="k",
+        max_retries=3,
+    )
+
+    assert client.max_retries == 3
+    assert captured["max_retries"] == 0
 
 
 def test_openai_estimates_output_from_tool_calls_when_no_content():

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -418,6 +418,28 @@ def test_anthropic_top_p_omitted_when_none():
     assert "top_p" not in kwargs
 
 
+def test_anthropic_keeps_compaction_record_in_conversation_order():
+    identity = "global identity"
+    compacted = "[Context auto-compacted]: earlier work"
+    system_parts, messages = convert_to_anthropic_messages(
+        [
+            {"role": "system", "content": identity},
+            {"role": "user", "content": "old request"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "system", "content": compacted, "compacted": True},
+            {"role": "user", "content": "new request"},
+        ]
+    )
+
+    assert system_parts == [identity]
+    assert [message["content"] for message in messages] == [
+        "old request",
+        [{"type": "text", "text": "old answer"}],
+        compacted,
+        "new request",
+    ]
+
+
 def test_max_output_tokens_reaches_both_provider_payloads():
     messages = [{"role": "user", "content": "hi"}]
 

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -358,6 +358,35 @@ def test_exact_model_capabilities_centralize_provider_compatibility(model, conte
     assert capabilities.honors_workflow_thinking_override is False
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "vendor/kimi-for-coding",
+        "gateway/kimi-for-coding-2026-08-07",
+    ],
+)
+def test_known_model_capabilities_accept_bounded_provider_aliases(model):
+    capabilities = model_capabilities(model)
+
+    assert capabilities.context_window == 262_144
+    assert capabilities.supports_forced_tool_choice is False
+    assert capabilities.honors_workflow_thinking_override is False
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "vendor/kimi-for-coding-preview",
+        "vendor/not-kimi-for-coding",
+    ],
+)
+def test_known_model_capabilities_reject_prefixed_near_misses(model):
+    capabilities = model_capabilities(model)
+
+    assert capabilities.context_window is None
+    assert capabilities.supports_forced_tool_choice is True
+
+
 def test_unknown_model_capabilities_use_neutral_defaults():
     capabilities = model_capabilities("unknown-model")
 

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -424,6 +424,41 @@ def test_openai_top_p_omitted_when_none():
     assert "top_p" not in kwargs
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["o1-preview", "o3-mini", "gateway/o1-2026-08-07"],
+)
+def test_openai_reasoning_models_use_compatible_request_fields(model):
+    kwargs = build_openai_kwargs(
+        model,
+        [{"role": "user", "content": "hi"}],
+        None,
+        0.2,
+        top_p=0.9,
+        max_output_tokens=123,
+    )
+
+    assert kwargs["max_completion_tokens"] == 123
+    assert "max_tokens" not in kwargs
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+
+
+def test_openai_reasoning_model_near_miss_keeps_classic_fields():
+    kwargs = build_openai_kwargs(
+        "vendor/not-o1-preview",
+        [{"role": "user", "content": "hi"}],
+        None,
+        0.2,
+        top_p=0.9,
+        max_output_tokens=123,
+    )
+
+    assert kwargs["max_tokens"] == 123
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["top_p"] == 0.9
+
+
 def test_anthropic_top_p_included_when_set():
     """Anthropic parity: top_p set -> the payload carries it."""
     kwargs = build_anthropic_kwargs(

--- a/tests/test_llm_usage_ledger.py
+++ b/tests/test_llm_usage_ledger.py
@@ -13,6 +13,7 @@ from opencollab.adapters.llm.types import Usage
 from opencollab.adapters.llm.usage_ledger import (
     append_usage_record,
     build_usage_record,
+    pricing_for_model,
     usage_cost_usd,
     usage_log_path,
 )
@@ -20,6 +21,15 @@ from opencollab.adapters.llm.usage_ledger import (
 
 def _read_jsonl(path):
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+@pytest.mark.parametrize("model", ["glm-4", "glm-5.1", "my-glm-proxy"])
+def test_non_glm52_models_do_not_receive_glm52_pricing(model):
+    assert pricing_for_model(model)["mode"] == "unset"
+
+
+def test_provider_prefixed_glm52_model_uses_glm52_pricing():
+    assert pricing_for_model("zhipu/glm-5.2")["mode"] == "glm-5.2-default"
 
 
 def test_glm_usage_cost_accounts_for_cache_discount(monkeypatch):

--- a/tests/test_local_env_processes.py
+++ b/tests/test_local_env_processes.py
@@ -200,6 +200,133 @@ async def test_process_timeout_covers_blocked_stdin_writer(tmp_path) -> None:
         )
 
 
+async def test_process_timeout_covers_subprocess_spawn(monkeypatch, tmp_path) -> None:
+    gate = asyncio.Event()
+    terminated = asyncio.Event()
+    original_spawn = process_module.asyncio.create_subprocess_exec
+    original_terminate = process_module.terminate_process
+
+    async def delayed_spawn(*args, **kwargs):
+        await gate.wait()
+        return await original_spawn(*args, **kwargs)
+
+    async def tracked_terminate(process, **kwargs):
+        result = await original_terminate(process, **kwargs)
+        terminated.set()
+        return result
+
+    monkeypatch.setattr(
+        process_module.asyncio,
+        "create_subprocess_exec",
+        delayed_spawn,
+    )
+    monkeypatch.setattr(process_module, "terminate_process", tracked_terminate)
+    task = asyncio.create_task(
+        run_process(
+            (sys.executable, "-c", "import time; time.sleep(5)"),
+            shell=False,
+            cwd=str(tmp_path),
+            timeout=0.01,
+        )
+    )
+
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=0.1)
+        assert task in done
+        with pytest.raises(asyncio.TimeoutError):
+            task.result()
+    finally:
+        gate.set()
+        if not task.done():
+            with pytest.raises(asyncio.TimeoutError):
+                await task
+        await asyncio.wait_for(terminated.wait(), timeout=1)
+
+
+async def test_process_cancellation_during_spawn_is_bounded(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    gate = asyncio.Event()
+    terminated = asyncio.Event()
+    original_spawn = process_module.asyncio.create_subprocess_exec
+    original_terminate = process_module.terminate_process
+
+    async def delayed_spawn(*args, **kwargs):
+        await gate.wait()
+        return await original_spawn(*args, **kwargs)
+
+    async def tracked_terminate(process, **kwargs):
+        result = await original_terminate(process, **kwargs)
+        terminated.set()
+        return result
+
+    monkeypatch.setattr(
+        process_module.asyncio,
+        "create_subprocess_exec",
+        delayed_spawn,
+    )
+    monkeypatch.setattr(process_module, "terminate_process", tracked_terminate)
+    task = asyncio.create_task(
+        run_process(
+            (sys.executable, "-c", "import time; time.sleep(5)"),
+            shell=False,
+            cwd=str(tmp_path),
+            timeout=5,
+        )
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=0.1)
+        assert task in done
+        with pytest.raises(asyncio.CancelledError):
+            task.result()
+    finally:
+        gate.set()
+        if not task.done():
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        await asyncio.wait_for(terminated.wait(), timeout=1)
+
+
+async def test_registry_abort_bounds_unfinished_spawn_handoff(monkeypatch) -> None:
+    registry = process_module.ProcessRegistry()
+    spawn_started = asyncio.Event()
+    spawn_release = asyncio.Event()
+    process = object()
+
+    async def factory():
+        spawn_started.set()
+        await spawn_release.wait()
+        return process
+
+    async def cleanup(candidate):
+        assert candidate is process
+        return True
+
+    monkeypatch.setattr(process_module, "PROCESS_KILL_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(process_module, "terminate_process", cleanup)
+    spawn_owner = asyncio.create_task(registry.spawn(factory))
+    await spawn_started.wait()
+    abort_owner = asyncio.create_task(registry.abort())
+
+    try:
+        done, _pending = await asyncio.wait({abort_owner}, timeout=0.1)
+        assert abort_owner in done
+        with pytest.raises(ProcessCleanupError, match="spawn handoff"):
+            abort_owner.result()
+    finally:
+        spawn_release.set()
+        with pytest.raises(RuntimeError, match="revoked"):
+            await spawn_owner
+        if not abort_owner.done():
+            await abort_owner
+
+    await registry.abort()
+
+
 async def test_cancellation_during_timeout_cleanup_is_preserved(monkeypatch) -> None:
     cleanup_started = asyncio.Event()
     cleanup_release = asyncio.Event()

--- a/tests/test_local_env_processes.py
+++ b/tests/test_local_env_processes.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import shlex
 import sys
+import threading
 
 import pytest
 
@@ -380,6 +381,62 @@ async def test_local_file_operations_reject_symlink_and_escape(tmp_path) -> None
     with pytest.raises(PermissionError):
         await env.write_file("../escape", "changed")
     assert outside.read_text(encoding="utf-8") == "outside"
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+async def test_local_file_io_does_not_block_event_loop(
+    tmp_path,
+    monkeypatch,
+    operation,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_file_io(*_args, **_kwargs):
+        started.set()
+        assert release.wait(1.0)
+        return b"payload"
+
+    env = LocalEnvironment(str(tmp_path))
+    if operation == "read":
+        monkeypatch.setattr(local_module, "read_regular_bytes", slow_file_io)
+        owner = asyncio.create_task(env.read_file("value"))
+    else:
+        monkeypatch.setattr(local_module, "write_regular_bytes_atomic", slow_file_io)
+        owner = asyncio.create_task(env.write_file("value", "payload"))
+    timer = threading.Timer(0.15, release.set)
+    timer.start()
+    try:
+        await asyncio.sleep(0.02)
+        assert started.is_set()
+        assert not owner.done()
+    finally:
+        release.set()
+        timer.cancel()
+        await owner
+
+
+async def test_local_cleanup_waits_for_cancelled_file_io(tmp_path, monkeypatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_write(*_args, **_kwargs) -> None:
+        started.set()
+        assert release.wait(1.0)
+
+    monkeypatch.setattr(local_module, "write_regular_bytes_atomic", slow_write)
+    env = LocalEnvironment(str(tmp_path))
+    writer = asyncio.create_task(env.write_file("value", "payload"))
+    assert await asyncio.to_thread(started.wait, 1.0)
+    writer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await writer
+
+    cleanup = asyncio.create_task(env.cleanup())
+    await asyncio.sleep(0.02)
+    assert not cleanup.done()
+    release.set()
+    await cleanup
 
 
 async def test_local_temp_files_have_owned_cleanup(tmp_path) -> None:

--- a/tests/test_local_env_processes.py
+++ b/tests/test_local_env_processes.py
@@ -64,7 +64,7 @@ async def test_local_exec_bounds_output(tmp_path, monkeypatch) -> None:
     [
         (b"ok", 4, b"ok", 0),
         (b"four", 4, b"four", 0),
-        (b"abcdef", 4, b"abcd", 2),
+        (b"abcdef", 4, b"abef", 2),
     ],
     ids=("below-limit", "exact-limit", "over-limit"),
 )
@@ -84,6 +84,22 @@ async def test_process_output_limit_counts_only_unretained_bytes(
     assert result.stdout == expected_stdout
     assert result.stdout_dropped_bytes == expected_dropped
     assert result.to_exec_result().stdout_truncated is (expected_dropped > 0)
+
+
+async def test_process_output_limit_preserves_real_head_and_tail() -> None:
+    payload = b"HEAD" + b"x" * 100 + b"TAIL"
+
+    result = await run_process(
+        (sys.executable, "-c", f"import os; os.write(1, {payload!r})"),
+        shell=False,
+        timeout=5,
+        output_limit=16,
+    )
+
+    assert result.stdout.startswith(b"HEAD")
+    assert result.stdout.endswith(b"TAIL")
+    assert len(result.stdout) == 16
+    assert result.stdout_dropped_bytes == len(payload) - 16
 
 
 async def test_local_timeout_kills_descendant_before_it_mutates_workspace(tmp_path) -> None:

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -71,8 +73,32 @@ def test_tracer_write_failure_is_sticky(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr("opencollab.adapters.trace.write_locked_text", fail)
     tracer.log_step("first", {})
     tracer.log_step("second", {})
+    tracer.flush()
     assert tracer.write_error == "OSError: disk full"
     assert tracer.dropped_steps == 2
+
+
+def test_tracer_slow_write_does_not_block_log_step(tmp_path, monkeypatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_write(*_args, **_kwargs) -> None:
+        started.set()
+        assert release.wait(1.0)
+
+    monkeypatch.setattr("opencollab.adapters.trace.write_locked_text", slow_write)
+    tracer = Tracer("run", output_dir=str(tmp_path))
+    timer = threading.Timer(0.15, release.set)
+    timer.start()
+    try:
+        before = time.monotonic()
+        tracer.log_step("slow", {})
+        elapsed = time.monotonic() - before
+        assert elapsed < 0.05
+    finally:
+        release.set()
+        timer.cancel()
+        tracer.close()
 
 
 def test_tracer_serialization_fallback_does_not_disable_later_steps(tmp_path) -> None:
@@ -122,3 +148,29 @@ async def test_event_sink_concurrent_records_remain_whole_json_lines(tmp_path) -
     rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
     assert {row["data"]["index"] for row in rows} == set(range(30))
     assert sink.write_error is None
+
+
+async def test_event_sink_slow_write_does_not_block_event_loop(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_append(*_args, **_kwargs) -> None:
+        started.set()
+        assert release.wait(1.0)
+
+    monkeypatch.setattr("opencollab.adapters.event_log.append_regular_text", slow_append)
+    sink = JsonlEventSink(str(tmp_path / "events.jsonl"))
+    owner = asyncio.create_task(sink.emit(SimpleNamespace(type="event", data={})))
+    timer = threading.Timer(0.15, release.set)
+    timer.start()
+    try:
+        await asyncio.sleep(0.02)
+        assert started.is_set()
+        assert not owner.done()
+    finally:
+        release.set()
+        timer.cancel()
+        await owner

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -64,6 +64,36 @@ def test_tracer_records_valid_jsonl_and_flushes(tmp_path) -> None:
     assert row["metrics"] == {"tokens": 3, "latency_s": 0.25}
 
 
+def test_tracer_reopen_continues_step_sequence(tmp_path) -> None:
+    first = Tracer("run", output_dir=str(tmp_path))
+    first.log_step("first", {})
+    first.log_step("second", {})
+    first.close()
+
+    resumed = Tracer("run", output_dir=str(tmp_path))
+    resumed.log_step("third", {})
+    resumed.close()
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "run.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["step"] for row in rows] == [1, 2, 3]
+
+
+def test_tracer_reopen_separates_an_unterminated_tail(tmp_path) -> None:
+    path = tmp_path / "run.jsonl"
+    path.write_text('{"step": 7}\n{"damaged":', encoding="utf-8")
+
+    resumed = Tracer("run", output_dir=str(tmp_path))
+    resumed.log_step("after-damage", {})
+    resumed.close()
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[-2] == '{"damaged":'
+    assert json.loads(lines[-1])["step"] == 8
+
+
 def test_tracer_write_failure_is_sticky(tmp_path, monkeypatch) -> None:
     tracer = Tracer("run", output_dir=str(tmp_path))
 

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -81,6 +81,34 @@ def test_tracer_reopen_continues_step_sequence(tmp_path) -> None:
     assert [row["step"] for row in rows] == [1, 2, 3]
 
 
+def test_tracer_rejects_overlapping_writer_for_the_same_file(tmp_path) -> None:
+    active = Tracer("run", output_dir=str(tmp_path))
+    try:
+        with pytest.raises(RuntimeError, match="already has an active writer"):
+            Tracer("run", output_dir=str(tmp_path))
+    finally:
+        active.close()
+
+    resumed = Tracer("run", output_dir=str(tmp_path))
+    resumed.log_step("after-release", {})
+    resumed.close()
+    row = json.loads((tmp_path / "run.jsonl").read_text(encoding="utf-8"))
+    assert row["step"] == 1
+
+
+def test_tracer_refuses_to_restart_when_bounded_tail_has_no_complete_step(
+    tmp_path,
+) -> None:
+    path = tmp_path / "run.jsonl"
+    oversized_record = json.dumps(
+        {"step": 7, "payload": "x" * (1024 * 1024 + 100)}
+    )
+    path.write_text(f"{oversized_record}\n", encoding="utf-8")
+
+    with pytest.raises(OSError, match="cannot safely recover trace step"):
+        Tracer("run", output_dir=str(tmp_path))
+
+
 def test_tracer_reopen_separates_an_unterminated_tail(tmp_path) -> None:
     path = tmp_path / "run.jsonl"
     path.write_text('{"step": 7}\n{"damaged":', encoding="utf-8")

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -72,6 +73,23 @@ def test_tracer_write_failure_is_sticky(tmp_path, monkeypatch) -> None:
     tracer.log_step("second", {})
     assert tracer.write_error == "OSError: disk full"
     assert tracer.dropped_steps == 2
+
+
+def test_tracer_serialization_fallback_does_not_disable_later_steps(tmp_path) -> None:
+    tracer = Tracer("run", output_dir=str(tmp_path))
+
+    tracer.log_step("path", {"workspace": Path("src")})
+    tracer.log_step("later", {"ok": True})
+    tracer.close()
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "run.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["type"] for row in rows] == ["path", "later"]
+    assert rows[0]["payload"]["workspace"] == "src"
+    assert tracer.write_error is None
+    assert tracer.dropped_steps == 0
 
 
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -118,8 +118,12 @@ def test_tracer_reopen_separates_an_unterminated_tail(tmp_path) -> None:
     resumed.close()
 
     lines = path.read_text(encoding="utf-8").splitlines()
-    assert lines[-2] == '{"damaged":'
-    assert json.loads(lines[-1])["step"] == 8
+    assert [json.loads(line)["step"] for line in lines] == [8]
+    quarantined = list(tmp_path.glob("run.jsonl.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == (
+        '{"step": 7}\n{"damaged":'
+    )
 
 
 def test_tracer_write_failure_is_sticky(tmp_path, monkeypatch) -> None:

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -130,6 +130,20 @@ def test_build_repo_map_stops_scanning_when_global_budget_is_exhausted(
     assert "truncated" in result
 
 
+def test_build_repo_map_reserves_root_budget_for_project_files(tmp_path):
+    for index in range(31):
+        (tmp_path / f"directory-{index:02}").mkdir()
+    for name in ("README.md", "pyproject.toml", "team.yaml"):
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    result = build_repo_map(str(tmp_path))
+
+    assert "README.md" in result
+    assert "pyproject.toml" in result
+    assert "team.yaml" in result
+    assert "directory-00/" in result
+
+
 def test_build_repo_map_missing_or_empty_workspace_returns_empty(tmp_path):
     assert build_repo_map(str(tmp_path / "nope")) == ""
     empty = tmp_path / "empty"

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -169,8 +169,18 @@ def test_build_repo_map_missing_or_empty_workspace_returns_empty(tmp_path):
 
 
 class _FakeEnv:
-    def __init__(self, stdout: str = "", returncode: int = 0, raises: bool = False):
-        self._result = ExecResult(returncode=returncode, stdout=stdout, stderr="")
+    def __init__(
+        self,
+        stdout: str = "",
+        returncode: int = 0,
+        raises: bool = False,
+        stderr: str = "",
+    ):
+        self._result = ExecResult(
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
         self._raises = raises
         self.cmds: list[str] = []
 
@@ -205,6 +215,24 @@ def test_build_repo_map_via_env_limits_enumeration_work() -> None:
     assert "truncated" in result
     assert "| head -n 6" in env.cmds[0]
     assert "| sort" not in env.cmds[0]
+
+
+def test_build_repo_map_via_env_checks_find_before_sorting():
+    env = _FakeEnv(stdout="./zeta.py\n./alpha.py\n")
+
+    result = run(build_repo_map_via_env(env))
+
+    assert "| sort" not in env.cmds[0]
+    assert result.index("alpha.py") < result.index("zeta.py")
+
+
+def test_build_repo_map_via_env_rejects_find_diagnostics():
+    env = _FakeEnv(
+        stdout="./visible.py\n",
+        stderr="find: unreadable directory",
+    )
+
+    assert run(build_repo_map_via_env(env)) == ""
 
 
 def test_build_repo_map_via_env_failure_or_empty_returns_empty():

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -192,6 +192,21 @@ def test_build_repo_map_balances_root_directories_and_other_files(tmp_path):
     assert "files omitted" in result
 
 
+def test_build_repo_map_reserves_root_siblings_before_directory_children(tmp_path):
+    for index in range(31):
+        directory = tmp_path / f"directory-{index:02}"
+        directory.mkdir()
+        (directory / "child.py").write_text("", encoding="utf-8")
+    root_files = ("AGENTS.md", "Makefile", "requirements.txt", "uv.lock")
+    for name in root_files:
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    result = build_repo_map(str(tmp_path), max_entries=35)
+
+    for name in root_files:
+        assert f"\n{name}\n" in f"\n{result}\n"
+
+
 def test_build_repo_map_missing_or_empty_workspace_returns_empty(tmp_path):
     assert build_repo_map(str(tmp_path / "nope")) == ""
     empty = tmp_path / "empty"

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -177,6 +177,21 @@ def test_build_repo_map_reserves_root_budget_for_project_files(tmp_path):
     assert "directory-00/" in result
 
 
+def test_build_repo_map_balances_root_directories_and_other_files(tmp_path):
+    for index in range(31):
+        (tmp_path / f"directory-{index:02}").mkdir()
+    for name in ("AGENTS.md", "Makefile", "requirements.txt", "uv.lock"):
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    result = build_repo_map(str(tmp_path))
+
+    for name in ("AGENTS.md", "Makefile", "requirements.txt", "uv.lock"):
+        assert name in result
+    assert "directory-00/" in result
+    assert "directories" in result
+    assert "files omitted" in result
+
+
 def test_build_repo_map_missing_or_empty_workspace_returns_empty(tmp_path):
     assert build_repo_map(str(tmp_path / "nope")) == ""
     empty = tmp_path / "empty"
@@ -194,11 +209,15 @@ class _FakeEnv:
         returncode: int = 0,
         raises: bool = False,
         stderr: str = "",
+        stdout_truncated: bool = False,
+        stderr_truncated: bool = False,
     ):
         self._result = ExecResult(
             returncode=returncode,
             stdout=stdout,
             stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
         )
         self._raises = raises
         self.cmds: list[str] = []
@@ -249,6 +268,15 @@ def test_build_repo_map_via_env_rejects_find_diagnostics():
     env = _FakeEnv(
         stdout="./visible.py\n",
         stderr="find: unreadable directory",
+    )
+
+    assert run(build_repo_map_via_env(env)) == ""
+
+
+def test_build_repo_map_via_env_rejects_truncated_traversal_output():
+    env = _FakeEnv(
+        stdout="./visible.py\n",
+        stdout_truncated=True,
     )
 
     assert run(build_repo_map_via_env(env)) == ""

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 
+from opencollab.adapters import repo_map as repo_map_module
 from opencollab.adapters.env import ExecResult, LocalEnvironment
 from opencollab.adapters.repo_map import (
     MAP_HEADER,
@@ -88,6 +89,47 @@ def test_build_repo_map_caps_entries_per_dir(tmp_path):
     assert "... (10 more)" in result
 
 
+def test_build_repo_map_stops_scanning_when_global_budget_is_exhausted(
+    tmp_path,
+    monkeypatch,
+):
+    for index in range(500):
+        (tmp_path / f"entry-{index:04}.txt").write_text("")
+    real_scandir = repo_map_module.os.scandir
+    scanned = 0
+
+    class CountingScandir:
+        def __init__(self, path):
+            self._inner = real_scandir(path)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            self._inner.close()
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            nonlocal scanned
+            entry = next(self._inner)
+            scanned += 1
+            return entry
+
+    monkeypatch.setattr(repo_map_module.os, "scandir", CountingScandir)
+
+    result = build_repo_map(
+        str(tmp_path),
+        max_entries=5,
+        max_dirs=2,
+        max_scanned_entries=32,
+    )
+
+    assert scanned <= 32
+    assert "truncated" in result
+
+
 def test_build_repo_map_missing_or_empty_workspace_returns_empty(tmp_path):
     assert build_repo_map(str(tmp_path / "nope")) == ""
     empty = tmp_path / "empty"
@@ -121,6 +163,20 @@ def test_build_repo_map_via_env_formats_find_output():
     assert "README.md" in result
     assert "\n.\n" not in result
     assert "find . -mindepth 1 -maxdepth" in env.cmds[0]
+
+
+def test_build_repo_map_via_env_limits_enumeration_work() -> None:
+    env = _FakeEnv(
+        stdout="\n".join(f"./path-{index:03}" for index in range(20)) + "\n"
+    )
+
+    result = run(build_repo_map_via_env(env, max_entries=5))
+
+    assert "path-004" in result
+    assert "path-005" not in result
+    assert "truncated" in result
+    assert "| head -n 6" in env.cmds[0]
+    assert "| sort" not in env.cmds[0]
 
 
 def test_build_repo_map_via_env_failure_or_empty_returns_empty():

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -10,6 +10,7 @@ registered-but-deferred source (the pre-existing behavior).
 from __future__ import annotations
 
 import asyncio
+import os
 
 from opencollab.adapters import repo_map as repo_map_module
 from opencollab.adapters.env import ExecResult, LocalEnvironment
@@ -266,7 +267,9 @@ def test_build_repo_map_via_env_limits_enumeration_work() -> None:
     assert "path-004" in result
     assert "path-005" not in result
     assert "truncated" in result
-    assert "| head -n 6" in env.cmds[0]
+    assert "mkfifo" in env.cmds[0]
+    assert "head -n 6" in env.cmds[0]
+    assert "| head" not in env.cmds[0]
     assert "| sort" not in env.cmds[0]
 
 
@@ -329,6 +332,45 @@ def test_build_repo_map_via_env_works_against_local_environment(tmp_path):
 
     assert "src/pkg/core.py" in result
     assert ".git" not in result
+
+
+def test_build_repo_map_via_env_accepts_find_sigpipe_at_the_entry_limit(tmp_path):
+    for index in range(100):
+        (tmp_path / f"entry-{index:03}.py").write_text("", encoding="utf-8")
+
+    result = run(
+        build_repo_map_via_env(LocalEnvironment(str(tmp_path)), max_entries=5)
+    )
+
+    assert "repository map truncated" in result
+    assert len(
+        [
+            line
+            for line in result.splitlines()
+            if line.startswith("entry-")
+        ]
+    ) == 5
+
+
+def test_build_repo_map_via_env_preserves_a_silent_find_failure(
+    tmp_path,
+    monkeypatch,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_find = fake_bin / "find"
+    fake_find.write_text(
+        "#!/bin/sh\nprintf './visible.py\\n'\nexit 7\n",
+        encoding="utf-8",
+    )
+    fake_find.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+
+    result = run(build_repo_map_via_env(LocalEnvironment(str(workspace))))
+
+    assert result == ""
 
 
 # --- injection into the PROJECT context layer --------------------------------

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -80,6 +80,20 @@ def test_build_repo_map_caps_total_chars(tmp_path):
     assert len(result) < 800
 
 
+def test_build_repo_map_truncates_only_at_complete_lines(tmp_path):
+    names = {f"module_with_a_long_name_{index:03}.py" for index in range(40)}
+    for name in names:
+        (tmp_path / name).write_text("", encoding="utf-8")
+
+    result = build_repo_map(str(tmp_path), max_chars=300)
+
+    for line in result.splitlines()[2:]:
+        entry = line.strip()
+        if not entry or "truncated" in entry:
+            continue
+        assert entry in names or entry.startswith("... (")
+
+
 def test_build_repo_map_caps_entries_per_dir(tmp_path):
     for i in range(40):
         (tmp_path / f"f{i:02}.py").write_text("")

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -63,6 +63,25 @@ def test_build_repo_map_skips_hidden_and_junk_dirs(tmp_path):
     assert "__pycache__" not in result
 
 
+def test_build_repo_map_keeps_common_hidden_project_configuration(tmp_path):
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    (tmp_path / ".github" / "workflows" / "ci.yml").write_text("", encoding="utf-8")
+    (tmp_path / ".devcontainer").mkdir()
+    (tmp_path / ".devcontainer" / "devcontainer.json").write_text("", encoding="utf-8")
+    (tmp_path / ".pre-commit-config.yaml").write_text("", encoding="utf-8")
+    (tmp_path / ".env").write_text("SECRET=hidden\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+
+    result = build_repo_map(str(tmp_path))
+
+    assert ".github/" in result
+    assert "ci.yml" in result
+    assert ".devcontainer/" in result
+    assert ".pre-commit-config.yaml" in result
+    assert ".env" not in result
+    assert not any(line.strip().startswith(".git/") for line in result.splitlines())
+
+
 def test_build_repo_map_respects_max_depth(tmp_path):
     result = build_repo_map(str(_workspace(tmp_path)), max_depth=2)
 
@@ -233,6 +252,24 @@ def test_build_repo_map_via_env_rejects_find_diagnostics():
     )
 
     assert run(build_repo_map_via_env(env)) == ""
+
+
+def test_build_repo_map_via_env_filters_hidden_paths_consistently():
+    env = _FakeEnv(
+        stdout=(
+            "./.github\n"
+            "./.github/workflows\n"
+            "./.github/workflows/ci.yml\n"
+            "./.env\n"
+            "./.git/HEAD\n"
+        )
+    )
+
+    result = run(build_repo_map_via_env(env))
+
+    assert ".github/workflows/ci.yml" in result
+    assert ".env" not in result
+    assert not any(line.strip().startswith(".git/") for line in result.splitlines())
 
 
 def test_build_repo_map_via_env_failure_or_empty_returns_empty():

--- a/tests/test_run_tests_tool.py
+++ b/tests/test_run_tests_tool.py
@@ -714,6 +714,36 @@ def test_run_tests_records_only_parser_backed_green_targets():
     assert tool.verified_targets == frozenset({target})
 
 
+def test_run_tests_invalidates_old_green_before_a_new_attempt_can_raise():
+    target = "tests/test_x.py::test_one"
+
+    class GreenThenError:
+        def __init__(self):
+            self.calls = 0
+
+        async def exec_cmd(self, _cmd, timeout=120.0):
+            self.calls += 1
+            if self.calls == 1:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=PLAIN_PASS_OUTPUT,
+                    stderr="",
+                )
+            raise RuntimeError("runner unavailable")
+
+    tool = RunTestsTool()
+    runtime = runtime_for(GreenThenError())
+    assert "Verdict: GREEN" in run(
+        tool.execute_with_runtime({"target": target}, runtime)
+    )
+    assert tool.verified_targets == frozenset({target})
+
+    with pytest.raises(RuntimeError, match="runner unavailable"):
+        run(tool.execute_with_runtime({"target": target}, runtime))
+
+    assert tool.verified_targets == frozenset()
+
+
 def test_run_tests_requires_named_target_pass_proof():
     runtime = runtime_for(FakeEnv(stdout=PASS_OUTPUT, returncode=0))
 

--- a/tests/test_run_tests_tool.py
+++ b/tests/test_run_tests_tool.py
@@ -146,6 +146,33 @@ def test_run_tests_accepts_plain_pytest_q_summary():
     assert "Verdict: GREEN" in result
 
 
+def test_run_tests_accepts_pass_proof_from_retained_capture_tail():
+    class TruncatedOutputEnv(FakeEnv):
+        async def exec_cmd(self, cmd: str, timeout: float = 120.0):
+            self.exec_calls.append((cmd, timeout))
+            return SimpleNamespace(
+                returncode=0,
+                stdout="captured head\n" + PLAIN_PASS_OUTPUT,
+                stderr="",
+                stdout_truncated=True,
+                stderr_truncated=False,
+                stdout_dropped_bytes=1_000_000,
+                stderr_dropped_bytes=0,
+            )
+
+    runtime = runtime_for(TruncatedOutputEnv())
+
+    result = run(
+        RunTestsTool().execute_with_runtime(
+            {"target": "tests/test_x.py::test_one"},
+            runtime,
+        )
+    )
+
+    assert "passed=1" in result
+    assert "Verdict: GREEN" in result
+
+
 def test_run_tests_directory_target_requires_a_descendant_pass():
     output = PLAIN_PASS_OUTPUT.replace(
         "tests/test_x.py::test_one",

--- a/tests/test_run_tests_tool.py
+++ b/tests/test_run_tests_tool.py
@@ -404,6 +404,36 @@ def test_run_tests_falls_back_to_native_runner_when_pytest_missing():
     assert "without an executed-target proof parser" in result
 
 
+def test_run_tests_does_not_fallback_from_a_green_pytest_message():
+    env = FakeEnv(
+        stdout=PLAIN_PASS_OUTPUT + "\nNo module named pytest\n",
+        returncode=0,
+    )
+    target = "tests/test_x.py::test_one"
+
+    result = run(
+        RunTestsTool().execute_with_runtime(
+            {"target": target},
+            runtime_for(env),
+        )
+    )
+
+    assert "Verdict: GREEN" in result
+    assert len(env.exec_calls) == 1
+
+
+def test_run_tests_does_not_fallback_from_failed_test_output_text():
+    env = FakeEnv(
+        stdout=FAIL_OUTPUT + "\nNo module named pytest\n",
+        returncode=1,
+    )
+
+    result = run(RunTestsTool().execute_with_runtime({}, runtime_for(env)))
+
+    assert "Verdict: RED" in result
+    assert len(env.exec_calls) == 1
+
+
 def test_run_tests_falls_back_to_go_runner_when_pytest_missing():
     env = ScriptedEnv([
         ("python -m pytest", 1, "No module named pytest"),

--- a/tests/test_run_tests_tool.py
+++ b/tests/test_run_tests_tool.py
@@ -774,6 +774,39 @@ def test_run_tests_invalidates_old_green_before_a_new_attempt_can_raise():
     assert tool.verified_targets == frozenset()
 
 
+@pytest.mark.parametrize("broad_target", ["tests/test_x.py", "./tests/test_x.py"])
+def test_run_tests_broader_attempt_invalidates_narrower_green_before_error(
+    broad_target,
+):
+    narrow_target = "tests/test_x.py::test_one"
+
+    class GreenThenError:
+        def __init__(self):
+            self.calls = 0
+
+        async def exec_cmd(self, _cmd, timeout=120.0):
+            self.calls += 1
+            if self.calls == 1:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=PLAIN_PASS_OUTPUT,
+                    stderr="",
+                )
+            raise RuntimeError("runner unavailable")
+
+    tool = RunTestsTool()
+    runtime = runtime_for(GreenThenError())
+    assert "Verdict: GREEN" in run(
+        tool.execute_with_runtime({"target": narrow_target}, runtime)
+    )
+    assert tool.verified_targets == frozenset({narrow_target})
+
+    with pytest.raises(RuntimeError, match="runner unavailable"):
+        run(tool.execute_with_runtime({"target": broad_target}, runtime))
+
+    assert tool.verified_targets == frozenset()
+
+
 def test_run_tests_requires_named_target_pass_proof():
     runtime = runtime_for(FakeEnv(stdout=PASS_OUTPUT, returncode=0))
 

--- a/tests/test_safe_files.py
+++ b/tests/test_safe_files.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import stat
+import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -59,6 +62,27 @@ def test_write_rejects_nested_ancestor_symlink(tmp_path) -> None:
     with pytest.raises(OSError, match="real directory"):
         write_regular_bytes_atomic(workspace / "link" / "sub" / "value", b"escape")
     assert not (outside / "sub").exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS system aliases only")
+@pytest.mark.parametrize(
+    ("alias_root", "canonical_root"),
+    [("/tmp", "/private/tmp"), ("/var/tmp", "/private/var/tmp")],
+)
+def test_macos_system_directory_aliases_match_canonical_paths(
+    alias_root,
+    canonical_root,
+) -> None:
+    with tempfile.TemporaryDirectory(dir=canonical_root) as directory:
+        canonical_directory = Path(directory)
+        alias_directory = Path(alias_root) / canonical_directory.relative_to(canonical_root)
+        alias_path = alias_directory / "state"
+        canonical_path = canonical_directory / "state"
+
+        write_regular_bytes_atomic(alias_path, b"payload")
+
+        assert read_regular_bytes(alias_path, max_bytes=7) == b"payload"
+        assert canonical_path.read_bytes() == b"payload"
 
 
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")

--- a/tests/test_safe_files.py
+++ b/tests/test_safe_files.py
@@ -34,7 +34,7 @@ def test_bounded_read_accepts_regular_file_and_rejects_large_file(tmp_path) -> N
 
 def test_ranged_text_read_handles_utf8_crlf_and_missing_final_newline(tmp_path) -> None:
     path = tmp_path / "value.txt"
-    path.write_bytes("零\r\n一\r\n二".encode())
+    path.write_bytes("alpha\r\nβeta\r\nγamma".encode())
 
     window = read_regular_text_range(
         path,
@@ -43,7 +43,7 @@ def test_ranged_text_read_handles_utf8_crlf_and_missing_final_newline(tmp_path) 
         max_chars=20,
     )
 
-    assert window.lines == ["一", "二"]
+    assert window.lines == ["βeta", "γamma"]
     assert window.start_line == 2
     assert window.total_lines == 3
     assert not window.has_more

--- a/tests/test_safe_files.py
+++ b/tests/test_safe_files.py
@@ -8,6 +8,7 @@ import stat
 
 import pytest
 
+import opencollab.adapters.safe_files as safe_files
 from opencollab.adapters.safe_files import (
     append_regular_text,
     create_regular_bytes_atomic,
@@ -149,6 +150,79 @@ def test_durable_unlink_removes_regular_file_and_reports_missing(tmp_path) -> No
     assert unlink_regular_file_durable(path)
     assert not path.exists()
     assert unlink_regular_file_durable(path) is False
+
+
+def test_atomic_replace_fsyncs_parent_after_publish(tmp_path, monkeypatch) -> None:
+    events: list[str] = []
+    original_fsync = os.fsync
+    original_replace = os.replace
+
+    def record_fsync(fd: int) -> None:
+        kind = "directory" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+        events.append(f"fsync:{kind}")
+        original_fsync(fd)
+
+    def record_replace(source, target) -> None:
+        events.append("replace")
+        original_replace(source, target)
+
+    monkeypatch.setattr(safe_files.os, "fsync", record_fsync)
+    monkeypatch.setattr(safe_files.os, "replace", record_replace)
+
+    write_regular_bytes_atomic(tmp_path / "state", b"new")
+
+    assert events[:3] == ["fsync:file", "replace", "fsync:directory"]
+
+
+def test_atomic_create_fsyncs_parent_after_link_and_unlink(tmp_path, monkeypatch) -> None:
+    events: list[str] = []
+    original_fsync = os.fsync
+    original_link = os.link
+    original_unlink = os.unlink
+
+    def record_fsync(fd: int) -> None:
+        kind = "directory" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+        events.append(f"fsync:{kind}")
+        original_fsync(fd)
+
+    def record_link(source, target, *, follow_symlinks=True) -> None:
+        events.append("link")
+        original_link(source, target, follow_symlinks=follow_symlinks)
+
+    def record_unlink(path) -> None:
+        events.append("unlink")
+        original_unlink(path)
+
+    monkeypatch.setattr(safe_files.os, "fsync", record_fsync)
+    monkeypatch.setattr(safe_files.os, "link", record_link)
+    monkeypatch.setattr(safe_files.os, "unlink", record_unlink)
+
+    create_regular_bytes_atomic(tmp_path / "state", b"new")
+
+    assert events[:4] == ["fsync:file", "link", "unlink", "fsync:directory"]
+
+
+def test_durable_unlink_fsyncs_parent_after_removal(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "owned"
+    path.write_bytes(b"owned")
+    events: list[str] = []
+    original_fsync = os.fsync
+    original_unlink = os.unlink
+
+    def record_fsync(fd: int) -> None:
+        kind = "directory" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+        events.append(f"fsync:{kind}")
+        original_fsync(fd)
+
+    def record_unlink(target) -> None:
+        events.append("unlink")
+        original_unlink(target)
+
+    monkeypatch.setattr(safe_files.os, "fsync", record_fsync)
+    monkeypatch.setattr(safe_files.os, "unlink", record_unlink)
+
+    assert unlink_regular_file_durable(path)
+    assert events == ["unlink", "fsync:directory"]
 
 
 def test_durable_unlink_rejects_symlinked_parent(tmp_path) -> None:

--- a/tests/test_safe_files.py
+++ b/tests/test_safe_files.py
@@ -17,6 +17,7 @@ from opencollab.adapters.safe_files import (
     create_regular_bytes_atomic,
     ensure_directory_no_symlinks,
     read_regular_bytes,
+    read_regular_text_range,
     unlink_regular_file_durable,
     write_regular_bytes_atomic,
     write_regular_file_atomic,
@@ -29,6 +30,41 @@ def test_bounded_read_accepts_regular_file_and_rejects_large_file(tmp_path) -> N
     assert read_regular_bytes(path, max_bytes=7) == b"payload"
     with pytest.raises(ValueError, match="exceeds"):
         read_regular_bytes(path, max_bytes=6)
+
+
+def test_ranged_text_read_handles_utf8_crlf_and_missing_final_newline(tmp_path) -> None:
+    path = tmp_path / "value.txt"
+    path.write_bytes("零\r\n一\r\n二".encode())
+
+    window = read_regular_text_range(
+        path,
+        offset=2,
+        limit=2,
+        max_chars=20,
+    )
+
+    assert window.lines == ["一", "二"]
+    assert window.start_line == 2
+    assert window.total_lines == 3
+    assert not window.has_more
+    assert not window.chars_truncated
+
+
+def test_ranged_text_read_bounds_one_long_line(tmp_path) -> None:
+    path = tmp_path / "value.txt"
+    path.write_bytes(b"x" * (1024 * 1024))
+
+    window = read_regular_text_range(
+        path,
+        offset=1,
+        limit=1,
+        max_chars=32,
+    )
+
+    assert window.lines == ["x" * 32]
+    assert window.total_lines is None
+    assert window.has_more
+    assert window.chars_truncated
 
 
 def test_missing_read_does_not_create_parent_directories(tmp_path) -> None:

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -67,6 +67,44 @@ def test_file_store_get_body_miss_returns_none(tmp_path):
     assert store.get_body("nonexistent") is None
 
 
+def test_file_store_parses_yaml_frontmatter_scalars(tmp_path):
+    skill_dir = tmp_path / "package"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """\
+---
+name: "review:code"
+description: >-
+  Review code carefully
+  and preserve evidence.
+---
+Run the review.
+""",
+        encoding="utf-8",
+    )
+
+    store = FileSkillStore(tmp_path)
+
+    assert store.list_manifests() == (
+        SkillManifest(
+            name="review:code",
+            description="Review code carefully and preserve evidence.",
+        ),
+    )
+    assert store.get_body("review:code") == "Run the review."
+
+
+def test_file_store_skips_non_mapping_yaml_frontmatter(tmp_path):
+    skill_dir = tmp_path / "package"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n- name\n- not-a-mapping\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+    assert FileSkillStore(tmp_path).list_manifests() == ()
+
+
 # --- FileSkillStore: robustness ---------------------------------------------
 
 

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -154,12 +154,17 @@ def test_file_store_skips_dir_without_skill_md(tmp_path):
 
 def test_file_store_rejects_oversized_body_instead_of_returning_partial_instructions(
     tmp_path,
+    caplog,
 ):
     big_body = "x" * (SKILL_BODY_MAX_CHARS + 5_000)
     _write_skill(tmp_path, "huge", description="Huge.", body=big_body)
     store = FileSkillStore(tmp_path)
     assert store.get_body("huge") is None
     assert store.list_manifests() == ()
+    assert store.load_diagnostics == (
+        f"skill 'huge' rejected: body exceeds {SKILL_BODY_MAX_CHARS} characters",
+    )
+    assert "skill 'huge' rejected" in caplog.text
 
 
 def test_file_store_returns_a_maximum_length_body_verbatim(tmp_path):

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -152,15 +152,41 @@ def test_file_store_skips_dir_without_skill_md(tmp_path):
 # --- FileSkillStore: size cap (single cap site) -----------------------------
 
 
-def test_file_store_caps_oversized_body(tmp_path):
+def test_file_store_rejects_oversized_body_instead_of_returning_partial_instructions(
+    tmp_path,
+):
     big_body = "x" * (SKILL_BODY_MAX_CHARS + 5_000)
     _write_skill(tmp_path, "huge", description="Huge.", body=big_body)
     store = FileSkillStore(tmp_path)
-    body = store.get_body("huge")
-    assert body is not None
-    assert len(body) <= SKILL_BODY_MAX_CHARS + 200  # cap + truncation marker
-    assert len(body) < len(big_body)
-    assert "truncated" in body
+    assert store.get_body("huge") is None
+    assert store.list_manifests() == ()
+
+
+def test_file_store_returns_a_maximum_length_body_verbatim(tmp_path):
+    body = "x" * SKILL_BODY_MAX_CHARS
+    _write_skill(tmp_path, "maximum", description="Maximum.", body=body)
+
+    store = FileSkillStore(tmp_path)
+
+    assert store.get_body("maximum") == body
+
+
+def test_file_store_rejects_large_files_at_a_bounded_read_limit(tmp_path, monkeypatch):
+    _write_skill(tmp_path, "huge", description="Huge.", body="x" * 100_000)
+    observed_limits: list[int] = []
+    original = skill_store_mod.read_regular_text
+
+    def observe_limit(path, *, max_bytes, encoding="utf-8"):
+        observed_limits.append(max_bytes)
+        return original(path, max_bytes=max_bytes, encoding=encoding)
+
+    monkeypatch.setattr(skill_store_mod, "read_regular_text", observe_limit)
+
+    store = FileSkillStore(tmp_path)
+
+    assert store.list_manifests() == ()
+    assert observed_limits
+    assert max(observed_limits) <= 64 * 1024
 
 
 def test_file_store_does_not_cap_small_body(tmp_path):

--- a/tests/test_tool_limits.py
+++ b/tests/test_tool_limits.py
@@ -6,12 +6,15 @@ budgets to its backend's context size. Unknown tools/kwargs fail fast.
 """
 
 import asyncio
+import shlex
+import sys
 
 import pytest
 
+from opencollab.adapters import _env_local as local_module
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.tools._output import truncate
-from opencollab.adapters.tools.bash import MAX_OUTPUT_CHARS
+from opencollab.adapters.tools.bash import MAX_OUTPUT_CHARS, BashTool
 from opencollab.application.tool_execution import ToolRuntime
 from opencollab.bootstrap.team_config import _build_team_config
 from opencollab.bootstrap.tool_registry import build_tools_for_role
@@ -110,6 +113,31 @@ def test_configured_cap_actually_bounds_bash_output(tmp_path):
 
     assert "truncated" in result
     assert len(result) < 400  # 100-char cap + exit-code line + marker
+
+
+def test_bash_reports_capture_loss_and_preserves_real_tail(tmp_path, monkeypatch):
+    monkeypatch.setattr(local_module, "PROCESS_OUTPUT_CAPTURE_BYTES", 32)
+    payload = "HEAD" + "x" * 100 + "TAIL"
+    command = (
+        f"{shlex.quote(sys.executable)} -c "
+        f"{shlex.quote(f'import os; os.write(1, {payload.encode()!r})')}"
+    )
+    runtime = ToolRuntime(
+        environment=LocalEnvironment(str(tmp_path)),
+        safety_policy=None,
+        permission_policy=None,
+    )
+
+    result = run(
+        BashTool(max_output_chars=80).execute_with_runtime(
+            {"command": command},
+            runtime,
+        )
+    )
+
+    assert "HEAD" in result
+    assert "TAIL" in result
+    assert "76 bytes of stdout dropped during capture" in result
 
 
 def test_all_capped_tools_accept_their_documented_kwargs():

--- a/tests/test_tool_output_clear_shaper.py
+++ b/tests/test_tool_output_clear_shaper.py
@@ -141,16 +141,25 @@ def test_history_trigger_target_never_negative_for_tiny_window():
     assert trigger >= 1 and target >= 1
 
 
-def test_model_context_window_lookup_matches_by_substring():
+def test_model_context_window_lookup_matches_bounded_families():
     from opencollab.adapters.llm import model_context_window
 
     assert model_context_window("claude-opus-4-8-2026") == 200_000
     assert model_context_window("gpt-4o-mini") == 128_000
     assert model_context_window("deepseek-chat") == 64_000
     assert model_context_window("glm-5.2") == 400_000
+    assert model_context_window("vendor/gpt-4o-mini") == 128_000
     assert model_context_window("k3") == 1_048_576
     assert model_context_window("kimi-for-coding") == 262_144
-    for near_miss in ("k3-256k", "kimi-k3", "kimi-k2.6", "kimi-k2.70", "kimi-for-coding-preview"):
+    for near_miss in (
+        "k3-256k",
+        "kimi-k3",
+        "kimi-k2.6",
+        "kimi-k2.70",
+        "kimi-for-coding-preview",
+        "gpt-4.1",
+        "vendor/gpt-4.1-mini",
+    ):
         assert model_context_window(near_miss) is None
     assert model_context_window("some-unknown-model") is None
     assert model_context_window(None) is None

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -546,6 +546,22 @@ def test_grep_tool_applies_max_results_globally():
     ]
 
 
+def test_grep_tool_does_not_fallback_after_normal_rg_no_match():
+    class NoMatchEnv(FakeEnv):
+        async def exec_cmd(self, cmd: str, timeout: float = 120.0):
+            self.exec_calls.append((cmd, timeout))
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    env = NoMatchEnv()
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(GrepTool().execute_with_runtime({"pattern": "absent"}, runtime))
+
+    assert result == "No matches found for pattern: absent"
+    assert len(env.exec_calls) == 1
+    assert "grep -r" not in env.exec_calls[0][0]
+
+
 def test_grep_tool_terminates_options_before_pattern_and_path():
     env = FakeEnv(stdout="")
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
@@ -559,10 +575,6 @@ def test_grep_tool_terminates_options_before_pattern_and_path():
 
     cmd, _ = env.exec_calls[0]
     assert "rg -n -- '--pre=touch pwned' --debug" in cmd
-    assert (
-        "grep -rEn --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.opencollab "
-        "-- '--pre=touch pwned' --debug"
-    ) in cmd
 
 
 def test_file_read_description_teaches_distill_and_forbids_reread():
@@ -583,7 +595,14 @@ def test_grep_tool_fallback_uses_ere_and_skips_session_dir():
     # nothing. It must also skip .opencollab so it can't "match" its own logged
     # pattern strings instead of real source. (Regression: a 100-step run stalled
     # because every alternation grep returned "No matches found".)
-    env = FakeEnv(stdout="")
+    class MissingRgEnv(FakeEnv):
+        async def exec_cmd(self, cmd: str, timeout: float = 120.0):
+            self.exec_calls.append((cmd, timeout))
+            if len(self.exec_calls) == 1:
+                return SimpleNamespace(returncode=127, stdout="", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    env = MissingRgEnv(stdout="")
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
 
     run(
@@ -592,8 +611,9 @@ def test_grep_tool_fallback_uses_ere_and_skips_session_dir():
         )
     )
 
-    cmd, _ = env.exec_calls[0]
-    assert "|| grep -rEn" in cmd
+    assert len(env.exec_calls) == 2
+    cmd, _ = env.exec_calls[1]
+    assert cmd.startswith("grep -rEn")
     assert " grep -rn " not in cmd  # the buggy BRE fallback must be gone
     assert "--exclude-dir=.opencollab" in cmd
 

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -322,6 +322,26 @@ def test_file_write_preserves_duplicate_old_str_error(tmp_path):
     )
 
 
+def test_file_write_rejects_overlapping_old_str_matches(tmp_path):
+    target = tmp_path / "note.txt"
+    target.write_text("aaa", encoding="utf-8")
+    env = LocalEnvironment(str(tmp_path))
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        FileWriteTool().execute_with_runtime(
+            {"path": "note.txt", "mode": "str_replace", "old_str": "aa", "new_str": "b"},
+            runtime,
+        )
+    )
+
+    assert (
+        result
+        == "Error: old_str found 2 times in note.txt. Provide more context to make it unique."
+    )
+    assert target.read_text(encoding="utf-8") == "aaa"
+
+
 # ---------------------------------------------------------------------------
 # Host write lock — only taken when I/O hits the host filesystem
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -562,6 +562,37 @@ def test_grep_tool_does_not_fallback_after_normal_rg_no_match():
     assert "grep -r" not in env.exec_calls[0][0]
 
 
+@pytest.mark.parametrize(
+    ("returncode", "stderr", "expected"),
+    [
+        (2, "regex parse error", "regex parse error"),
+        (2, "path does not exist", "path does not exist"),
+        (-1, "Command timed out after 30s", "timed out"),
+    ],
+)
+def test_grep_tool_reports_backend_failures(returncode, stderr, expected):
+    class FailedSearchEnv(FakeEnv):
+        async def exec_cmd(self, cmd: str, timeout: float = 120.0):
+            self.exec_calls.append((cmd, timeout))
+            return SimpleNamespace(
+                returncode=returncode,
+                stdout="",
+                stderr=stderr,
+                stdout_truncated=False,
+                stderr_truncated=False,
+            )
+
+    env = FailedSearchEnv()
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(GrepTool().execute_with_runtime({"pattern": "["}, runtime))
+
+    assert result.startswith("Error: rg search failed")
+    assert expected in result
+    assert "No matches" not in result
+    assert "2>/dev/null" not in env.exec_calls[0][0]
+
+
 def test_grep_tool_terminates_options_before_pattern_and_path():
     env = FakeEnv(stdout="")
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -527,6 +527,25 @@ def test_grep_tool_rejects_non_integer_max_results_before_exec():
     assert env.exec_calls == []
 
 
+def test_grep_tool_applies_max_results_globally():
+    env = FakeEnv(
+        stdout="\n".join(f"src/file_{index}.py:1:needle" for index in range(6))
+    )
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        GrepTool().execute_with_runtime(
+            {"pattern": "needle", "max_results": 2},
+            runtime,
+        )
+    )
+
+    assert result.splitlines() == [
+        "src/file_0.py:1:needle",
+        "src/file_1.py:1:needle",
+    ]
+
+
 def test_grep_tool_terminates_options_before_pattern_and_path():
     env = FakeEnv(stdout="")
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
@@ -539,7 +558,7 @@ def test_grep_tool_terminates_options_before_pattern_and_path():
     )
 
     cmd, _ = env.exec_calls[0]
-    assert "rg -n --max-count 50 -- '--pre=touch pwned' --debug" in cmd
+    assert "rg -n -- '--pre=touch pwned' --debug" in cmd
     assert (
         "grep -rEn --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.opencollab "
         "-- '--pre=touch pwned' --debug"

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -125,6 +125,26 @@ def test_bash_rejects_invalid_output_limits_at_construction(value):
         BashTool(max_output_chars=value)
 
 
+@pytest.mark.parametrize(
+    ("tool_type", "parameter"),
+    [
+        (FileReadTool, "max_read_chars"),
+        (GrepTool, "max_grep_chars"),
+        (GitDiffTool, "max_diff_chars"),
+        (GitDiffTool, "max_status_chars"),
+        (RunTestsTool, "max_traceback_chars"),
+    ],
+)
+@pytest.mark.parametrize("value", [0, -1, False, 1.5])
+def test_public_tools_reject_invalid_output_limits_at_construction(
+    tool_type,
+    parameter,
+    value,
+):
+    with pytest.raises(ValueError, match="positive integer"):
+        tool_type(**{parameter: value})
+
+
 def test_bash_tool_without_env_returns_existing_error():
     runtime = ToolRuntime(environment=None, safety_policy=None, permission_policy=None)
 

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -279,6 +279,42 @@ def test_file_write_create_and_str_replace(tmp_path):
     assert (workspace / "note.txt").read_text(encoding="utf-8") == "beta\n"
 
 
+@pytest.mark.parametrize("existing", [False, True])
+def test_file_write_create_requires_explicit_content(tmp_path, existing):
+    target = tmp_path / "note.txt"
+    if existing:
+        target.write_text("KEEP", encoding="utf-8")
+    env = LocalEnvironment(str(tmp_path))
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        FileWriteTool().execute_with_runtime(
+            {"path": "note.txt", "mode": "create"},
+            runtime,
+        )
+    )
+
+    assert result == "Error: content is required for create mode."
+    assert target.exists() is existing
+    if existing:
+        assert target.read_text(encoding="utf-8") == "KEEP"
+
+
+def test_file_write_create_allows_explicit_empty_content(tmp_path):
+    env = LocalEnvironment(str(tmp_path))
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(
+        FileWriteTool().execute_with_runtime(
+            {"path": "empty.txt", "mode": "create", "content": ""},
+            runtime,
+        )
+    )
+
+    assert "Created/wrote" in result
+    assert (tmp_path / "empty.txt").read_text(encoding="utf-8") == ""
+
+
 def test_file_write_preserves_workspace_path_jail(tmp_path):
     workspace = tmp_path / "ws"
     workspace.mkdir()

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -593,6 +593,20 @@ def test_grep_tool_reports_backend_failures(returncode, stderr, expected):
     assert "2>/dev/null" not in env.exec_calls[0][0]
 
 
+def test_grep_tool_includes_hidden_project_paths_with_noise_exclusions():
+    env = FakeEnv(stdout=".github/workflows/ci.yml:1:needle\n")
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(GrepTool().execute_with_runtime({"pattern": "needle"}, runtime))
+
+    assert result == ".github/workflows/ci.yml:1:needle"
+    command = env.exec_calls[0][0]
+    assert "rg -n --hidden " in command
+    assert "-g '!.git/**'" in command
+    assert "-g '!.venv/**'" in command
+    assert "-g '!.opencollab/**'" in command
+
+
 def test_grep_tool_terminates_options_before_pattern_and_path():
     env = FakeEnv(stdout="")
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
@@ -605,7 +619,8 @@ def test_grep_tool_terminates_options_before_pattern_and_path():
     )
 
     cmd, _ = env.exec_calls[0]
-    assert "rg -n -- '--pre=touch pwned' --debug" in cmd
+    assert "rg -n --hidden" in cmd
+    assert "-- '--pre=touch pwned' --debug" in cmd
 
 
 def test_file_read_description_teaches_distill_and_forbids_reread():

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -119,6 +119,12 @@ def test_tool_runtime_confirm_fn_returns_none_without_permission_policy():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("value", [0, -1, False, 1.5])
+def test_bash_rejects_invalid_output_limits_at_construction(value):
+    with pytest.raises(ValueError, match="positive integer"):
+        BashTool(max_output_chars=value)
+
+
 def test_bash_tool_without_env_returns_existing_error():
     runtime = ToolRuntime(environment=None, safety_policy=None, permission_policy=None)
 

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -187,6 +187,27 @@ def test_file_read_reads_through_runtime(tmp_path):
     assert "1\talpha" not in result
 
 
+def test_file_read_small_range_bypasses_full_file_limit(tmp_path):
+    target = tmp_path / "large.txt"
+    target.write_bytes(b"first\nsecond\n" + b"x" * (5 * 1024 * 1024))
+    runtime = ToolRuntime(
+        environment=LocalEnvironment(str(tmp_path)),
+        safety_policy=None,
+        permission_policy=None,
+    )
+
+    result = run(
+        FileReadTool().execute_with_runtime(
+            {"path": "large.txt", "offset": 1, "limit": 2},
+            runtime,
+        )
+    )
+
+    assert "1\tfirst" in result
+    assert "2\tsecond" in result
+    assert "more lines below" in result
+
+
 def test_file_read_preserves_workspace_path_jail(tmp_path):
     workspace = tmp_path / "ws"
     workspace.mkdir()
@@ -219,7 +240,7 @@ def test_file_read_preserves_permission_error_string(monkeypatch, tmp_path):
     async def raise_permission_error(*args, **kwargs):
         raise PermissionError("denied")
 
-    monkeypatch.setattr(LocalEnvironment, "read_file", raise_permission_error)
+    monkeypatch.setattr(LocalEnvironment, "read_text_range", raise_permission_error)
     env = LocalEnvironment(str(tmp_path))
     runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
 

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from rich.text import Text
 
 from opencollab.adapters.tui import TUI
+from opencollab.adapters.tui import renderer as renderer_mod
 from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
 
 
@@ -411,6 +412,40 @@ def test_live_timeline_cap_does_not_truncate_complete_agent_history():
     history = tui.render_selected_history()
     assert "activity 0" in history
     assert "activity 99" in history
+
+
+def test_agent_history_has_a_global_per_agent_bound():
+    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
+    state = tui._state_for(1)
+
+    for index in range(renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 20):
+        tui._append_activity(
+            (f"bounded activity {index}", tui._STYLE_MUTED),
+            state=state,
+        )
+
+    assert len(state.history_blocks) == renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT
+    tui.select_agent(1)
+    history = tui.render_selected_history()
+    assert "bounded activity 0" not in history
+    assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in history
+
+
+def test_completed_agent_render_states_have_a_global_bound():
+    tui = TUI()
+
+    for aid in range(1, renderer_mod.MAX_TERMINAL_AGENT_STATES + 10):
+        tui.event_handler(
+            SchedulerEvent(
+                "agent_completed",
+                {"aid": aid, "role": "worker", "latency": 0.1},
+            )
+        )
+
+    retained_children = {aid for aid in tui._agent_states if aid != 0}
+    assert len(retained_children) <= renderer_mod.MAX_TERMINAL_AGENT_STATES
+    assert 1 not in retained_children
+    assert renderer_mod.MAX_TERMINAL_AGENT_STATES + 9 in retained_children
 
 
 def test_user_message_is_recorded_only_in_target_history_and_revises_cache_key():

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -499,14 +499,30 @@ def test_terminal_agent_summaries_have_a_global_bound():
     assert tui.terminal_agent_summaries_omitted == 10
 
 
-def test_terminal_provider_entries_cannot_recreate_evicted_render_states():
+@pytest.mark.parametrize(
+    ("event_type", "provider_phase"),
+    [
+        ("agent_completed", "done"),
+        ("agent_failed", "error"),
+        ("agent_cancelled", "stopped"),
+    ],
+)
+def test_terminal_provider_entries_cannot_recreate_evicted_render_states(
+    event_type,
+    provider_phase,
+):
     tui = TUI(Console(file=StringIO(), width=100, color_system=None))
     tui._live_paused = True
     total = renderer_mod.MAX_TERMINAL_AGENT_STATES + 300
     roster = [
         {"aid": 0, "role": "lead", "phase": "idle", "busy": False},
         *[
-            {"aid": aid, "role": "worker", "phase": "done", "busy": False}
+            {
+                "aid": aid,
+                "role": "worker",
+                "phase": provider_phase,
+                "busy": False,
+            }
             for aid in range(1, total + 1)
         ],
     ]
@@ -514,8 +530,13 @@ def test_terminal_provider_entries_cannot_recreate_evicted_render_states():
     for aid in range(1, total + 1):
         tui.event_handler(
             SchedulerEvent(
-                "agent_completed",
-                {"aid": aid, "role": "worker", "latency": 0.1},
+                event_type,
+                {
+                    "aid": aid,
+                    "role": "worker",
+                    "latency": 0.1,
+                    "error": "boom",
+                },
             )
         )
 

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -16,6 +16,7 @@ from rich.text import Text
 
 from opencollab.adapters.tui import TUI
 from opencollab.adapters.tui import renderer as renderer_mod
+from opencollab.adapters.tui import renderer_events as renderer_events_mod
 from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
 
 
@@ -331,6 +332,8 @@ def test_compat_filter_setting_keeps_scheduler_roster_visible():
 
 def test_agent_selection_wraps_through_live_agents_only():
     tui = TUI()
+    tui._state_for(2)
+    tui._state_for(5)
     tui.set_team_provider(lambda: [
         {"aid": 0, "role": "lead", "phase": "idle", "busy": False},
         {"aid": None, "role": "analyst", "phase": "available", "busy": False},
@@ -414,6 +417,25 @@ def test_live_timeline_cap_does_not_truncate_complete_agent_history():
     assert "activity 99" in history
 
 
+def test_all_timeline_append_paths_share_one_global_bound():
+    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
+    state = tui._state_for(1)
+
+    for index in range(renderer_events_mod.MAX_TIMELINE_BLOCKS * 3):
+        tui.event_handler(
+            SessionRuntimeEvent(
+                "text_delta",
+                {"content": f"assistant {index}", "aid": 1},
+            )
+        )
+        tui.event_handler(
+            SessionRuntimeEvent("error", {"reason": f"failure {index}", "aid": 1})
+        )
+        tui.record_user_message(1, f"user {index}")
+
+    assert len(state.timeline_blocks) == renderer_events_mod.MAX_TIMELINE_BLOCKS
+
+
 def test_agent_history_has_a_global_per_agent_bound():
     tui = TUI(Console(file=StringIO(), width=100, color_system=None))
     state = tui._state_for(1)
@@ -475,6 +497,35 @@ def test_terminal_agent_summaries_have_a_global_bound():
         == renderer_mod.MAX_TERMINAL_AGENT_SUMMARIES
     )
     assert tui.terminal_agent_summaries_omitted == 10
+
+
+def test_terminal_provider_entries_cannot_recreate_evicted_render_states():
+    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
+    tui._live_paused = True
+    total = renderer_mod.MAX_TERMINAL_AGENT_STATES + 300
+    roster = [
+        {"aid": 0, "role": "lead", "phase": "idle", "busy": False},
+        *[
+            {"aid": aid, "role": "worker", "phase": "done", "busy": False}
+            for aid in range(1, total + 1)
+        ],
+    ]
+    tui.set_team_provider(lambda: roster)
+    for aid in range(1, total + 1):
+        tui.event_handler(
+            SchedulerEvent(
+                "agent_completed",
+                {"aid": aid, "role": "worker", "latency": 0.1},
+            )
+        )
+
+    retained = len(tui._agent_states)
+    for aid in range(1, total + 1):
+        tui.select_agent(aid)
+        tui.render_selected_history()
+
+    assert retained <= renderer_mod.MAX_TERMINAL_AGENT_STATES + 1
+    assert len(tui._agent_states) == retained
 
 
 def test_user_message_is_recorded_only_in_target_history_and_revises_cache_key():

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -428,6 +428,7 @@ def test_agent_history_has_a_global_per_agent_bound():
     tui.select_agent(1)
     history = tui.render_selected_history()
     assert "bounded activity 0" not in history
+    assert "20 older history blocks omitted" in history
     assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in history
 
 
@@ -446,6 +447,34 @@ def test_completed_agent_render_states_have_a_global_bound():
     assert len(retained_children) <= renderer_mod.MAX_TERMINAL_AGENT_STATES
     assert 1 not in retained_children
     assert renderer_mod.MAX_TERMINAL_AGENT_STATES + 9 in retained_children
+    summaries = {summary["aid"]: summary for summary in tui.terminal_agent_summaries}
+    assert summaries[1]["role"] == "worker"
+    assert summaries[1]["state"] == "idle"
+    assert summaries[1]["retained_history_blocks"] > 0
+
+
+def test_terminal_agent_summaries_have_a_global_bound():
+    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
+    tui._live_paused = True
+    total = (
+        renderer_mod.MAX_TERMINAL_AGENT_STATES
+        + renderer_mod.MAX_TERMINAL_AGENT_SUMMARIES
+        + 10
+    )
+
+    for aid in range(1, total + 1):
+        tui.event_handler(
+            SchedulerEvent(
+                "agent_completed",
+                {"aid": aid, "role": "worker", "latency": 0.1},
+            )
+        )
+
+    assert (
+        len(tui.terminal_agent_summaries)
+        == renderer_mod.MAX_TERMINAL_AGENT_SUMMARIES
+    )
+    assert tui.terminal_agent_summaries_omitted == 10
 
 
 def test_user_message_is_recorded_only_in_target_history_and_revises_cache_key():

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -118,7 +118,7 @@ def test_workflow_run_prints_event_and_result_markup_literally(monkeypatch):
 
     reg = Registry()
     reg.register(literal.__workflow_spec__)
-    monkeypatch.setattr(workflow_cli, "load_registry", lambda: reg)
+    monkeypatch.setattr(workflow_cli, "load_registry", lambda _workspace=".": reg)
     monkeypatch.setattr(workflow_cli, "missing_api_key_for", lambda *a, **k: False)
 
     async def fake_run_workflow(_spec, _args, **kwargs):

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -32,17 +32,21 @@ def _stub_registry() -> Registry:
     return reg
 
 
-def test_workflow_run_prints_result_as_json(monkeypatch):
+def test_workflow_run_prints_result_as_json(tmp_path, monkeypatch):
     @workflow(name="echo", description="echoes its args")
     async def echo(ctx, args):
         return {"received": args}
 
     reg = Registry()
     reg.register(echo.__workflow_spec__)
-    monkeypatch.setattr(workflow_cli, "load_registry", lambda: reg)
-    monkeypatch.setattr(workflow_cli, "missing_api_key_for", lambda *a, **k: False)
-
     captured: dict[str, Any] = {}
+
+    def fake_load_registry(workspace="."):
+        captured["registry_workspace"] = workspace
+        return reg
+
+    monkeypatch.setattr(workflow_cli, "load_registry", fake_load_registry)
+    monkeypatch.setattr(workflow_cli, "missing_api_key_for", lambda *a, **k: False)
 
     async def fake_run_workflow(spec_or_fn, args, **kwargs):
         captured["spec_or_fn"] = spec_or_fn
@@ -53,9 +57,22 @@ def test_workflow_run_prints_result_as_json(monkeypatch):
 
     monkeypatch.setattr(workflow_cli, "run_workflow", fake_run_workflow)
 
+    workspace = tmp_path / "example-workspace"
+    workspace.mkdir()
     result = runner.invoke(
         workflow_cli.app,
-        ["run", "echo", "--args", '{"name": "bob"}', "--budget", "50000", "--concurrency", "2"],
+        [
+            "run",
+            "echo",
+            "--args",
+            '{"name": "bob"}',
+            "--budget",
+            "50000",
+            "--concurrency",
+            "2",
+            "--workspace",
+            str(workspace),
+        ],
     )
 
     assert result.exit_code == 0
@@ -64,6 +81,33 @@ def test_workflow_run_prints_result_as_json(monkeypatch):
     assert captured["args"] == {"name": "bob"}
     assert captured["kwargs"]["budget"] == 50000
     assert captured["kwargs"]["max_concurrency"] == 2
+    assert captured["registry_workspace"] == str(workspace)
+
+
+def test_load_registry_resolves_relative_directory_from_workspace(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    workflow_dir = project / "custom-workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "example.py").write_text(
+        "\n".join(
+            [
+                "from opencollab.application.workflow_registry import workflow",
+                "",
+                '@workflow(name="workspace-flow", description="workspace scoped")',
+                "async def run(ctx, args):",
+                "    return None",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setenv("OPENCOLLAB_WORKFLOWS_DIR", "custom-workflows")
+
+    registry = workflow_cli.load_registry(str(project))
+
+    assert registry.get("workspace-flow").description == "workspace scoped"
 
 
 def test_workflow_run_default_budget_raised_to_1m(monkeypatch):
@@ -74,13 +118,14 @@ def test_workflow_run_default_budget_raised_to_1m(monkeypatch):
     raised value reaches the context: ``--budget`` is None, so run_workflow falls
     back to ``cfg['budget']``.
     """
+
     @workflow(name="echo", description="echoes its args")
     async def echo(ctx, args):
         return {"ok": True}
 
     reg = Registry()
     reg.register(echo.__workflow_spec__)
-    monkeypatch.setattr(workflow_cli, "load_registry", lambda: reg)
+    monkeypatch.setattr(workflow_cli, "load_registry", lambda _workspace=".": reg)
     monkeypatch.setattr(workflow_cli, "missing_api_key_for", lambda *a, **k: False)
     # A small config fallback budget so the 1M floor is the value that wins.
     monkeypatch.setattr(
@@ -115,13 +160,14 @@ def test_workflow_run_default_budget_raised_to_1m(monkeypatch):
 
 def test_workflow_run_explicit_budget_not_raised(monkeypatch):
     """An explicit --budget below 1M is honored verbatim, not floored up."""
+
     @workflow(name="echo", description="echoes its args")
     async def echo(ctx, args):
         return {"ok": True}
 
     reg = Registry()
     reg.register(echo.__workflow_spec__)
-    monkeypatch.setattr(workflow_cli, "load_registry", lambda: reg)
+    monkeypatch.setattr(workflow_cli, "load_registry", lambda _workspace=".": reg)
     monkeypatch.setattr(workflow_cli, "missing_api_key_for", lambda *a, **k: False)
 
     captured: dict[str, Any] = {}
@@ -133,9 +179,7 @@ def test_workflow_run_explicit_budget_not_raised(monkeypatch):
 
     monkeypatch.setattr(workflow_cli, "run_workflow", fake_run_workflow)
 
-    result = runner.invoke(
-        workflow_cli.app, ["run", "echo", "--args", "{}", "--budget", "12345"]
-    )
+    result = runner.invoke(workflow_cli.app, ["run", "echo", "--args", "{}", "--budget", "12345"])
 
     assert result.exit_code == 0
     # Explicit budget is passed through and the cfg budget equals it (resolve_config
@@ -145,7 +189,7 @@ def test_workflow_run_explicit_budget_not_raised(monkeypatch):
 
 
 def test_workflow_run_unknown_name_exits_nonzero(monkeypatch):
-    monkeypatch.setattr(workflow_cli, "load_registry", lambda: _stub_registry())
+    monkeypatch.setattr(workflow_cli, "load_registry", lambda _workspace=".": _stub_registry())
 
     result = runner.invoke(workflow_cli.app, ["run", "nope", "--args", "{}"])
 
@@ -153,7 +197,7 @@ def test_workflow_run_unknown_name_exits_nonzero(monkeypatch):
 
 
 def test_workflow_run_invalid_json_args_exits_nonzero(monkeypatch):
-    monkeypatch.setattr(workflow_cli, "load_registry", lambda: _stub_registry())
+    monkeypatch.setattr(workflow_cli, "load_registry", lambda _workspace=".": _stub_registry())
 
     result = runner.invoke(workflow_cli.app, ["run", "alpha", "--args", "{not-json"])
 

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -7,6 +7,7 @@ drive the Typer commands through ``CliRunner`` and assert on stdout.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import Any
 
 from typer.testing import CliRunner
@@ -108,6 +109,37 @@ def test_load_registry_resolves_relative_directory_from_workspace(tmp_path, monk
     registry = workflow_cli.load_registry(str(project))
 
     assert registry.get("workspace-flow").description == "workspace scoped"
+
+
+def test_workflow_run_prints_event_and_result_markup_literally(monkeypatch):
+    @workflow(name="literal", description="returns bracketed data")
+    async def literal(ctx, args):
+        return None
+
+    reg = Registry()
+    reg.register(literal.__workflow_spec__)
+    monkeypatch.setattr(workflow_cli, "load_registry", lambda: reg)
+    monkeypatch.setattr(workflow_cli, "missing_api_key_for", lambda *a, **k: False)
+
+    async def fake_run_workflow(_spec, _args, **kwargs):
+        await kwargs["event_sink"].emit(
+            SimpleNamespace(kind="log", message="[x] [link=unterminated")
+        )
+        return {"values": ["[bold]literal[/bold]", "[x]"]}
+
+    monkeypatch.setattr(workflow_cli, "run_workflow", fake_run_workflow)
+
+    result = runner.invoke(
+        workflow_cli.app,
+        ["run", "literal", "--args", "{}", "--budget", "50000", "--no-save"],
+    )
+
+    assert result.exit_code == 0
+    assert "-- [x] [link=unterminated" in result.stdout
+    json_start = result.stdout.rfind("\n{") + 1
+    assert json.loads(result.stdout[json_start:]) == {
+        "values": ["[bold]literal[/bold]", "[x]"],
+    }
 
 
 def test_workflow_run_default_budget_raised_to_1m(monkeypatch):

--- a/tests/test_working_tree_probe.py
+++ b/tests/test_working_tree_probe.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from opencollab.adapters._env_base import ExecResult
 from opencollab.adapters.working_tree import EnvWorkingTreeProbe
 
 
@@ -38,6 +39,17 @@ class RecordingEnv:
     async def exec_cmd(self, cmd: str, timeout: float = 120.0):
         self.commands.append(cmd)
         return SimpleNamespace(stdout=self._stdout)
+
+
+class ScriptedEnv:
+    def __init__(self, results, *, workspace: str = "/ws") -> None:
+        self.workspace = workspace
+        self._results = list(results)
+        self.commands: list[str] = []
+
+    async def exec_cmd(self, cmd: str, timeout: float = 120.0):
+        self.commands.append(cmd)
+        return self._results.pop(0)
 
 
 def test_changed_excluding_issues_exclude_pathspec_and_returns_bool():
@@ -89,6 +101,41 @@ def test_changed_excluding_empty_falls_back_to_plain_status():
     ]
 
 
+@pytest.mark.parametrize(
+    "result",
+    [
+        ExecResult(1, "partial", "failed"),
+        ExecResult(0, "partial", "", stdout_truncated=True),
+        ExecResult(0, "partial", "", stdout_dropped_bytes=9),
+        ExecResult(0, "", "partial", stderr_truncated=True),
+    ],
+)
+def test_diff_rejects_incomplete_status_evidence(result):
+    probe = EnvWorkingTreeProbe(ScriptedEnv([result]), workspace="/ws")
+
+    with pytest.raises(RuntimeError, match="working-tree status"):
+        run(probe.diff())
+
+
+def test_diff_rejects_truncated_tracked_patch():
+    env = ScriptedEnv(
+        [
+            ExecResult(0, " M source.py\n", ""),
+            ExecResult(
+                0,
+                "diff --git a/source.py b/source.py\n",
+                "",
+                stdout_truncated=True,
+                stdout_dropped_bytes=128,
+            ),
+        ]
+    )
+    probe = EnvWorkingTreeProbe(env, workspace="/ws")
+
+    with pytest.raises(RuntimeError, match="tracked diff exceeded capture limit"):
+        run(probe.diff())
+
+
 # --------------------------------------------------------------------------- #
 # real-git integration (skipped where git is unavailable)
 # --------------------------------------------------------------------------- #
@@ -104,7 +151,7 @@ class _RealEnv:
         proc = subprocess.run(
             cmd, shell=True, capture_output=True, text=True
         )
-        return SimpleNamespace(stdout=proc.stdout, stderr=proc.stderr)
+        return ExecResult(proc.returncode, proc.stdout, proc.stderr)
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -158,3 +205,54 @@ def test_real_git_source_edit_alongside_injected_is_detected(tmp_path: Path):
     assert run(probe.changed()) is True
     # Excluding only the injected test still sees the source edit -> True.
     assert run(probe.changed_excluding([inj])) is True
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+def test_real_git_diff_covers_staged_unstaged_and_untracked_changes(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "unstaged.py").write_text("unstaged = 1\n")
+    (repo / "staged.py").write_text("staged = 1\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    (repo / "unstaged.py").write_text("unstaged = 2\n")
+    (repo / "staged.py").write_text("staged = 2\n")
+    _git(repo, "add", "staged.py")
+    (repo / "new file.py").write_text("untracked = 3\n")
+
+    probe = EnvWorkingTreeProbe(_RealEnv(str(repo)), workspace=str(repo))
+    evidence = run(probe.diff())
+
+    assert run(probe.changed()) is True
+    assert " M unstaged.py" in evidence
+    assert "M  staged.py" in evidence
+    assert "?? \"new file.py\"" in evidence
+    assert "-unstaged = 1" in evidence
+    assert "+unstaged = 2" in evidence
+    assert "-staged = 1" in evidence
+    assert "+staged = 2" in evidence
+    assert "+untracked = 3" in evidence
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+def test_real_git_untracked_empty_file_remains_visible_in_diff_evidence(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "tracked.py").write_text("x = 1\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+    (repo / "empty.txt").touch()
+
+    evidence = run(
+        EnvWorkingTreeProbe(_RealEnv(str(repo)), workspace=str(repo)).diff()
+    )
+
+    assert "?? empty.txt" in evidence
+    assert "[Untracked file: empty.txt]" in evidence

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -279,6 +279,52 @@ async def test_git_worktree_rejects_dirty_source_snapshot(tmp_path) -> None:
     assert not _branch_exists(source, branch)
 
 
+async def test_git_worktree_preserves_ignored_output_until_recovered(
+    tmp_path,
+) -> None:
+    source = _repo(tmp_path / "repo")
+    (source / ".gitignore").write_text("*.ignored\n", encoding="utf-8")
+    _git(source, "add", ".gitignore")
+    _git(source, "commit", "-qm", "add ignore rule")
+    env = WorktreeEnvironment(str(source), branch_name="ignored-output")
+    workspace = Path(await env.setup())
+    (workspace / "lost.ignored").write_text("deliver me\n", encoding="utf-8")
+    (workspace / "shown.txt").write_text("shown\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="ignored untracked files"):
+        await env.get_diff()
+    with pytest.raises(RuntimeError, match="worktree retained"):
+        await env.cleanup()
+
+    assert workspace.is_dir()
+    assert (workspace / "lost.ignored").read_text(encoding="utf-8") == "deliver me\n"
+    (workspace / "lost.ignored").unlink()
+    assert "shown.txt" in await env.get_diff()
+    await env.cleanup()
+    assert not workspace.exists()
+
+
+async def test_git_worktree_preserves_oversized_diff_until_recovered(
+    tmp_path,
+) -> None:
+    source = _repo(tmp_path / "repo")
+    env = WorktreeEnvironment(str(source), branch_name="oversized-output")
+    workspace = Path(await env.setup())
+    (workspace / "large.txt").write_text("x" * (1_200_000), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="exceeded capture limit"):
+        await env.get_diff()
+    with pytest.raises(RuntimeError, match="worktree retained"):
+        await env.cleanup()
+
+    assert workspace.is_dir()
+    assert (workspace / "large.txt").stat().st_size == 1_200_000
+    (workspace / "large.txt").unlink()
+    assert await env.get_diff() == ""
+    await env.cleanup()
+    assert not workspace.exists()
+
+
 async def test_git_worktree_preserves_nested_source_workspace(tmp_path) -> None:
     source = _repo(tmp_path / "repo")
     nested = source / "packages" / "worker"
@@ -333,9 +379,14 @@ async def test_git_worktree_rejects_truncated_patch_evidence(tmp_path) -> None:
         return ExecResult(0, "partial diff", "", stdout_truncated=True)
 
     assert env._local_env is not None
+    real_exec = env._local_env.exec_cmd
     env._local_env.exec_cmd = truncated_exec
     with pytest.raises(RuntimeError, match="exceeded capture limit"):
         await env.get_diff()
+    with pytest.raises(RuntimeError, match="worktree retained"):
+        await env.cleanup()
+    env._local_env.exec_cmd = real_exec
+    assert await env.get_diff() == ""
     await env.cleanup()
 
 
@@ -348,9 +399,14 @@ async def test_git_worktree_reports_returncode_when_diff_has_no_stderr(tmp_path)
         return ExecResult(128, "", "")
 
     assert env._local_env is not None
+    real_exec = env._local_env.exec_cmd
     env._local_env.exec_cmd = failed_exec
     with pytest.raises(RuntimeError, match="git exited with status 128"):
         await env.get_diff()
+    with pytest.raises(RuntimeError, match="worktree retained"):
+        await env.cleanup()
+    env._local_env.exec_cmd = real_exec
+    assert await env.get_diff() == ""
     await env.cleanup()
 
 

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -39,6 +39,21 @@ def _branch_exists(repo, branch: str) -> bool:
     return _git(repo, "show-ref", "--verify", f"refs/heads/{branch}", check=False).returncode == 0
 
 
+class _OneShotAsyncBarrier:
+    """Release all waiters once the expected parties have arrived."""
+
+    def __init__(self, parties: int) -> None:
+        self._parties = parties
+        self._arrived = 0
+        self._released = asyncio.Event()
+
+    async def wait(self) -> None:
+        self._arrived += 1
+        if self._arrived == self._parties:
+            self._released.set()
+        await self._released.wait()
+
+
 async def test_pool_without_worktrees_returns_local_environment(tmp_path) -> None:
     pool = WorktreePool(str(tmp_path), use_worktrees=False)
     env = await pool.acquire("coder")
@@ -196,7 +211,7 @@ async def test_concurrent_same_branch_setup_preserves_winner_after_loser_cleanup
     branch = "same-branch"
     first = WorktreeEnvironment(str(source), branch_name=branch)
     second = WorktreeEnvironment(str(source), branch_name=branch)
-    barrier = asyncio.Barrier(2)
+    barrier = _OneShotAsyncBarrier(2)
 
     def make_racing_git(env):
         real_git = env._git

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -63,6 +64,7 @@ async def test_non_git_source_uses_independent_directory_copy(tmp_path) -> None:
     await env.write_file("note.txt", "child")
     assert (source / "note.txt").read_text(encoding="utf-8") == "source"
     assert await env.read_file("note.txt") == "child"
+    assert "child" in await env.get_diff()
     await env.cleanup()
     assert not os.path.exists(workspace)
 
@@ -86,6 +88,33 @@ async def test_non_git_copy_preserves_file_and_directory_symlinks(tmp_path) -> N
     with pytest.raises(OSError):
         await env.read_file("dir-link/secret.txt")
     await env.cleanup()
+
+
+async def test_non_git_copy_exports_changes_before_cleanup(tmp_path) -> None:
+    source = tmp_path / "plain"
+    source.mkdir()
+    (source / "changed.txt").write_text("before\n", encoding="utf-8")
+    (source / "removed.txt").write_text("remove me\n", encoding="utf-8")
+    env = WorktreeEnvironment(str(source), branch_name="plain-export")
+    workspace = await env.setup()
+    await env.write_file("changed.txt", "after\n")
+    (Path(workspace) / "removed.txt").unlink()
+    (Path(workspace) / "added.txt").write_text("added\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unexported non-Git worktree changes"):
+        await env.cleanup()
+    assert os.path.exists(workspace)
+
+    diff = await env.get_diff()
+    assert "changed.txt" in diff
+    assert "removed.txt" in diff
+    assert "added.txt" in diff
+    assert "-before" in diff
+    assert "+after" in diff
+    assert "opencollab-cp-" not in diff
+
+    await env.cleanup()
+    assert not os.path.exists(workspace)
 
 
 async def test_git_worktree_reports_committed_and_untracked_changes(tmp_path) -> None:

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -279,6 +279,26 @@ async def test_git_worktree_rejects_dirty_source_snapshot(tmp_path) -> None:
     assert not _branch_exists(source, branch)
 
 
+async def test_git_worktree_preserves_nested_source_workspace(tmp_path) -> None:
+    source = _repo(tmp_path / "repo")
+    nested = source / "packages" / "worker"
+    nested.mkdir(parents=True)
+    (nested / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(source, "add", "packages/worker/module.py")
+    _git(source, "commit", "-qm", "add nested package")
+    env = WorktreeEnvironment(str(nested), branch_name="nested-source")
+
+    workspace = Path(await env.setup())
+
+    assert workspace.name == "worker"
+    assert (workspace / "module.py").read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert not (workspace / "packages").exists()
+    await env.write_file("module.py", "VALUE = 2\n")
+    assert (nested / "module.py").read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert "packages/worker/module.py" in await env.get_diff()
+    await env.cleanup()
+
+
 async def test_git_worktree_rejects_truncated_patch_evidence(tmp_path) -> None:
     source = _repo(tmp_path / "repo")
     env = WorktreeEnvironment(str(source), branch_name="truncated-diff")
@@ -434,7 +454,9 @@ async def test_double_cancellation_cannot_interrupt_setup_cleanup(tmp_path, monk
     cleanup_release = asyncio.Event()
     cleanup_done = asyncio.Event()
 
-    async def fake_git(*_args, **_kwargs):
+    async def fake_git(*args, **_kwargs):
+        if args[-1:] == ("--show-toplevel",):
+            return ExecResult(0, str(source), "")
         return ExecResult(0, ".git\n", "")
 
     async def blocked_setup():

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import asyncio
 import os
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
 
+from opencollab.adapters import _env_worktree as worktree_module
 from opencollab.adapters import worktree_pool as pool_module
 from opencollab.adapters.env import ExecResult, LocalEnvironment, WorktreeEnvironment
 from opencollab.adapters.worktree_pool import WorktreePool
@@ -82,6 +84,63 @@ async def test_non_git_source_uses_independent_directory_copy(tmp_path) -> None:
     assert "child" in await env.get_diff()
     await env.cleanup()
     assert not os.path.exists(workspace)
+
+
+async def test_non_git_copy_does_not_block_event_loop(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "plain"
+    source.mkdir()
+    (source / "note.txt").write_text("source", encoding="utf-8")
+    started = threading.Event()
+    release = threading.Event()
+    original_copytree = worktree_module.shutil.copytree
+
+    def slow_copytree(*args, **kwargs):
+        started.set()
+        assert release.wait(1.0)
+        return original_copytree(*args, **kwargs)
+
+    monkeypatch.setattr(worktree_module.shutil, "copytree", slow_copytree)
+    env = WorktreeEnvironment(str(source), branch_name="plain-async-copy")
+    owner = asyncio.create_task(env.setup())
+    timer = threading.Timer(0.15, release.set)
+    timer.start()
+    try:
+        await asyncio.sleep(0.02)
+        assert started.is_set()
+        assert not owner.done()
+    finally:
+        release.set()
+        timer.cancel()
+    await owner
+    await env.cleanup()
+
+
+async def test_non_git_cleanup_does_not_block_event_loop(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "plain"
+    source.mkdir()
+    env = WorktreeEnvironment(str(source), branch_name="plain-async-cleanup")
+    await env.setup()
+    started = threading.Event()
+    release = threading.Event()
+    original_rmtree = worktree_module.shutil.rmtree
+
+    def slow_rmtree(*args, **kwargs):
+        started.set()
+        assert release.wait(1.0)
+        return original_rmtree(*args, **kwargs)
+
+    monkeypatch.setattr(worktree_module.shutil, "rmtree", slow_rmtree)
+    owner = asyncio.create_task(env.cleanup())
+    timer = threading.Timer(0.15, release.set)
+    timer.start()
+    try:
+        await asyncio.sleep(0.02)
+        assert started.is_set()
+        assert not owner.done()
+    finally:
+        release.set()
+        timer.cancel()
+    await owner
 
 
 async def test_non_git_copy_preserves_file_and_directory_symlinks(tmp_path) -> None:

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -86,6 +86,49 @@ async def test_non_git_source_uses_independent_directory_copy(tmp_path) -> None:
     assert not os.path.exists(workspace)
 
 
+async def test_concurrent_setup_reuses_one_worktree(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "plain"
+    source.mkdir()
+    env = WorktreeEnvironment(str(source), branch_name="plain-concurrent")
+    started = asyncio.Event()
+    release = asyncio.Event()
+    probe_count = 0
+    copy_count = 0
+
+    async def blocking_probe(*args, **_kwargs):
+        nonlocal probe_count
+        assert args == ("rev-parse", "--git-dir")
+        probe_count += 1
+        started.set()
+        await release.wait()
+        return ExecResult(1, "", "")
+
+    async def fake_copy() -> None:
+        nonlocal copy_count
+        copy_count += 1
+        baseline = tmp_path / f"baseline-{copy_count}"
+        worktree = tmp_path / f"worktree-{copy_count}"
+        baseline.mkdir()
+        worktree.mkdir()
+        env._copy_baseline_dir = str(baseline)
+        env._worktree_dir = str(worktree)
+
+    monkeypatch.setattr(env, "_git", blocking_probe)
+    monkeypatch.setattr(env, "_setup_directory_copy", fake_copy)
+    first = asyncio.create_task(env.setup())
+    await started.wait()
+    second = asyncio.create_task(env.setup())
+    try:
+        await asyncio.sleep(0.01)
+        assert probe_count == 1
+    finally:
+        release.set()
+        outcomes = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert copy_count == 1
+    assert outcomes == [env.workspace, env.workspace]
+
+
 async def test_non_git_copy_does_not_block_event_loop(tmp_path, monkeypatch) -> None:
     source = tmp_path / "plain"
     source.mkdir()

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -162,6 +162,60 @@ async def test_failed_worktree_add_removes_unregistered_directory(tmp_path, monk
     assert not _branch_exists(source, "failed-add")
 
 
+async def test_concurrent_same_branch_setup_preserves_winner_after_loser_cleanup(tmp_path, monkeypatch) -> None:
+    source = _repo(tmp_path / "repo")
+    branch = "same-branch"
+    first = WorktreeEnvironment(str(source), branch_name=branch)
+    second = WorktreeEnvironment(str(source), branch_name=branch)
+    barrier = asyncio.Barrier(2)
+
+    def make_racing_git(env):
+        real_git = env._git
+        paused = False
+
+        async def racing_git(*args, **kwargs):
+            nonlocal paused
+            if not paused and args[:2] == ("show-ref", "--verify"):
+                paused = True
+                await barrier.wait()
+            return await real_git(*args, **kwargs)
+
+        return racing_git
+
+    monkeypatch.setattr(first, "_git", make_racing_git(first))
+    monkeypatch.setattr(second, "_git", make_racing_git(second))
+    outcomes = await asyncio.gather(first.setup(), second.setup(), return_exceptions=True)
+
+    winners = [env for env, outcome in zip((first, second), outcomes) if isinstance(outcome, str)]
+    failures = [outcome for outcome in outcomes if isinstance(outcome, Exception)]
+    assert len(winners) == 1
+    assert len(failures) == 1
+    winner = winners[0]
+    assert _branch_exists(source, branch)
+    assert os.path.isdir(winner.workspace)
+    assert os.path.exists(os.path.join(winner.workspace, "tracked.txt"))
+
+    await winner.cleanup()
+    assert not _branch_exists(source, branch)
+
+
+async def test_worktree_cleanup_preserves_externally_advanced_owned_branch(tmp_path) -> None:
+    source = _repo(tmp_path / "repo")
+    branch = "externally-advanced"
+    env = WorktreeEnvironment(str(source), branch_name=branch)
+    workspace = await env.setup()
+    base = _git(source, "rev-parse", branch).stdout.strip()
+    tree = _git(source, "rev-parse", f"{base}^{{tree}}").stdout.strip()
+    advanced = _git(source, "commit-tree", tree, "-p", base, "-m", "external advance").stdout.strip()
+    _git(source, "update-ref", f"refs/heads/{branch}", advanced, base)
+
+    await env.cleanup()
+
+    assert not os.path.exists(workspace)
+    assert _branch_exists(source, branch)
+    assert _git(source, "rev-parse", branch).stdout.strip() == advanced
+
+
 async def test_double_cancellation_cannot_interrupt_setup_cleanup(tmp_path, monkeypatch) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -299,6 +299,31 @@ async def test_git_worktree_preserves_nested_source_workspace(tmp_path) -> None:
     await env.cleanup()
 
 
+async def test_git_worktree_initializes_source_available_submodules(tmp_path) -> None:
+    dependency = _repo(tmp_path / "dependency")
+    source = _repo(tmp_path / "repo")
+    _git(
+        source,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        str(dependency),
+        "vendor/dependency",
+    )
+    _git(source, "commit", "-qam", "add local dependency")
+    assert (source / "vendor" / "dependency" / "tracked.txt").is_file()
+    env = WorktreeEnvironment(str(source), branch_name="local-submodule")
+
+    workspace = Path(await env.setup())
+
+    assert (workspace / "vendor" / "dependency" / "tracked.txt").read_text(
+        encoding="utf-8"
+    ) == "base\n"
+    await env.cleanup()
+
+
 async def test_git_worktree_rejects_truncated_patch_evidence(tmp_path) -> None:
     source = _repo(tmp_path / "repo")
     env = WorktreeEnvironment(str(source), branch_name="truncated-diff")

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -390,6 +390,41 @@ async def test_worktree_cleanup_preserves_externally_advanced_owned_branch(tmp_p
     assert _git(source, "rev-parse", branch).stdout.strip() == advanced
 
 
+async def test_worktree_cleanup_stops_when_local_environment_is_not_quiescent(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    source = _repo(tmp_path / "repo")
+    env = WorktreeEnvironment(str(source), branch_name="retry-local-cleanup")
+    workspace = await env.setup()
+    assert env._local_env is not None
+    local_env = env._local_env
+    real_cleanup = local_env.cleanup
+    git_calls: list[tuple[str, ...]] = []
+    real_git = env._git
+
+    async def track_git(*args, **kwargs):
+        git_calls.append(args)
+        return await real_git(*args, **kwargs)
+
+    async def fail_cleanup():
+        raise RuntimeError("process still alive")
+
+    monkeypatch.setattr(env, "_git", track_git)
+    monkeypatch.setattr(local_env, "cleanup", fail_cleanup)
+
+    with pytest.raises(RuntimeError, match="worktree cleanup failed"):
+        await env.cleanup()
+
+    assert os.path.isdir(workspace)
+    assert env._local_env is local_env
+    assert not any(args[:2] == ("worktree", "remove") for args in git_calls)
+
+    monkeypatch.setattr(local_env, "cleanup", real_cleanup)
+    await env.cleanup()
+    assert not os.path.exists(workspace)
+
+
 async def test_double_cancellation_cannot_interrupt_setup_cleanup(tmp_path, monkeypatch) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -370,6 +370,80 @@ async def test_git_worktree_initializes_source_available_submodules(tmp_path) ->
     await env.cleanup()
 
 
+async def test_git_worktree_maps_nested_submodules_to_initialized_source(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    leaf = _repo(tmp_path / "leaf")
+    middle = _repo(tmp_path / "middle")
+    _git(
+        middle,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        str(leaf),
+        "vendor/leaf",
+    )
+    _git(
+        middle,
+        "config",
+        "-f",
+        ".gitmodules",
+        "submodule.vendor/leaf.url",
+        "https://example.invalid/leaf.git",
+    )
+    _git(middle, "add", ".gitmodules", "vendor/leaf")
+    _git(middle, "commit", "-qm", "add nested leaf")
+
+    source = _repo(tmp_path / "repo")
+    _git(
+        source,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        str(middle),
+        "modules/middle",
+    )
+    _git(
+        source / "modules" / "middle",
+        "-c",
+        "protocol.allow=never",
+        "-c",
+        "protocol.file.allow=always",
+        "-c",
+        f"submodule.vendor/leaf.url={leaf}",
+        "submodule",
+        "update",
+        "--init",
+        "--no-fetch",
+        "--",
+        "vendor/leaf",
+    )
+    _git(
+        source,
+        "config",
+        "-f",
+        ".gitmodules",
+        "submodule.modules/middle.url",
+        "https://example.invalid/middle.git",
+    )
+    _git(source, "add", ".gitmodules", "modules/middle")
+    _git(source, "commit", "-qm", "add nested dependency")
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+    env = WorktreeEnvironment(str(source), branch_name="nested-local-submodule")
+
+    workspace = Path(await env.setup())
+
+    assert (
+        workspace / "modules" / "middle" / "vendor" / "leaf" / "tracked.txt"
+    ).read_text(encoding="utf-8") == "base\n"
+    await env.cleanup()
+
+
 async def test_git_worktree_rejects_truncated_patch_evidence(tmp_path) -> None:
     source = _repo(tmp_path / "repo")
     env = WorktreeEnvironment(str(source), branch_name="truncated-diff")

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -251,6 +251,34 @@ async def test_git_worktree_reports_committed_and_untracked_changes(tmp_path) ->
     assert not _branch_exists(source, branch)
 
 
+async def test_git_worktree_rejects_dirty_source_snapshot(tmp_path) -> None:
+    source = _repo(tmp_path / "repo")
+    (source / "deleted.txt").write_text("delete\n", encoding="utf-8")
+    _git(source, "add", "deleted.txt")
+    _git(source, "commit", "-qm", "add deletion fixture")
+    (source / "staged.txt").write_text("staged\n", encoding="utf-8")
+    _git(source, "add", "staged.txt")
+    (source / "tracked.txt").write_text("unstaged\n", encoding="utf-8")
+    (source / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+    (source / "deleted.txt").unlink()
+    branch = "dirty-source"
+    env = WorktreeEnvironment(str(source), branch_name=branch)
+
+    try:
+        with pytest.raises(RuntimeError, match="uncommitted changes") as captured:
+            await env.setup()
+    finally:
+        if env._local_env is not None:
+            await env.cleanup()
+
+    detail = str(captured.value)
+    assert "staged.txt" in detail
+    assert "tracked.txt" in detail
+    assert "untracked.txt" in detail
+    assert "deleted.txt" in detail
+    assert not _branch_exists(source, branch)
+
+
 async def test_git_worktree_rejects_truncated_patch_evidence(tmp_path) -> None:
     source = _repo(tmp_path / "repo")
     env = WorktreeEnvironment(str(source), branch_name="truncated-diff")

--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -59,7 +59,42 @@ class _OneShotAsyncBarrier:
 async def test_pool_without_worktrees_returns_local_environment(tmp_path) -> None:
     pool = WorktreePool(str(tmp_path), use_worktrees=False)
     env = await pool.acquire("coder")
+    temporary = await env.write_temp_file("owned", prefix="pool-", suffix=".tmp")
+
     assert isinstance(env, LocalEnvironment)
+    assert pool._envs == [env]
+
+    await pool.release_env(env)
+
+    assert pool._envs == []
+    assert env.revoked is True
+    assert not os.path.exists(temporary)
+
+
+async def test_pool_retains_failed_local_cleanup_for_retry(
+    tmp_path, monkeypatch
+) -> None:
+    class RetriableLocalEnvironment:
+        def __init__(self, workspace):
+            self.workspace = workspace
+            self.cleanup_calls = 0
+
+        async def cleanup(self):
+            self.cleanup_calls += 1
+            if self.cleanup_calls == 1:
+                raise OSError("local cleanup failed")
+
+    monkeypatch.setattr(
+        pool_module, "LocalEnvironment", RetriableLocalEnvironment
+    )
+    pool = WorktreePool(str(tmp_path), use_worktrees=False)
+    env = await pool.acquire("coder")
+
+    with pytest.raises(OSError, match="local cleanup failed"):
+        await pool.release_env(env)
+    assert pool._envs == [env]
+
+    await pool.release_env(env)
     assert pool._envs == []
 
 


### PR DESCRIPTION
Batch 1 of the split of #42 + #43. See the [review plan](https://github.com/RISE-X-Lab/OpenCollab/pull/42#issuecomment-5223868958) for the full context.

## Scope

91 commits from the audited range `4e4cd2d..8820950`, cherry-picked onto `main` in their original order. The selection rule is mechanical and verifiable: **every commit here touches only `opencollab/adapters/`** — no `domain/`, no `application/`, no `bootstrap/`, no `sdk/`. Confirmed by `git diff --name-only main HEAD -- opencollab | cut -d/ -f2 | sort -u` returning exactly `adapters`.

That rule is what makes this batch safe to land ahead of the rest: **none of the seven policy decisions flagged in the review plan fall inside it.** They all live in `domain/`, `application/shaping/`, or `bootstrap/`. Nothing here changes the session FSM, the enforcement contract, compaction policy, or config strictness.

Also included: 5 pure `test:` commits that pair with fixes in this batch (`a1e15c0`, `df05fb0`, `c2500ef`, and two others). Without them `test_public_readiness` and `test_workflow_cli` fail — filtering by source path alone silently drops them.

Deliberately excluded: `bf8089c` and `49d4856` (`storage.py` restored-message validators). They depend on the new `JournalSnapshotStorePort` and belong with the inner batch.

## Validation

- 91/91 commits cherry-pick cleanly, no manual conflict resolution.
- `uv run pytest -q` → **`1733 passed, 2 skipped`**
- `uv run ruff check .` → **clean**
- 56 files changed, +5817 / -372.

## What changes for users

The batch is mostly defensive hardening in adapters, but it does tighten some tool contracts. All of these return a tool error rather than raising, so an agent sees a normal failed tool result:

- `file-write` requires `content` in `create` mode
- `edit` rejects overlapping replacements
- `apply-patch` enforces hunk ranges and rejects no-op results
- `grep` enforces a global result limit; `bash` validates its output limit eagerly
- `local-env` rejects non-UTF-8 edits; `worktree` rejects dirty source snapshots
- `docker` validates bind mount sources and rejects a "successful" timeout status
- `skills` rejects partial instruction bodies

Plus bounded-memory fixes across the TUI render state, prompt history cache, apply-patch fuzzy matching, and repo-map.
