### PR TITLE
fix(ci): distinguish baseline line drift from new secrets

### DIFF
--- a/scripts/check_secret_history.py
+++ b/scripts/check_secret_history.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shlex
 import subprocess
@@ -11,6 +12,11 @@ import tempfile
 from pathlib import Path, PurePosixPath
 
 BASELINE_PATH = ".secrets.baseline"
+# ``detect-secrets-hook`` reserves this exit code for "I rewrote the baseline",
+# which it does whenever a baselined secret moved to a different line. That is
+# bookkeeping, not a finding; a real detection exits 1 and never rewrites the
+# baseline. The two are told apart in ``_scan_materialized_tree``.
+BASELINE_UPDATED_EXIT = 3
 
 
 def _git(repository: Path, *args: str) -> bytes:
@@ -55,6 +61,28 @@ def _materialize_tree(repository: Path, commit: str, destination: Path) -> list[
     return paths
 
 
+def _secret_fingerprints(payload: bytes) -> set[tuple[str, str, str]]:
+    """Identify every baselined secret as (file, detector, hashed secret).
+
+    Line numbers are deliberately excluded. Where an audited fixture sits in its
+    file is not a security property, so a commit that inserts lines above one
+    must not read as a new finding.
+    """
+    results = json.loads(payload.decode("utf-8")).get("results") or {}
+    if not isinstance(results, dict):
+        raise ValueError("baseline results must be an object")
+    return {
+        (str(filename), str(entry.get("type", "")), str(entry.get("hashed_secret", "")))
+        for filename, entries in results.items()
+        for entry in entries
+    }
+
+
+def _introduced_secrets(trusted_baseline: bytes, scanned_baseline: Path) -> set[tuple[str, str, str]]:
+    """Fingerprints the scanner recorded that the trusted baseline does not hold."""
+    return _secret_fingerprints(scanned_baseline.read_bytes()) - _secret_fingerprints(trusted_baseline)
+
+
 def _scan_materialized_tree(
     repository: Path,
     commit: str,
@@ -88,8 +116,25 @@ def _scan_materialized_tree(
         cwd=tree,
         check=False,
     )
-    if completed.returncode:
-        print(f"::error::Secret scan failed for proposed commit {commit}.")
+    if not completed.returncode:
+        return 0
+    if completed.returncode == BASELINE_UPDATED_EXIT:
+        try:
+            introduced = _introduced_secrets(trusted_baseline, baseline)
+        except (OSError, ValueError) as exc:
+            print(f"::error::Unreadable baseline after scanning commit {commit}: {exc}")
+            return completed.returncode
+        if not introduced:
+            print(
+                f"Commit {commit} only moved already-audited secrets; "
+                "no new secret was introduced."
+            )
+            return 0
+        for filename, detector, _hashed in sorted(introduced):
+            print(
+                f"::error file={filename}::{detector} is not present in the trusted baseline."
+            )
+    print(f"::error::Secret scan failed for proposed commit {commit}.")
     return completed.returncode
 
 

--- a/tests/test_secret_history_check.py
+++ b/tests/test_secret_history_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -37,7 +38,14 @@ def _repository(tmp_path: Path) -> tuple[Path, str, Path]:
     _git(repository, "init")
     _git(repository, "config", "user.name", "Security Test")
     _git(repository, "config", "user.email", "security@example.invalid")
-    (repository / ".secrets.baseline").write_text("{}\n", encoding="utf-8")
+    audited = {
+        "results": {
+            "fixtures.py": [
+                {"type": "Secret Keyword", "hashed_secret": "abc123", "line_number": 4}  # pragma: allowlist secret
+            ]
+        }
+    }
+    (repository / ".secrets.baseline").write_text(json.dumps(audited) + "\n", encoding="utf-8")
     (repository / "base.txt").write_text("base\n", encoding="utf-8")
     _git(repository, "add", ".")
     _git(repository, "commit", "-m", "base")
@@ -45,6 +53,7 @@ def _repository(tmp_path: Path) -> tuple[Path, str, Path]:
     scanner = tmp_path / "fake-scanner.py"
     scanner.write_text(
         """#!/usr/bin/env python3
+import json
 import pathlib
 import subprocess
 import sys
@@ -57,9 +66,27 @@ subprocess.run(
 if sys.argv[sys.argv.index("--baseline") + 1] != ".secrets.baseline":
     raise SystemExit(2)
 paths = [name for name in sys.argv[sys.argv.index("--baseline") + 2:] if name != "--"]
+baseline = pathlib.Path(".secrets.baseline")
 for name in paths:
-    if b"DEMO_SECRET" in pathlib.Path(name).read_bytes():
+    body = pathlib.Path(name).read_bytes()
+    # A real detection: reported to the operator, baseline left untouched.
+    if b"DEMO_SECRET" in body:
         raise SystemExit(1)
+    if b"DEMO_CORRUPT_BASELINE" in body:
+        baseline.write_text("not json", encoding="utf-8")
+        raise SystemExit(3)
+    # detect-secrets rewrites the baseline and exits 3 once anything about a
+    # recorded entry no longer matches the tree it is scanning.
+    if b"DEMO_MOVED" in body or b"DEMO_UNAUDITED" in body:
+        document = json.loads(baseline.read_text(encoding="utf-8"))
+        entries = document["results"]["fixtures.py"]
+        entries[0]["line_number"] += 10
+        if b"DEMO_UNAUDITED" in body:
+            entries.append(
+                {"type": "AWS Access Key", "hashed_secret": "def456", "line_number": 9}  # pragma: allowlist secret
+            )
+        baseline.write_text(json.dumps(document), encoding="utf-8")
+        raise SystemExit(3)
 """,
         encoding="utf-8",
     )
@@ -125,6 +152,43 @@ def test_secret_history_scans_secret_removed_by_later_commit(tmp_path):
 
     assert result.returncode == 1
     assert "Secret scan failed for proposed commit" in result.stdout
+
+
+def test_secret_history_accepts_an_audited_secret_that_only_moved(tmp_path):
+    repository, base, scanner = _repository(tmp_path)
+    (repository / "fixtures.py").write_text("DEMO_MOVED\n", encoding="utf-8")
+    _git(repository, "add", "fixtures.py")
+    _git(repository, "commit", "-m", "shift an audited fixture down its file")
+
+    result = _run(repository, base, "HEAD", scanner)
+
+    assert result.returncode == 0
+    assert "only moved already-audited secrets" in result.stdout
+
+
+def test_secret_history_rejects_a_secret_absent_from_the_trusted_baseline(tmp_path):
+    repository, base, scanner = _repository(tmp_path)
+    (repository / "fixtures.py").write_text("DEMO_UNAUDITED\n", encoding="utf-8")
+    _git(repository, "add", "fixtures.py")
+    _git(repository, "commit", "-m", "record an unaudited secret")
+
+    result = _run(repository, base, "HEAD", scanner)
+
+    assert result.returncode == 3
+    assert "AWS Access Key is not present in the trusted baseline" in result.stdout
+    assert "Secret scan failed for proposed commit" in result.stdout
+
+
+def test_secret_history_rejects_a_baseline_it_cannot_read_after_scanning(tmp_path):
+    repository, base, scanner = _repository(tmp_path)
+    (repository / "fixtures.py").write_text("DEMO_CORRUPT_BASELINE\n", encoding="utf-8")
+    _git(repository, "add", "fixtures.py")
+    _git(repository, "commit", "-m", "leave an unreadable baseline behind")
+
+    result = _run(repository, base, "HEAD", scanner)
+
+    assert result.returncode == 3
+    assert "Unreadable baseline" in result.stdout
 
 
 def test_secret_history_rejects_baseline_change(tmp_path):


### PR DESCRIPTION
## Problem

`check_secret_history.py` writes `main`'s baseline into every proposed commit's tree and treats **any** non-zero scanner exit as a failure. `detect-secrets-hook` uses distinct exit codes:

| Exit | Meaning | Baseline rewritten |
|---|---|---|
| 0 | tree matches the baseline | no |
| **1** | **a secret not in the baseline was found** | no |
| **3** | the baseline was rewritten to match the tree | yes |

Exit 3 fires whenever an audited secret moved to a different line. Inserting ten lines above a baselined test fixture therefore fails the gate, with a message that reads like a security finding:

```
The baseline file was updated.
Probably to keep line numbers of secrets up-to-date.
Error: Secret scan failed for proposed commit a2b43c5...
```

Nothing about that tree is less safe. **Where a fixture sits in its file is not a security property**, and the gate currently cannot tell that case apart from a real detection.

This is already blocking work: #43's `secrets` job fails at `01f2492`, and #44's at `a2b43c5`. Both are pure line drift in `tests/test_llm_usage_ledger.py` and `tests/test_config.py`. #42 passes only because the five baselined files it touches happen not to shift a recorded line.

Two workarounds do not apply, for the record:

- The `security-baseline-update` label only gates whether a PR may modify `.secrets.baseline` between base and head. The per-commit loop runs unconditionally against `git show base:.secrets.baseline`, so the label cannot reach it.
- Adding `# pragma: allowlist secret` to the drifted lines still exits 3, because the now-unmatched baseline entries make the hook rewrite the file anyway. Verified locally.

## Change

On exit 3, compare the rewritten baseline against the trusted one by `(file, detector, hashed_secret)` — ignoring `line_number` — and pass only when the scan recorded nothing the trusted baseline does not already hold. Everything else keeps its current behaviour:

- exit 1 (a real detection) is rejected unconditionally and never consults the baseline
- exit 3 that records a fingerprint absent from the trusted baseline is rejected, and each one is reported with `::error file=`
- a baseline that cannot be parsed after a scan is rejected rather than assumed benign
- the label rule, the baseline-only rule, and `--trusted-tree` are untouched

## Validation

End-to-end against the real scanner (`uvx --from detect-secrets==1.5.0 detect-secrets-hook`):

- `a2b43c5`, the commit failing on #44 — now `Commit a2b43c5… only moved already-audited secrets; no new secret was introduced.` / **exit 0**
- an `AKIA…` key appended to `opencollab/domain/identity.py` — still `ERROR: Potential secrets about to be committed to git repo!` / **exit 1**

Unit tests: 3 added to `tests/test_secret_history_check.py` (moved entry accepted, unaudited entry rejected, unreadable baseline rejected), with the fake scanner extended to model exit 3. `12 passed`, `ruff check .` clean.
