### PR TITLE
fix(llm): tolerate null tool arguments in usage fallback

### DIFF
--- a/opencollab/adapters/llm/openai_provider.py
+++ b/opencollab/adapters/llm/openai_provider.py
@@ -309,7 +309,14 @@ def _estimate_output_tokens(message: Any) -> int:
     """Estimate output tokens from response text + serialized tool-call args."""
     text = message.content or ""
     for tool_call in message.tool_calls or []:
-        text += tool_call.function.name + tool_call.function.arguments
+        # Some OpenAI-compatible gateways emit partially formed tool calls with
+        # ``arguments=null`` (or, more rarely, ``name=null``). Usage estimation
+        # is observational and must not turn that provider response into a
+        # Python TypeError before the normal structured-output retry can act.
+        text += (
+            (getattr(tool_call.function, "name", None) or "")
+            + (getattr(tool_call.function, "arguments", None) or "")
+        )
     return estimate_tokens(text) if text else 0
 
 

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -482,6 +482,22 @@ def test_openai_estimates_output_from_tool_calls_when_no_content():
     assert result.usage.estimated is True
 
 
+def test_openai_usage_fallback_tolerates_null_tool_arguments():
+    """A gateway's partial tool call must not crash usage estimation."""
+    tool_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="structured_output", arguments=None),
+    )
+    messages = [{"role": "user", "content": "commit the structured result"}]
+    resp = _openai_resp(usage=None, content=None, tool_calls=[tool_call])
+
+    result = parse_openai_response(resp, messages)
+
+    assert result.usage.output_tokens > 0
+    assert result.usage.estimated is True
+    assert result.tool_calls[0]["function"]["arguments"] == ""
+
+
 # ---------------------------------------------------------------------------
 # reasoning_content harvest — rescue a genuinely empty thinking turn
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

OpenAI-compatible providers can return a partially formed tool call with
`function.arguments = null`. When the response does not contain provider usage
metadata, OpenCollab estimates output usage from the response text and
serialized tool-call fields. The previous fallback concatenated the function
name and arguments directly, so a valid provider response could raise:

```text
TypeError: can only concatenate str (not "NoneType") to str
```

This patch treats missing tool-call names or arguments as empty strings during
the observational usage estimate. Structured-output handling can then continue
to validate or retry the response normally.

## What changed

- Normalize nullable `name` and `arguments` fields in
  `opencollab/adapters/llm/openai_provider.py`.
- Add a regression test covering a response with no usage, no content, and a
  tool call whose arguments are `None`.
- Keep the existing estimated-usage contract: the response is marked as
  estimated and receives a positive output-token estimate.

This is intentionally limited to provider response normalization. It does not
change token-budget accounting, retry policy, tool execution, or public API
behavior for complete tool calls.

## Root cause and impact

Some OpenAI-compatible gateways emit `arguments: null` while assembling a
structured tool call. The usage fallback is diagnostic/accounting code, but the
old implementation allowed that bookkeeping path to abort the whole response
before normal structured-output recovery could run. The failure is therefore
provider-adapter handling, not a model quota, GPU, or user tool implementation
failure.

## Validation

- `uv run pytest -q tests/test_llm_providers.py` — 71 passed
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy .venv/bin/python -m pytest -q` — 1536 passed, 1 skipped
- `.venv/bin/ruff check .` — passed

The proxy variables are unset for the full-suite command because this checkout
does not include the optional `socksio` dependency; this avoids an unrelated
environment-level proxy construction failure.
