### PR TITLE
fix(runtime): make persistence and observability bounded

### DIFF
--- a/opencollab/adapters/hooks.py
+++ b/opencollab/adapters/hooks.py
@@ -36,6 +36,7 @@ class ShellHookRunner(HookPort):
             else None
         )
         self.cleanup_quiesced = True
+        self.cleanup_error: ProcessCleanupError | None = None
         self._executors: dict[str, CommandExecutor] = {"command": self._run_command}
 
     async def fire(self, event_name: str, payload: dict[str, Any]) -> HookOutcome:
@@ -92,6 +93,7 @@ class ShellHookRunner(HookPort):
             return
         except ProcessCleanupError as exc:
             self.cleanup_quiesced = False
+            self.cleanup_error = exc
             logger.warning("hook command cleanup failed (%s): %s", spec.command, exc)
             raise
         except asyncio.CancelledError:

--- a/opencollab/adapters/safe_files.py
+++ b/opencollab/adapters/safe_files.py
@@ -276,13 +276,17 @@ def read_regular_text_range(
             os.close(fd)
 
 
-def open_regular_text_append(path: str | os.PathLike[str]) -> TextIO:
+def open_regular_text_append(
+    path: str | os.PathLike[str],
+    *,
+    readable: bool = False,
+) -> TextIO:
     target = _absolute(path)
     ensure_directory_no_symlinks(target.parent)
     _current_regular(target, context="append")
     fd = os.open(
         target,
-        os.O_WRONLY
+        (os.O_RDWR if readable else os.O_WRONLY)
         | os.O_APPEND
         | os.O_CREAT
         | getattr(os, "O_NONBLOCK", 0)

--- a/opencollab/adapters/storage.py
+++ b/opencollab/adapters/storage.py
@@ -6,12 +6,18 @@ from typing import Any, BinaryIO
 
 from opencollab.adapters.safe_files import (
     ensure_directory_no_symlinks,
+    open_regular_text_append,
     read_regular_bytes,
+    write_locked_text,
+    write_regular_bytes_atomic,
     write_regular_file_atomic,
 )
 
 MAX_SESSION_SNAPSHOT_BYTES = 64 * 1024 * 1024
 _JSON_WRITE_CHUNK_CHARS = 64 * 1024
+_AUTOSAVE_SEQUENCE_KEY = "_autosave_sequence"
+_AUTOSAVE_JOURNAL_VERSION = 1
+_AUTOSAVE_JOURNAL_SUFFIX = ".journal"
 
 
 class _BoundedUTF8Writer:
@@ -46,6 +52,10 @@ class _BoundedUTF8Writer:
 class SessionStore:
     allowed_roles = {"system", "user", "assistant", "tool"}
 
+    def has_snapshot(self, path: str) -> bool:
+        """Return whether a base or recoverable journal sidecar is present."""
+        return os.path.lexists(path) or os.path.lexists(self._journal_path(path))
+
     def save(
         self,
         path: str,
@@ -63,11 +73,78 @@ class SessionStore:
 
     def load_snapshot(self, path: str, system_prompt: str) -> dict[str, Any]:
         """Load the versioned snapshot, accepting legacy list/JSONL files."""
-        text = self._read_snapshot_text(path)
+        try:
+            text = self._read_snapshot_text(path)
+        except FileNotFoundError:
+            text = None
+        records = self._read_journal_records(path)
+        if text is None and not records:
+            raise FileNotFoundError(path)
 
-        parsed = self._parse_document(text)
+        parsed = self._parse_document(text) if text is not None else {}
         snapshot = dict(parsed) if isinstance(parsed, dict) else {"messages": parsed}
         messages = list(snapshot.get("messages", []))
+        sequence = self._snapshot_sequence(snapshot)
+        for record in records:
+            record_sequence = self._record_integer(record, "sequence", minimum=1)
+            if record_sequence <= sequence:
+                continue
+            replace_from = self._record_integer(record, "replace_from", minimum=0)
+            message_count = self._record_integer(record, "message_count", minimum=0)
+            if replace_from > len(messages):
+                raise ValueError(
+                    "Invalid autosave journal: replace_from exceeds restored messages"
+                )
+            delta = record.get("messages")
+            meta = record.get("meta")
+            if not isinstance(delta, list) or not isinstance(meta, dict):
+                raise ValueError(
+                    "Invalid autosave journal: messages and meta must be structured"
+                )
+            self._validate_messages(delta)
+            messages = [*messages[:replace_from], *delta]
+            if len(messages) != message_count:
+                raise ValueError(
+                    "Invalid autosave journal: message_count does not match delta"
+                )
+            seen_reset = record.get("seen_result_hashes_reset")
+            seen_added = record.get("seen_result_hashes_added")
+            if not isinstance(seen_reset, bool) or not isinstance(seen_added, list):
+                raise ValueError(
+                    "Invalid autosave journal: seen-result hash delta"
+                )
+            if not all(isinstance(value, str) for value in seen_added):
+                raise ValueError(
+                    "Invalid autosave journal: seen-result hashes must be text"
+                )
+            prior_state = snapshot.get("session_state")
+            prior_seen = (
+                prior_state.get("seen_result_hashes", [])
+                if isinstance(prior_state, dict)
+                else []
+            )
+            if not isinstance(prior_seen, list) or not all(
+                isinstance(value, str) for value in prior_seen
+            ):
+                raise ValueError(
+                    "Invalid session snapshot: seen-result hashes must be text"
+                )
+            seen_hashes = set() if seen_reset else set(prior_seen)
+            seen_hashes.update(seen_added)
+            restored_meta = dict(meta)
+            restored_state = (
+                dict(restored_meta.get("session_state", {}))
+                if isinstance(restored_meta.get("session_state", {}), dict)
+                else {}
+            )
+            restored_state["seen_result_hashes"] = sorted(seen_hashes)
+            restored_meta["session_state"] = restored_state
+            snapshot = {
+                **restored_meta,
+                _AUTOSAVE_SEQUENCE_KEY: record_sequence,
+            }
+            sequence = record_sequence
+
         self._validate_messages(messages)
         if not messages:
             messages = [{"role": "system", "content": system_prompt}]
@@ -97,6 +174,201 @@ class SessionStore:
         if isinstance(obj, list):
             return obj
         raise ValueError("Invalid session file: expected object or array")
+
+    def append_snapshot_delta(
+        self,
+        path: str,
+        *,
+        sequence: int,
+        replace_from: int,
+        messages: list[dict[str, Any]],
+        meta: dict[str, Any],
+        seen_result_hashes_reset: bool = False,
+        seen_result_hashes_added: list[str] | None = None,
+    ) -> None:
+        """Durably append one absolute, idempotent autosave delta."""
+        if (
+            isinstance(sequence, bool)
+            or not isinstance(sequence, int)
+            or sequence < 1
+        ):
+            raise ValueError("autosave sequence must be a positive integer")
+        if (
+            isinstance(replace_from, bool)
+            or not isinstance(replace_from, int)
+            or replace_from < 0
+        ):
+            raise ValueError("autosave replace_from must be a non-negative integer")
+        if not isinstance(seen_result_hashes_reset, bool):
+            raise ValueError("autosave seen-result reset must be boolean")
+        seen_added = (
+            [] if seen_result_hashes_added is None else seen_result_hashes_added
+        )
+        if not isinstance(seen_added, list) or not all(
+            isinstance(value, str) for value in seen_added
+        ):
+            raise ValueError("autosave seen-result hashes must be text")
+        self._validate_messages(messages)
+        journal_meta = dict(meta)
+        raw_state = journal_meta.get("session_state")
+        if isinstance(raw_state, dict):
+            journal_state = dict(raw_state)
+            journal_state.pop("seen_result_hashes", None)
+            journal_meta["session_state"] = journal_state
+        record = {
+            "journal_version": _AUTOSAVE_JOURNAL_VERSION,
+            "sequence": sequence,
+            "replace_from": replace_from,
+            "message_count": replace_from + len(messages),
+            "messages": messages,
+            "meta": journal_meta,
+            "seen_result_hashes_reset": seen_result_hashes_reset,
+            "seen_result_hashes_added": seen_added,
+        }
+        self._append_journal_record(path, record)
+
+    def checkpoint_snapshot(
+        self,
+        path: str,
+        messages: list[dict[str, Any]],
+        *,
+        meta: dict[str, Any],
+        sequence: int,
+    ) -> None:
+        """Publish one full base, then atomically compact its covered journal."""
+        if (
+            isinstance(sequence, bool)
+            or not isinstance(sequence, int)
+            or sequence < 0
+        ):
+            raise ValueError("autosave sequence must be a non-negative integer")
+        self._ensure_parent(path)
+        obj = {
+            **meta,
+            _AUTOSAVE_SEQUENCE_KEY: sequence,
+            "messages": messages,
+        }
+        self._atomic_json_write(path, obj)
+        write_regular_bytes_atomic(
+            self._journal_path(path),
+            b"",
+            max_bytes=0,
+        )
+
+    @staticmethod
+    def _journal_path(path: str) -> str:
+        return f"{path}{_AUTOSAVE_JOURNAL_SUFFIX}"
+
+    @staticmethod
+    def _encode_journal_record(record: dict[str, Any]) -> str:
+        return (
+            json.dumps(
+                record,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+
+    def _append_journal_record(self, path: str, record: dict[str, Any]) -> None:
+        journal_path = self._journal_path(path)
+        payload = self._encode_journal_record(record)
+        payload_size = len(payload.encode("utf-8"))
+        if payload_size > MAX_SESSION_SNAPSHOT_BYTES:
+            raise ValueError(
+                "autosave journal record exceeds "
+                f"{MAX_SESSION_SNAPSHOT_BYTES} UTF-8 bytes while writing: "
+                f"{journal_path}"
+            )
+        with open_regular_text_append(journal_path, readable=True) as handle:
+            current_size = os.fstat(handle.fileno()).st_size
+            complete_size = self._complete_journal_size(
+                handle.fileno(),
+                current_size,
+            )
+            if complete_size < current_size:
+                os.ftruncate(handle.fileno(), complete_size)
+                current_size = complete_size
+            if current_size + payload_size > MAX_SESSION_SNAPSHOT_BYTES:
+                raise ValueError(
+                    "autosave journal exceeds "
+                    f"{MAX_SESSION_SNAPSHOT_BYTES} UTF-8 bytes while writing: "
+                    f"{journal_path}"
+                )
+            write_locked_text(handle, payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    @staticmethod
+    def _complete_journal_size(fd: int, size: int) -> int:
+        """Find the end of the last complete line using bounded tail reads."""
+        if size == 0 or os.pread(fd, 1, size - 1) == b"\n":
+            return size
+        cursor = size
+        while cursor:
+            start = max(0, cursor - _JSON_WRITE_CHUNK_CHARS)
+            chunk = os.pread(fd, cursor - start, start)
+            newline = chunk.rfind(b"\n")
+            if newline >= 0:
+                return start + newline + 1
+            cursor = start
+        return 0
+
+    def _read_journal_records(self, path: str) -> list[dict[str, Any]]:
+        journal_path = self._journal_path(path)
+        try:
+            payload = read_regular_bytes(
+                journal_path,
+                max_bytes=MAX_SESSION_SNAPSHOT_BYTES,
+            )
+        except FileNotFoundError:
+            return []
+        final_newline = payload.rfind(b"\n")
+        if final_newline < 0:
+            return []
+        try:
+            complete = payload[: final_newline + 1].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Invalid autosave journal: non-UTF-8 record") from exc
+        records: list[dict[str, Any]] = []
+        for lineno, line in enumerate(complete.splitlines(), 1):
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid autosave journal record at line {lineno}"
+                ) from exc
+            if not isinstance(record, dict):
+                raise ValueError(
+                    f"Invalid autosave journal record at line {lineno}: expected object"
+                )
+            if record.get("journal_version") != _AUTOSAVE_JOURNAL_VERSION:
+                raise ValueError(
+                    f"Invalid autosave journal record at line {lineno}: version"
+                )
+            records.append(record)
+        return records
+
+    @staticmethod
+    def _snapshot_sequence(snapshot: dict[str, Any]) -> int:
+        value = snapshot.get(_AUTOSAVE_SEQUENCE_KEY, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("Invalid session snapshot: autosave sequence")
+        return value
+
+    @staticmethod
+    def _record_integer(
+        record: dict[str, Any],
+        key: str,
+        *,
+        minimum: int,
+    ) -> int:
+        value = record.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            raise ValueError(f"Invalid autosave journal: {key}")
+        return value
 
     @staticmethod
     def _parse_jsonl(text: str) -> list[dict[str, Any]]:

--- a/opencollab/application/_scheduler_cleanup.py
+++ b/opencollab/application/_scheduler_cleanup.py
@@ -159,7 +159,24 @@ class SchedulerCleanupMixin:
         if not session_resources_closed:
             failures.append("session resource close failed or timed out")
 
-        release_safe = not pending and environments_aborted and persistence_quiesced and session_resources_closed
+        lifecycle_errors: list[BaseException] = []
+        lifecycle_quiesced = True
+        for description, resource in self._lifecycle_resources:
+            if getattr(resource, "cleanup_quiesced", False) is True:
+                continue
+            lifecycle_quiesced = False
+            failures.append(f"{description} did not quiesce")
+            error = getattr(resource, "cleanup_error", None)
+            if isinstance(error, BaseException):
+                lifecycle_errors.append(error)
+
+        release_safe = (
+            not pending
+            and environments_aborted
+            and persistence_quiesced
+            and session_resources_closed
+            and lifecycle_quiesced
+        )
         worktrees_released = release_safe and await self._release_worktree_pool_bounded(timeout=timeout)
         if not worktrees_released:
             failures.append(
@@ -171,6 +188,8 @@ class SchedulerCleanupMixin:
             failure = RuntimeError("technical scheduler cleanup failed: " + "; ".join(failures))
             if persistence_errors:
                 raise failure from persistence_errors[0]
+            if lifecycle_errors:
+                raise failure from lifecycle_errors[0]
             raise failure
 
     def _persistence_sessions(self, initial: tuple[Any, ...]) -> tuple[Any, ...]:

--- a/opencollab/application/autosave.py
+++ b/opencollab/application/autosave.py
@@ -13,6 +13,7 @@ SaveOperation = Callable[[], None]
 PrepareSave = Callable[[], SaveOperation | None]
 
 SAVE_TRIGGERS = frozenset({"user_message_appended", "step_end"})
+AUTOSAVE_DEBOUNCE_SECONDS = 0.05
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,7 @@ class AutoSaveSubscriber(EventPublisherPort):
         self._last_error: Exception | None = None
         self._failure_count = 0
         self._pending = False
+        self._wake: asyncio.Event | None = None
 
     @property
     def last_error(self) -> Exception | None:
@@ -77,13 +79,17 @@ class AutoSaveSubscriber(EventPublisherPort):
     async def emit(self, event: SessionEvent) -> None:
         if event.type not in SAVE_TRIGGERS:
             return
-        self.enqueue()
+        self._enqueue(force=False)
         # Let the owned worker freeze the first pending generation before the
         # caller continues mutating session state, without waiting for I/O.
         await asyncio.sleep(0)
 
     def enqueue(self) -> asyncio.Task[None] | None:
-        """Queue the latest generation without waiting for persistence."""
+        """Force the latest generation into the owned persistence worker."""
+        return self._enqueue(force=True)
+
+    def _enqueue(self, *, force: bool) -> asyncio.Task[None]:
+        """Queue one generation, optionally ending the debounce window."""
         loop = asyncio.get_running_loop()
         self._pending = True
         owner = self._tail
@@ -94,7 +100,12 @@ class AutoSaveSubscriber(EventPublisherPort):
                 raise error
             owner = None
         if owner is not None and not owner.done():
+            if force and self._wake is not None:
+                self._wake.set()
             return owner
+        self._wake = asyncio.Event()
+        if force:
+            self._wake.set()
         owner = loop.create_task(self._drain_latest())
         self._tail = owner
         self._owners.add(owner)
@@ -112,16 +123,30 @@ class AutoSaveSubscriber(EventPublisherPort):
 
     async def _drain_latest(self) -> None:
         cancelled = False
-        while self._pending:
+        while True:
             self._pending = False
             operation = self._prepare_operation()
-            if operation is None:
-                continue
-            write = asyncio.create_task(asyncio.to_thread(_run_save, operation))
-            cancelled = await self._wait_owned(write) or cancelled
-            error = write.result()
-            if error is not None:
-                self._record_failure(error)
+            if operation is not None:
+                write = asyncio.create_task(asyncio.to_thread(_run_save, operation))
+                cancelled = await self._wait_owned(write) or cancelled
+                error = write.result()
+                if error is not None:
+                    self._record_failure(error)
+
+            wake = self._wake
+            if not cancelled and wake is not None:
+                try:
+                    await asyncio.wait_for(
+                        wake.wait(),
+                        timeout=AUTOSAVE_DEBOUNCE_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    pass
+                except asyncio.CancelledError:
+                    cancelled = True
+                wake.clear()
+            if not self._pending:
+                break
         if cancelled:
             raise asyncio.CancelledError
 
@@ -149,5 +174,6 @@ class AutoSaveSubscriber(EventPublisherPort):
         self._owners.discard(owner)
         if self._tail is owner:
             self._tail = None
+            self._wake = None
         if not owner.cancelled():
             owner.exception()

--- a/opencollab/application/autosave.py
+++ b/opencollab/application/autosave.py
@@ -35,11 +35,11 @@ class AutoSaveSubscriber(EventPublisherPort):
     Two phases keep the write off the hot path without tearing the snapshot:
     *freeze* runs ``prepare_fn`` on the event loop to capture a self-consistent
     copy of mutable session state, then *flush* runs the file I/O off-thread via
-    ``asyncio.to_thread``. Step checkpoints use exponentially spaced
-    generations (1, 2, 4, 8, ...) so the cumulative snapshot volume stays
-    linear as a session grows. A single worker also coalesces generations that
-    have not started yet, so a slow sink writes the latest pending snapshot
-    instead of replaying every obsolete intermediate state.
+    ``asyncio.to_thread``. Production session operations append an incremental
+    journal record and periodically compact it into an atomic base snapshot.
+    A single worker also coalesces generations that have not started yet, so a
+    slow sink writes the latest pending state instead of replaying every
+    obsolete intermediate state.
 
     Ordering is guaranteed by *single-subscriber ownership*, not by any key:
     one subscriber owns every queued task, so caller cancellation cannot
@@ -61,8 +61,6 @@ class AutoSaveSubscriber(EventPublisherPort):
         self._last_error: Exception | None = None
         self._failure_count = 0
         self._pending = False
-        self._step_generation = 0
-        self._next_step_checkpoint = 1
 
     @property
     def last_error(self) -> Exception | None:
@@ -81,11 +79,6 @@ class AutoSaveSubscriber(EventPublisherPort):
     async def emit(self, event: SessionEvent) -> None:
         if event.type not in SAVE_TRIGGERS:
             return
-        if event.type == "step_end":
-            self._step_generation += 1
-            if self._step_generation < self._next_step_checkpoint:
-                return
-            self._next_step_checkpoint *= 2
         self._enqueue()
         # Let the owned worker freeze the first pending generation before the
         # caller continues mutating session state, without waiting for I/O.

--- a/opencollab/application/autosave.py
+++ b/opencollab/application/autosave.py
@@ -13,7 +13,6 @@ SaveOperation = Callable[[], None]
 PrepareSave = Callable[[], SaveOperation | None]
 
 SAVE_TRIGGERS = frozenset({"user_message_appended", "step_end"})
-AUTOSAVE_DEBOUNCE_SECONDS = 0.05
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +35,11 @@ class AutoSaveSubscriber(EventPublisherPort):
     Two phases keep the write off the hot path without tearing the snapshot:
     *freeze* runs ``prepare_fn`` on the event loop to capture a self-consistent
     copy of mutable session state, then *flush* runs the file I/O off-thread via
-    ``asyncio.to_thread``. A single worker coalesces generations that have not
-    started yet, so a slow sink writes the latest pending snapshot instead of
-    replaying every obsolete intermediate state.
+    ``asyncio.to_thread``. Step checkpoints use exponentially spaced
+    generations (1, 2, 4, 8, ...) so the cumulative snapshot volume stays
+    linear as a session grows. A single worker also coalesces generations that
+    have not started yet, so a slow sink writes the latest pending snapshot
+    instead of replaying every obsolete intermediate state.
 
     Ordering is guaranteed by *single-subscriber ownership*, not by any key:
     one subscriber owns every queued task, so caller cancellation cannot
@@ -60,7 +61,8 @@ class AutoSaveSubscriber(EventPublisherPort):
         self._last_error: Exception | None = None
         self._failure_count = 0
         self._pending = False
-        self._wake: asyncio.Event | None = None
+        self._step_generation = 0
+        self._next_step_checkpoint = 1
 
     @property
     def last_error(self) -> Exception | None:
@@ -79,17 +81,22 @@ class AutoSaveSubscriber(EventPublisherPort):
     async def emit(self, event: SessionEvent) -> None:
         if event.type not in SAVE_TRIGGERS:
             return
-        self._enqueue(force=False)
+        if event.type == "step_end":
+            self._step_generation += 1
+            if self._step_generation < self._next_step_checkpoint:
+                return
+            self._next_step_checkpoint *= 2
+        self._enqueue()
         # Let the owned worker freeze the first pending generation before the
         # caller continues mutating session state, without waiting for I/O.
         await asyncio.sleep(0)
 
     def enqueue(self) -> asyncio.Task[None] | None:
-        """Force the latest generation into the owned persistence worker."""
-        return self._enqueue(force=True)
+        """Flush the latest generation through the owned persistence worker."""
+        return self._enqueue()
 
-    def _enqueue(self, *, force: bool) -> asyncio.Task[None]:
-        """Queue one generation, optionally ending the debounce window."""
+    def _enqueue(self) -> asyncio.Task[None]:
+        """Queue one generation, coalescing it behind an active write."""
         loop = asyncio.get_running_loop()
         self._pending = True
         owner = self._tail
@@ -100,12 +107,7 @@ class AutoSaveSubscriber(EventPublisherPort):
                 raise error
             owner = None
         if owner is not None and not owner.done():
-            if force and self._wake is not None:
-                self._wake.set()
             return owner
-        self._wake = asyncio.Event()
-        if force:
-            self._wake.set()
         owner = loop.create_task(self._drain_latest())
         self._tail = owner
         self._owners.add(owner)
@@ -123,7 +125,7 @@ class AutoSaveSubscriber(EventPublisherPort):
 
     async def _drain_latest(self) -> None:
         cancelled = False
-        while True:
+        while self._pending:
             self._pending = False
             operation = self._prepare_operation()
             if operation is not None:
@@ -132,21 +134,6 @@ class AutoSaveSubscriber(EventPublisherPort):
                 error = write.result()
                 if error is not None:
                     self._record_failure(error)
-
-            wake = self._wake
-            if not cancelled and wake is not None:
-                try:
-                    await asyncio.wait_for(
-                        wake.wait(),
-                        timeout=AUTOSAVE_DEBOUNCE_SECONDS,
-                    )
-                except asyncio.TimeoutError:
-                    pass
-                except asyncio.CancelledError:
-                    cancelled = True
-                wake.clear()
-            if not self._pending:
-                break
         if cancelled:
             raise asyncio.CancelledError
 
@@ -174,6 +161,5 @@ class AutoSaveSubscriber(EventPublisherPort):
         self._owners.discard(owner)
         if self._tail is owner:
             self._tail = None
-            self._wake = None
         if not owner.cancelled():
             owner.exception()

--- a/opencollab/application/autosave.py
+++ b/opencollab/application/autosave.py
@@ -33,11 +33,11 @@ class AutoSaveSubscriber(EventPublisherPort):
     """Freeze-then-flush persistence of session snapshots (Command + Memento).
 
     Two phases keep the write off the hot path without tearing the snapshot:
-    *freeze* runs ``prepare_fn`` synchronously on the event loop to capture a
-    self-consistent copy of mutable session state, then *flush* runs the file
-    I/O off-thread via ``asyncio.to_thread``. Saves chain in strict submission
-    order — each flush awaits the previous tail before writing — so a later
-    snapshot never overtakes an earlier one.
+    *freeze* runs ``prepare_fn`` on the event loop to capture a self-consistent
+    copy of mutable session state, then *flush* runs the file I/O off-thread via
+    ``asyncio.to_thread``. A single worker coalesces generations that have not
+    started yet, so a slow sink writes the latest pending snapshot instead of
+    replaying every obsolete intermediate state.
 
     Ordering is guaranteed by *single-subscriber ownership*, not by any key:
     one subscriber owns every queued task, so caller cancellation cannot
@@ -58,6 +58,7 @@ class AutoSaveSubscriber(EventPublisherPort):
         self._owners: set[asyncio.Task[None]] = set()
         self._last_error: Exception | None = None
         self._failure_count = 0
+        self._pending = False
 
     @property
     def last_error(self) -> Exception | None:
@@ -76,24 +77,25 @@ class AutoSaveSubscriber(EventPublisherPort):
     async def emit(self, event: SessionEvent) -> None:
         if event.type not in SAVE_TRIGGERS:
             return
-        owner = self.enqueue()
-        if owner is not None:
-            await asyncio.shield(owner)
+        self.enqueue()
+        # Let the owned worker freeze the first pending generation before the
+        # caller continues mutating session state, without waiting for I/O.
+        await asyncio.sleep(0)
 
     def enqueue(self) -> asyncio.Task[None] | None:
-        """Freeze and queue one save without waiting for earlier snapshots."""
-        operation = self._prepare_operation()
-        if operation is None:
-            return None
+        """Queue the latest generation without waiting for persistence."""
         loop = asyncio.get_running_loop()
-        previous = self._tail
-        if previous is not None and previous.get_loop() is not loop:
-            if not previous.done():
+        self._pending = True
+        owner = self._tail
+        if owner is not None and owner.get_loop() is not loop:
+            if not owner.done():
                 error = RuntimeError("auto-save subscriber cannot span active event loops")
                 self._record_failure(error)
                 raise error
-            previous = None
-        owner = loop.create_task(self._save_after(previous, operation))
+            owner = None
+        if owner is not None and not owner.done():
+            return owner
+        owner = loop.create_task(self._drain_latest())
         self._tail = owner
         self._owners.add(owner)
         owner.add_done_callback(self._save_done)
@@ -108,19 +110,18 @@ class AutoSaveSubscriber(EventPublisherPort):
             self._record_failure(exc)
             return None
 
-    async def _save_after(
-        self,
-        previous: asyncio.Task[None] | None,
-        operation: SaveOperation,
-    ) -> None:
+    async def _drain_latest(self) -> None:
         cancelled = False
-        if previous is not None:
-            cancelled = await self._wait_owned(previous)
-        write = asyncio.create_task(asyncio.to_thread(_run_save, operation))
-        cancelled = await self._wait_owned(write) or cancelled
-        error = write.result()
-        if error is not None:
-            self._record_failure(error)
+        while self._pending:
+            self._pending = False
+            operation = self._prepare_operation()
+            if operation is None:
+                continue
+            write = asyncio.create_task(asyncio.to_thread(_run_save, operation))
+            cancelled = await self._wait_owned(write) or cancelled
+            error = write.result()
+            if error is not None:
+                self._record_failure(error)
         if cancelled:
             raise asyncio.CancelledError
 

--- a/opencollab/application/hooks.py
+++ b/opencollab/application/hooks.py
@@ -24,6 +24,11 @@ _DIRECT_EVENT_MAP: dict[str, str] = {
     "agent_spawned": "SessionStart",
     "error": "Notification",
 }
+_TERMINAL_DISPOSITIONS = {
+    "agent_completed": "completed",
+    "agent_failed": "failed",
+    "agent_cancelled": "cancelled",
+}
 
 
 class HookEventSubscriber(EventPublisherPort):
@@ -35,6 +40,9 @@ class HookEventSubscriber(EventPublisherPort):
         if hook_event is None:
             return
         payload = {"hook_event_name": hook_event, **dict(event.data)}
+        disposition = _TERMINAL_DISPOSITIONS.get(event.type)
+        if disposition is not None:
+            payload["disposition"] = disposition
         await self._runner.fire(hook_event, payload)
 
     def _hook_event_for(self, event: Any) -> str | None:
@@ -42,6 +50,8 @@ class HookEventSubscriber(EventPublisherPort):
             # parent_aid is None only for agent 0 (the lead): that completion is
             # the whole team stopping; a child completing is a SubagentStop.
             return "Stop" if event.data.get("parent_aid") is None else "SubagentStop"
+        if event.type in {"agent_failed", "agent_cancelled"}:
+            return "Stop" if event.data.get("aid") == 0 else "SubagentStop"
         return _DIRECT_EVENT_MAP.get(event.type)
 
 

--- a/opencollab/application/ports.py
+++ b/opencollab/application/ports.py
@@ -436,6 +436,37 @@ class SnapshotStorePort(Protocol):
         ...
 
 
+@runtime_checkable
+class JournalSnapshotStorePort(Protocol):
+    """Optional incremental autosave writer with atomic compaction."""
+
+    def has_snapshot(self, path: str) -> bool:
+        ...
+
+    def append_snapshot_delta(
+        self,
+        path: str,
+        *,
+        sequence: int,
+        replace_from: int,
+        messages: list[dict[str, Any]],
+        meta: dict[str, Any],
+        seen_result_hashes_reset: bool = False,
+        seen_result_hashes_added: list[str] | None = None,
+    ) -> None:
+        ...
+
+    def checkpoint_snapshot(
+        self,
+        path: str,
+        messages: list[dict[str, Any]],
+        *,
+        meta: dict[str, Any],
+        sequence: int,
+    ) -> None:
+        ...
+
+
 class TracePort(Protocol):
     """Trajectory recorder surface."""
 

--- a/opencollab/application/scheduler.py
+++ b/opencollab/application/scheduler.py
@@ -180,6 +180,9 @@ class Scheduler(
         self._cleanup_task: asyncio.Task[None] | None = None
         self._fallback_autosavers: dict[int, AutoSaveSubscriber] = {}
         self._scheduler_persistence_errors: list[Exception] = []
+        # Bootstrap-owned resources whose process/persistence state must be
+        # proven quiescent before scheduler cleanup may release worktrees.
+        self._lifecycle_resources: list[tuple[str, Any]] = []
         # A synchronous review loop temporarily yields its caller's turn lease
         # through ordinary ``spawn`` calls. Context-local accounting records only
         # leases actually released by this review invocation, so an external API
@@ -188,6 +191,16 @@ class Scheduler(
         self._review_parent_lease_tracker: contextvars.ContextVar[
             tuple[int, dict[str, int]] | None
         ] = contextvars.ContextVar("review_parent_lease_tracker", default=None)
+
+    def register_lifecycle_resource(
+        self,
+        resource: Any,
+        *,
+        description: str,
+    ) -> None:
+        """Make an externally owned resource part of final cleanup evidence."""
+        self._lifecycle_resources.append((description, resource))
+
 
 __all__ = [
     "LaunchSpec",

--- a/opencollab/application/schema_validate.py
+++ b/opencollab/application/schema_validate.py
@@ -27,7 +27,12 @@ _TYPE_CHECKS = {
     "array": lambda v: isinstance(v, list),
     "string": lambda v: isinstance(v, str),
     "boolean": lambda v: isinstance(v, bool),
-    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+    "integer": lambda v: (
+        isinstance(v, (int, float))
+        and not isinstance(v, bool)
+        and math.isfinite(v)
+        and float(v).is_integer()
+    ),
     "number": lambda v: (
         isinstance(v, (int, float))
         and not isinstance(v, bool)
@@ -165,7 +170,7 @@ def _validate(value: Any, schema: dict[str, Any], path: str, errors: list[str]) 
         return
 
     enum = schema.get("enum")
-    if enum is not None and value not in enum:
+    if enum is not None and not any(_json_equal(value, member) for member in enum):
         errors.append(f"{path}: value {value!r} not in enum {enum!r}")
 
     one_of = schema.get("oneOf")
@@ -187,6 +192,9 @@ def _validate(value: Any, schema: dict[str, Any], path: str, errors: list[str]) 
     if _is_number(value):
         _validate_number(value, schema, path, errors)
 
+    # Container constraints apply according to the accepted instance type, not
+    # the literal shape of ``type``.  In particular, ``["object", "null"]``
+    # still needs to validate properties when the instance is an object.
     if isinstance(value, dict):
         _validate_object(value, schema, path, errors)
     elif isinstance(value, list):
@@ -262,6 +270,33 @@ def _is_number(value: Any) -> bool:
         and not isinstance(value, bool)
         and math.isfinite(value)
     )
+
+
+def _json_equal(left: Any, right: Any) -> bool:
+    """Return JSON-Schema equality without Python's bool/int aliasing."""
+    if isinstance(left, bool) or isinstance(right, bool):
+        return isinstance(left, bool) and isinstance(right, bool) and left is right
+    if _is_number(left) or _is_number(right):
+        return _is_number(left) and _is_number(right) and left == right
+    if left is None or right is None:
+        return left is None and right is None
+    if isinstance(left, str) or isinstance(right, str):
+        return isinstance(left, str) and isinstance(right, str) and left == right
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(_json_equal(a, b) for a, b in zip(left, right, strict=True))
+        )
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and left.keys() == right.keys()
+            and all(_json_equal(left[key], right[key]) for key in left)
+        )
+    return type(left) is type(right) and left == right
 
 
 def _check_type(value: Any, expected_type: Any) -> bool:

--- a/opencollab/application/self_collaboration.py
+++ b/opencollab/application/self_collaboration.py
@@ -70,6 +70,35 @@ async def _emit_review_event(
         logger.error("review event %s failed: %s", event.type, exc)
 
 
+def _format_review_failure(
+    *,
+    iteration: int,
+    stage: str,
+    artifact: str,
+    feedback: str = "",
+    reason: str = "",
+    coder_phase: str | None = None,
+    coder_reason: str | None = None,
+) -> str:
+    sections = [
+        f"[Self-Collaboration: FAILED after {iteration} iteration(s)]",
+        f"Failure stage: {stage}",
+    ]
+    if reason:
+        sections.append(f"Failure reason: {reason}")
+    if coder_phase is not None:
+        sections.extend(
+            (
+                f"Coder terminal phase: {coder_phase}",
+                f"Coder terminal reason: {coder_reason or 'none'}",
+            )
+        )
+    sections.append(f"Last implementation:\n{artifact}")
+    if feedback:
+        sections.append(f"Last reviewer feedback:\n{feedback}")
+    return "\n\n".join(sections)
+
+
 async def run_spawn_with_review(
     scheduler: ReviewLoopScheduler,
     parent_aid: int,
@@ -90,6 +119,7 @@ async def run_spawn_with_review(
     max_iterations = validate_review_iterations(max_iterations)
     current_task = task
     last_result = ""
+    last_feedback = ""
 
     for iteration in range(1, max_iterations + 1):
         await _emit_review_event(
@@ -98,8 +128,41 @@ async def run_spawn_with_review(
         )
 
         # Spawn coder and wait
-        coder_aid = await scheduler.spawn(parent_aid, "coder", current_task, context)
-        await scheduler.wait_until_terminal(coder_aid)
+        try:
+            coder_aid = await scheduler.spawn(
+                parent_aid,
+                "coder",
+                current_task,
+                context,
+            )
+        except Exception as exc:
+            await _emit_review_event(
+                scheduler,
+                scheduler.events.review_completed(iteration, False),
+            )
+            return _format_review_failure(
+                iteration=iteration,
+                stage="coder_spawn",
+                artifact=last_result,
+                feedback=last_feedback,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+        try:
+            await scheduler.wait_until_terminal(coder_aid)
+        except Exception as exc:
+            coder_scb = scheduler.table.get(coder_aid)
+            code_result = coder_scb.result if coder_scb else last_result
+            await _emit_review_event(
+                scheduler,
+                scheduler.events.review_completed(iteration, False),
+            )
+            return _format_review_failure(
+                iteration=iteration,
+                stage="coder_wait",
+                artifact=code_result,
+                feedback=last_feedback,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
         coder_scb = scheduler.table.get(coder_aid)
         code_result = coder_scb.result if coder_scb else ""
         if coder_scb is None or coder_scb.state.phase is not SessionPhase.DONE:
@@ -109,12 +172,15 @@ async def run_spawn_with_review(
                 scheduler,
                 scheduler.events.review_completed(iteration, False),
             )
-            return (
-                f"[Self-Collaboration: FAILED after {iteration} iteration(s)]\n\n"
-                f"Coder terminal phase: {phase}\n"
-                f"Coder terminal reason: {reason or 'none'}\n\n"
-                f"Last implementation:\n{code_result}"
+            return _format_review_failure(
+                iteration=iteration,
+                stage="coder_terminal",
+                artifact=code_result,
+                feedback=last_feedback,
+                coder_phase=phase,
+                coder_reason=reason,
             )
+        last_result = code_result
 
         # Spawn reviewer and wait
         review_prompt = (
@@ -128,15 +194,44 @@ async def run_spawn_with_review(
             f"VERDICT: FAIL\n\n"
             f"If FAIL, provide detailed fix instructions before the verdict line."
         )
-        reviewer_aid = await scheduler.spawn(
-            parent_aid,
-            "reviewer",
-            review_prompt,
-            context,
-        )
-        await scheduler.wait_until_terminal(reviewer_aid)
+        try:
+            reviewer_aid = await scheduler.spawn(
+                parent_aid,
+                "reviewer",
+                review_prompt,
+                context,
+            )
+        except Exception as exc:
+            await _emit_review_event(
+                scheduler,
+                scheduler.events.review_completed(iteration, False),
+            )
+            return _format_review_failure(
+                iteration=iteration,
+                stage="reviewer_spawn",
+                artifact=last_result,
+                feedback=last_feedback,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+        try:
+            await scheduler.wait_until_terminal(reviewer_aid)
+        except Exception as exc:
+            reviewer_scb = scheduler.table.get(reviewer_aid)
+            review_result = reviewer_scb.result if reviewer_scb else ""
+            await _emit_review_event(
+                scheduler,
+                scheduler.events.review_completed(iteration, False),
+            )
+            return _format_review_failure(
+                iteration=iteration,
+                stage="reviewer_wait",
+                artifact=last_result,
+                feedback=review_result or last_feedback,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
         reviewer_scb = scheduler.table.get(reviewer_aid)
         review_result = reviewer_scb.result if reviewer_scb else ""
+        last_feedback = review_result
 
         verdict = ReviewVerdict.parse(review_result)
         reviewer_completed = (
@@ -163,11 +258,12 @@ async def run_spawn_with_review(
             f"Reapply the previous implementation in your fresh worktree, preserve its "
             f"correct parts, and fix the issues identified by the reviewer."
         )
-        last_result = code_result
-
-    return (
-        f"[Self-Collaboration: FAILED after {max_iterations} iterations]\n\n"
-        f"Last implementation:\n{last_result}"
+    return _format_review_failure(
+        iteration=max_iterations,
+        stage="review_verdict",
+        artifact=last_result,
+        feedback=last_feedback,
+        reason="reviewer did not return a passing verdict",
     )
 
 

--- a/opencollab/application/self_collaboration.py
+++ b/opencollab/application/self_collaboration.py
@@ -151,7 +151,7 @@ async def run_spawn_with_review(
             await scheduler.wait_until_terminal(coder_aid)
         except Exception as exc:
             coder_scb = scheduler.table.get(coder_aid)
-            code_result = coder_scb.result if coder_scb else last_result
+            code_result = (coder_scb.result if coder_scb else "") or last_result
             await _emit_review_event(
                 scheduler,
                 scheduler.events.review_completed(iteration, False),
@@ -164,7 +164,7 @@ async def run_spawn_with_review(
                 reason=f"{type(exc).__name__}: {exc}",
             )
         coder_scb = scheduler.table.get(coder_aid)
-        code_result = coder_scb.result if coder_scb else ""
+        code_result = (coder_scb.result if coder_scb else "") or last_result
         if coder_scb is None or coder_scb.state.phase is not SessionPhase.DONE:
             phase = "missing" if coder_scb is None else coder_scb.state.phase.value
             reason = None if coder_scb is None else coder_scb.state.terminal_reason

--- a/opencollab/application/session.py
+++ b/opencollab/application/session.py
@@ -337,6 +337,7 @@ class Session:
             self.state.__dict__.clear()
             self.state.__dict__.update(restored.__dict__)
             self._restore_auto_save_tracking(snapshot)
+            self._checkpoint_restored_auto_save_target(path)
             return
 
         self.messages = messages
@@ -438,6 +439,7 @@ class Session:
             self.state.set_phase(SessionPhase.IDLE)
             self._append_restore_results_for_open_tool_calls()
         self._restore_auto_save_tracking(snapshot)
+        self._checkpoint_restored_auto_save_target(path)
 
     def _restore_auto_save_tracking(self, snapshot: dict[str, Any]) -> None:
         sequence = _snapshot_nonnegative_int(snapshot.get("_autosave_sequence"))
@@ -454,6 +456,11 @@ class Session:
         self._next_auto_save_checkpoint = (
             1 if sequence == 0 else 1 << sequence.bit_length()
         )
+
+    def _checkpoint_restored_auto_save_target(self, source_path: str) -> None:
+        target_path = self._auto_save_path
+        if target_path and not _same_snapshot_path(source_path, target_path):
+            self.save(target_path)
 
     def _open_tool_call_ids(self) -> list[str]:
         # Pair calls and results in transcript order. Tool-call ids are expected
@@ -513,7 +520,7 @@ class Session:
     def save(self, path: str) -> None:
         messages, meta = self._snapshot_for_save()
         if (
-            path == self._auto_save_path
+            _same_snapshot_path(path, self._auto_save_path)
             and isinstance(self.store, JournalSnapshotStorePort)
         ):
             self.store.checkpoint_snapshot(
@@ -650,6 +657,14 @@ class Session:
 _LEGACY_TERMINAL_PHASES = frozenset(
     {"cancelled", "budget_exceeded", "step_limit_exceeded", "context_overflow"}
 )
+
+
+def _same_snapshot_path(left: str | None, right: str | None) -> bool:
+    if left is None or right is None:
+        return False
+    return os.path.normcase(os.path.abspath(os.fspath(left))) == os.path.normcase(
+        os.path.abspath(os.fspath(right))
+    )
 
 
 def _restore_phase(raw: object) -> SessionPhase:

--- a/opencollab/application/session.py
+++ b/opencollab/application/session.py
@@ -11,6 +11,7 @@ from opencollab.application.autosave import AutoSaveSubscriber
 from opencollab.application.event_bus import EventBus
 from opencollab.application.ports import (
     EnvironmentPort,
+    JournalSnapshotStorePort,
     LLMPort,
     PermissionPort,
     SafetyPolicyPort,
@@ -100,6 +101,11 @@ class Session:
         self._owns_llm = runtime.owns_llm
         self._llm_closed = False
         self._llm_close_error: BaseException | None = None
+        self._auto_save_sequence = 0
+        self._auto_save_message_count = 0
+        self._auto_save_rewrite_from: int | None = 0
+        self._auto_save_seen_result_hashes: set[str] = set()
+        self._next_auto_save_checkpoint = 1
         # The env attribute mirrors the runtime's tool_execution env so
         # downstream readers (snapshot, characterization tests) still see
         # the same Environment instance.
@@ -208,6 +214,8 @@ class Session:
     @messages.setter
     def messages(self, value: list[dict]) -> None:
         self.state.replace_messages(value)
+        if hasattr(self, "_auto_save_rewrite_from"):
+            self._auto_save_rewrite_from = 0
 
     @property
     def used_tokens(self) -> int:
@@ -287,7 +295,17 @@ class Session:
         if self._launch_applied:
             return
         self._launch_applied = True
-        if launch.session_file and os.path.exists(launch.session_file):
+        resumable = bool(
+            launch.session_file
+            and (
+                os.path.exists(launch.session_file)
+                or (
+                    isinstance(self.store, JournalSnapshotStorePort)
+                    and self.store.has_snapshot(launch.session_file)
+                )
+            )
+        )
+        if launch.session_file and resumable:
             self.restore(launch.session_file)
         elif launch.auto_save_path:
             self.save(launch.auto_save_path)
@@ -318,6 +336,7 @@ class Session:
             ] if isinstance(pending_messages, list) else []
             self.state.__dict__.clear()
             self.state.__dict__.update(restored.__dict__)
+            self._restore_auto_save_tracking(snapshot)
             return
 
         self.messages = messages
@@ -418,6 +437,23 @@ class Session:
         if self.state.phase is SessionPhase.AWAITING_EVENTS and self.state.pending_events.is_empty():
             self.state.set_phase(SessionPhase.IDLE)
             self._append_restore_results_for_open_tool_calls()
+        self._restore_auto_save_tracking(snapshot)
+
+    def _restore_auto_save_tracking(self, snapshot: dict[str, Any]) -> None:
+        sequence = _snapshot_nonnegative_int(snapshot.get("_autosave_sequence"))
+        self._auto_save_sequence = sequence
+        stored_messages = snapshot.get("messages")
+        self._auto_save_message_count = min(
+            len(stored_messages) if isinstance(stored_messages, list) else 0,
+            len(self.state.messages),
+        )
+        self._auto_save_rewrite_from = None
+        self._auto_save_seen_result_hashes = set(
+            self.state.turn.seen_result_hashes
+        )
+        self._next_auto_save_checkpoint = (
+            1 if sequence == 0 else 1 << sequence.bit_length()
+        )
 
     def _open_tool_call_ids(self) -> list[str]:
         # Pair calls and results in transcript order. Tool-call ids are expected
@@ -476,9 +512,25 @@ class Session:
 
     def save(self, path: str) -> None:
         messages, meta = self._snapshot_for_save()
+        if (
+            path == self._auto_save_path
+            and isinstance(self.store, JournalSnapshotStorePort)
+        ):
+            self.store.checkpoint_snapshot(
+                path,
+                messages,
+                meta=meta,
+                sequence=self._auto_save_sequence,
+            )
+            self._auto_save_message_count = len(self.state.messages)
+            self._auto_save_rewrite_from = None
+            self._auto_save_seen_result_hashes = set(
+                self.state.turn.seen_result_hashes
+            )
+            return
         self.store.save(path, messages, meta=meta)
 
-    def _snapshot_for_save(self) -> tuple[list[dict], dict]:
+    def _snapshot_for_save(self, message_start: int = 0) -> tuple[list[dict], dict]:
         """Freeze one internally consistent payload before persistence starts."""
         meta = {
             "snapshot_version": 1,
@@ -513,7 +565,7 @@ class Session:
         if self.state.pending_user_messages:
             meta["pending_messages"] = self.state.enriched_pending_user_messages()
         return (
-            copy.deepcopy(self.state.enriched_messages()),
+            copy.deepcopy(self.state.enriched_messages(message_start)),
             copy.deepcopy(meta),
         )
 
@@ -521,8 +573,64 @@ class Session:
         if not self._auto_save_path:
             return None
         path = self._auto_save_path
-        messages, meta = self._snapshot_for_save()
-        return lambda: self.store.save(path, messages, meta=meta)
+        if not isinstance(self.store, JournalSnapshotStorePort):
+            messages, meta = self._snapshot_for_save()
+            return lambda: self.store.save(path, messages, meta=meta)
+
+        sequence = self._auto_save_sequence + 1
+        message_count = len(self.state.messages)
+        replace_from = min(self._auto_save_message_count, message_count)
+        if replace_from:
+            # The run loop can fold steering into the most recent persisted
+            # user message, so retain one-message overlap without re-copying
+            # the complete transcript.
+            replace_from -= 1
+        if self._auto_save_rewrite_from is not None:
+            replace_from = min(replace_from, self._auto_save_rewrite_from)
+        messages, meta = self._snapshot_for_save(replace_from)
+        current_seen_hashes = set(self.state.turn.seen_result_hashes)
+        seen_hashes_reset = not self._auto_save_seen_result_hashes.issubset(
+            current_seen_hashes
+        )
+        seen_hashes_added = sorted(
+            current_seen_hashes
+            if seen_hashes_reset
+            else current_seen_hashes - self._auto_save_seen_result_hashes
+        )
+        checkpoint_due = sequence >= self._next_auto_save_checkpoint
+        checkpoint_messages = (
+            copy.deepcopy(self.state.enriched_messages())
+            if checkpoint_due
+            else None
+        )
+
+        def persist_incrementally() -> None:
+            self.store.append_snapshot_delta(
+                path,
+                sequence=sequence,
+                replace_from=replace_from,
+                messages=messages,
+                meta=meta,
+                seen_result_hashes_reset=seen_hashes_reset,
+                seen_result_hashes_added=seen_hashes_added,
+            )
+            # The journal append is already fsync'd. Advance the absolute
+            # cursor before optional compaction so a failed base rewrite
+            # cannot cause the durable delta to be skipped on the next save.
+            self._auto_save_sequence = sequence
+            self._auto_save_message_count = message_count
+            self._auto_save_rewrite_from = None
+            self._auto_save_seen_result_hashes = current_seen_hashes
+            if checkpoint_messages is not None:
+                self.store.checkpoint_snapshot(
+                    path,
+                    checkpoint_messages,
+                    meta=meta,
+                    sequence=sequence,
+                )
+                self._next_auto_save_checkpoint *= 2
+
+        return persist_incrementally
 
     def enqueue_auto_save(self) -> asyncio.Task[None] | None:
         if self._auto_save_subscriber is None:

--- a/opencollab/application/tool_execution.py
+++ b/opencollab/application/tool_execution.py
@@ -28,6 +28,7 @@ from opencollab.application.tool_execution_runtime import (
     DEFAULT_TOOL_CANCELLATION_FORCE_TIMEOUT,
     DEFAULT_TOOL_ENVIRONMENT_ABORT_TIMEOUT,
     ToolExecutionRuntimeMixin,
+    sanitize_observation_args,
 )
 from opencollab.application.tool_execution_runtime import (
     DeferredCall as DeferredCall,
@@ -374,8 +375,12 @@ class ToolExecutionUseCase(ToolExecutionRuntimeMixin):
                     )
                     continue
 
+            observation_args = sanitize_observation_args(args)
             await self._emit_observation(
-                lambda: self.event_factory.tool_start(tool_name, args),
+                lambda: self.event_factory.tool_start(
+                    tool_name,
+                    observation_args,
+                ),
                 label="tool_start",
             )
 
@@ -428,7 +433,11 @@ class ToolExecutionUseCase(ToolExecutionRuntimeMixin):
             if self.tracer:
                 self._trace_observation(
                     step_type="tool_exec",
-                    payload=self.trace_payload(tool_name, args, tool_output),
+                    payload=self.trace_payload(
+                        tool_name,
+                        observation_args,
+                        tool_output,
+                    ),
                     tokens=0,
                     latency=tool_latency,
                 )

--- a/opencollab/application/tool_execution_runtime.py
+++ b/opencollab/application/tool_execution_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import json
 import logging
@@ -18,6 +19,108 @@ from opencollab.application.async_timeout import (
 from opencollab.application.ports import AskUserPort, EnvironmentPort, PermissionPort, SafetyPolicyPort
 
 logger = logging.getLogger(__name__)
+
+OBSERVATION_PAYLOAD_BUDGET_BYTES = 8 * 1024
+OBSERVATION_STRING_PREVIEW_CHARS = 512
+OBSERVATION_MAX_ITEMS = 64
+OBSERVATION_MAX_DEPTH = 8
+
+
+def sanitize_observation_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Return a structure-preserving, bounded copy for event and trace sinks."""
+    budget = [OBSERVATION_PAYLOAD_BUDGET_BYTES]
+    sanitized = _sanitize_observation_value(args, budget=budget, depth=0)
+    return sanitized if isinstance(sanitized, dict) else {"value": sanitized}
+
+
+def _sanitize_observation_value(
+    value: Any,
+    *,
+    budget: list[int],
+    depth: int,
+) -> Any:
+    if isinstance(value, str):
+        raw = value.encode("utf-8", errors="surrogatepass")
+        if (
+            len(value) <= OBSERVATION_STRING_PREVIEW_CHARS
+            and len(raw) + 32 <= budget[0]
+        ):
+            budget[0] -= len(raw) + 32
+            return value
+        preview = value[:OBSERVATION_STRING_PREVIEW_CHARS]
+        budget[0] = max(
+            0,
+            budget[0]
+            - len(preview.encode("utf-8", errors="surrogatepass"))
+            - 192,
+        )
+        return {
+            "__opencollab_truncated__": True,
+            "preview": preview,
+            "original_length": len(value),
+            "original_bytes": len(raw),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
+    if value is None or isinstance(value, (bool, int, float)):
+        budget[0] = max(0, budget[0] - 32)
+        return value
+    if depth >= OBSERVATION_MAX_DEPTH:
+        budget[0] = max(0, budget[0] - 96)
+        return {
+            "__opencollab_truncated__": True,
+            "original_type": type(value).__name__,
+        }
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        items = list(value.items())
+        for index, (key, nested) in enumerate(items):
+            if index >= OBSERVATION_MAX_ITEMS or budget[0] < 128:
+                result["__opencollab_truncated_items__"] = len(items) - index
+                break
+            rendered_key = str(key)
+            if len(rendered_key) > 128:
+                key_raw = rendered_key.encode("utf-8", errors="surrogatepass")
+                rendered_key = (
+                    rendered_key[:64]
+                    + "...[sha256:"
+                    + hashlib.sha256(key_raw).hexdigest()
+                    + "]"
+                )
+            budget[0] = max(
+                0,
+                budget[0]
+                - len(rendered_key.encode("utf-8", errors="surrogatepass"))
+                - 16,
+            )
+            result[rendered_key] = _sanitize_observation_value(
+                nested,
+                budget=budget,
+                depth=depth + 1,
+            )
+        return result
+    if isinstance(value, (list, tuple)):
+        result_list: list[Any] = []
+        for index, nested in enumerate(value):
+            if index >= OBSERVATION_MAX_ITEMS or budget[0] < 128:
+                result_list.append(
+                    {
+                        "__opencollab_truncated_items__": len(value) - index,
+                    }
+                )
+                break
+            result_list.append(
+                _sanitize_observation_value(
+                    nested,
+                    budget=budget,
+                    depth=depth + 1,
+                )
+            )
+        return result_list
+    return _sanitize_observation_value(
+        str(value),
+        budget=budget,
+        depth=depth + 1,
+    )
 
 
 def _positive_env_float(name: str, default: float) -> float:
@@ -296,8 +399,9 @@ class ToolExecutionRuntimeMixin:
         if not tool:
             return None, f"Error: unknown tool '{tool_name}'."
 
+        observation_args = sanitize_observation_args(args)
         await self._emit_observation(
-            lambda: self.event_factory.tool_start(tool_name, args),
+            lambda: self.event_factory.tool_start(tool_name, observation_args),
             label="tool_start",
         )
 

--- a/opencollab/application/tool_execution_runtime.py
+++ b/opencollab/application/tool_execution_runtime.py
@@ -21,16 +21,54 @@ from opencollab.application.ports import AskUserPort, EnvironmentPort, Permissio
 logger = logging.getLogger(__name__)
 
 OBSERVATION_PAYLOAD_BUDGET_BYTES = 8 * 1024
+OBSERVATION_CONTAINER_RESERVE_BYTES = 512
 OBSERVATION_STRING_PREVIEW_CHARS = 512
+OBSERVATION_SCALAR_PREVIEW_CHARS = 128
 OBSERVATION_MAX_ITEMS = 64
 OBSERVATION_MAX_DEPTH = 8
 
 
+def _serialized_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, default=str).encode(
+        "utf-8",
+        errors="surrogatepass",
+    )
+
+
+def _budgeted_metadata(
+    metadata: dict[str, Any],
+    *,
+    budget: list[int],
+) -> dict[str, Any]:
+    encoded = _serialized_json_bytes(metadata)
+    if len(encoded) <= budget[0]:
+        budget[0] -= len(encoded)
+        return metadata
+    compact = {
+        "__opencollab_truncated__": True,
+        "original_type": metadata.get("original_type", "value"),
+    }
+    budget[0] = max(0, budget[0] - len(_serialized_json_bytes(compact)))
+    return compact
+
+
 def sanitize_observation_args(args: dict[str, Any]) -> dict[str, Any]:
     """Return a structure-preserving, bounded copy for event and trace sinks."""
-    budget = [OBSERVATION_PAYLOAD_BUDGET_BYTES]
+    budget = [
+        OBSERVATION_PAYLOAD_BUDGET_BYTES
+        - OBSERVATION_CONTAINER_RESERVE_BYTES
+    ]
     sanitized = _sanitize_observation_value(args, budget=budget, depth=0)
-    return sanitized if isinstance(sanitized, dict) else {"value": sanitized}
+    result = sanitized if isinstance(sanitized, dict) else {"value": sanitized}
+    encoded = _serialized_json_bytes(result)
+    if len(encoded) <= OBSERVATION_PAYLOAD_BUDGET_BYTES:
+        return result
+    return {
+        "__opencollab_truncated__": True,
+        "original_type": "dict",
+        "bounded_representation_bytes": len(encoded),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+    }
 
 
 def _sanitize_observation_value(
@@ -41,35 +79,64 @@ def _sanitize_observation_value(
 ) -> Any:
     if isinstance(value, str):
         raw = value.encode("utf-8", errors="surrogatepass")
+        encoded = _serialized_json_bytes(value)
         if (
             len(value) <= OBSERVATION_STRING_PREVIEW_CHARS
-            and len(raw) + 32 <= budget[0]
+            and len(encoded) <= budget[0]
         ):
-            budget[0] -= len(raw) + 32
+            budget[0] -= len(encoded)
             return value
         preview = value[:OBSERVATION_STRING_PREVIEW_CHARS]
-        budget[0] = max(
-            0,
-            budget[0]
-            - len(preview.encode("utf-8", errors="surrogatepass"))
-            - 192,
+        return _budgeted_metadata(
+            {
+                "__opencollab_truncated__": True,
+                "preview": preview,
+                "original_length": len(value),
+                "original_bytes": len(raw),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            },
+            budget=budget,
         )
-        return {
-            "__opencollab_truncated__": True,
-            "preview": preview,
-            "original_length": len(value),
-            "original_bytes": len(raw),
-            "sha256": hashlib.sha256(raw).hexdigest(),
-        }
     if value is None or isinstance(value, (bool, int, float)):
-        budget[0] = max(0, budget[0] - 32)
-        return value
+        try:
+            encoded = _serialized_json_bytes(value)
+        except (OverflowError, ValueError):
+            return _budgeted_metadata(
+                {
+                    "__opencollab_truncated__": True,
+                    "original_type": type(value).__name__,
+                    "serialization_error": "scalar exceeds JSON conversion limits",
+                },
+                budget=budget,
+            )
+        if (
+            len(encoded) <= OBSERVATION_SCALAR_PREVIEW_CHARS
+            and len(encoded) <= budget[0]
+        ):
+            budget[0] -= len(encoded)
+            return value
+        preview = encoded[:OBSERVATION_SCALAR_PREVIEW_CHARS].decode(
+            "utf-8",
+            errors="replace",
+        )
+        return _budgeted_metadata(
+            {
+                "__opencollab_truncated__": True,
+                "original_type": type(value).__name__,
+                "preview": preview,
+                "original_bytes": len(encoded),
+                "sha256": hashlib.sha256(encoded).hexdigest(),
+            },
+            budget=budget,
+        )
     if depth >= OBSERVATION_MAX_DEPTH:
-        budget[0] = max(0, budget[0] - 96)
-        return {
-            "__opencollab_truncated__": True,
-            "original_type": type(value).__name__,
-        }
+        return _budgeted_metadata(
+            {
+                "__opencollab_truncated__": True,
+                "original_type": type(value).__name__,
+            },
+            budget=budget,
+        )
     if isinstance(value, dict):
         result: dict[str, Any] = {}
         items = list(value.items())
@@ -89,8 +156,8 @@ def _sanitize_observation_value(
             budget[0] = max(
                 0,
                 budget[0]
-                - len(rendered_key.encode("utf-8", errors="surrogatepass"))
-                - 16,
+                - len(_serialized_json_bytes(rendered_key))
+                - 2,
             )
             result[rendered_key] = _sanitize_observation_value(
                 nested,

--- a/opencollab/bootstrap/config.py
+++ b/opencollab/bootstrap/config.py
@@ -140,6 +140,20 @@ class OpenCollabConfig(BaseModel):
     llm_timeout: float = Field(default=600.0, gt=0, allow_inf_nan=False)
     filter_messages: bool = Field(default=False)
 
+    @field_validator(
+        "budget",
+        "temperature",
+        "top_p",
+        "max_output_tokens",
+        "llm_timeout",
+        mode="before",
+    )
+    @classmethod
+    def _reject_boolean_numbers(cls, value: Any) -> Any:
+        if isinstance(value, bool):
+            raise ValueError("numeric configuration values must not be booleans")
+        return value
+
     @field_validator("top_p", mode="before")
     @classmethod
     def _coerce_top_p(cls, value: Any) -> Any:
@@ -157,13 +171,6 @@ class OpenCollabConfig(BaseModel):
         # real bool, mirroring how temperature accepts its string form.
         if isinstance(value, str):
             return _parse_bool(value)
-        return value
-
-    @field_validator("llm_timeout", mode="before")
-    @classmethod
-    def _reject_boolean_llm_timeout(cls, value: Any) -> Any:
-        if isinstance(value, bool):
-            raise ValueError("llm_timeout must be a finite positive number")
         return value
 
     @field_validator("thinking_params", mode="before")

--- a/opencollab/bootstrap/scheduler_factory.py
+++ b/opencollab/bootstrap/scheduler_factory.py
@@ -138,6 +138,7 @@ def build_scheduler(
             scheduler=scheduler,
             workspace=ctx.workspace,
         )
+        scheduler.register_lifecycle_resource(runner, description="hook processes")
         event_bus.subscribe(HookEventSubscriber(runner))
 
     # Persist a team.json manifest from the live roster on every roster change.

--- a/opencollab/bootstrap/team_config.py
+++ b/opencollab/bootstrap/team_config.py
@@ -130,6 +130,12 @@ class RoleConfig(BaseModel):
     ) -> dict[Any, Any] | None:
         return _validate_thinking_params(value)
 
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _reject_boolean_temperature(cls, value: Any) -> Any:
+        if isinstance(value, bool):
+            raise ValueError("role temperature must not be a boolean")
+        return value
 
 class _RoleFileModel(BaseModel):
     """On-disk role entry; ``prompt`` or ``prompt_file`` (resolved at load)."""
@@ -174,6 +180,12 @@ class _RoleFileModel(BaseModel):
     ) -> dict[Any, Any] | None:
         return _validate_thinking_params(value)
 
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _reject_boolean_temperature(cls, value: Any) -> Any:
+        if isinstance(value, bool):
+            raise ValueError("role temperature must not be a boolean")
+        return value
 
 class _HookActionFileModel(BaseModel):
     """On-disk hook entry: one action bound to a lifecycle event."""
@@ -184,6 +196,13 @@ class _HookActionFileModel(BaseModel):
     matcher: str | None = None
     type: str = "command"
     timeout: float = Field(default=30.0, gt=0, allow_inf_nan=False)
+
+    @field_validator("timeout", mode="before")
+    @classmethod
+    def _reject_boolean_timeout(cls, value: Any) -> Any:
+        if isinstance(value, bool):
+            raise ValueError("hook timeout must not be a boolean")
+        return value
 
 
 class _TeamFileModel(BaseModel):

--- a/opencollab/bootstrap/team_config.py
+++ b/opencollab/bootstrap/team_config.py
@@ -33,7 +33,12 @@ from opencollab.bootstrap.tool_registry import (
     KNOWN_TOOL_NAMES,
     validate_tool_limits,
 )
-from opencollab.domain.hooks import HOOK_ACTION_TYPES, HOOK_EVENT_NAMES, HookSpec
+from opencollab.domain.hooks import (
+    EXECUTABLE_HOOK_ACTION_TYPES,
+    HOOK_ACTION_TYPES,
+    HOOK_EVENT_NAMES,
+    HookSpec,
+)
 from opencollab.domain.identity import role_collision_key, validate_role_identity
 from opencollab.domain.team import Topology
 
@@ -389,6 +394,11 @@ def _build_hook_specs(hooks: dict[str, list[_HookActionFileModel]]) -> tuple[Hoo
                 raise ValueError(
                     f"Unknown hook action type '{action.type}' for event "
                     f"'{event_name}'. Known types: {sorted(HOOK_ACTION_TYPES)}"
+                )
+            if action.type not in EXECUTABLE_HOOK_ACTION_TYPES:
+                raise ValueError(
+                    f"Hook action type '{action.type}' for event '{event_name}' "
+                    "is recognized but not implemented"
                 )
             specs.append(
                 HookSpec(

--- a/opencollab/domain/hooks.py
+++ b/opencollab/domain/hooks.py
@@ -32,12 +32,11 @@ HOOK_EVENT_NAMES: frozenset[str] = frozenset(
 # Events whose payload carries a tool name and therefore support a ``matcher``.
 TOOL_SCOPED_EVENTS: frozenset[str] = frozenset({"PreToolUse", "PostToolUse"})
 
-# Action types a hook may declare. ``command`` is the only one a runner executes
-# in phase 1; ``prompt`` and ``agent`` are reserved (a config may declare them,
-# but firing one raises until its executor lands). Anything outside this set is a
-# typo and is rejected at config load so it fails fast rather than silently never
-# firing.
+# Recognized action vocabulary and the subset that the installed runner can
+# execute. Keeping both here gives configuration and runtime one source of truth
+# while reserving future names without accepting inert configurations.
 HOOK_ACTION_TYPES: frozenset[str] = frozenset({"command", "prompt", "agent"})
+EXECUTABLE_HOOK_ACTION_TYPES: frozenset[str] = frozenset({"command"})
 
 
 @dataclass(frozen=True)
@@ -103,6 +102,7 @@ def match_hooks(
 __all__ = [
     "HOOK_EVENT_NAMES",
     "HOOK_ACTION_TYPES",
+    "EXECUTABLE_HOOK_ACTION_TYPES",
     "TOOL_SCOPED_EVENTS",
     "HookSpec",
     "HookOutcome",

--- a/opencollab/domain/session.py
+++ b/opencollab/domain/session.py
@@ -236,16 +236,21 @@ class SessionState:
                 len(self.messages) - len(self.message_timestamps)
             )
 
-    def enriched_messages(self) -> list[dict[str, Any]]:
+    def enriched_messages(self, start: int = 0) -> list[dict[str, Any]]:
         """Messages with their creation ``timestamp`` merged in, for persistence.
 
         Re-aligns first so messages appended by bypassing ``append_message``
         (e.g. direct list mutation) still get a timestamp.
         """
+        if isinstance(start, bool) or not isinstance(start, int) or start < 0:
+            raise ValueError("message start must be a non-negative integer")
         self._align_timestamps()
         return [
             {**msg, "timestamp": ts}
-            for msg, ts in zip(self.messages, self.message_timestamps)
+            for msg, ts in zip(
+                self.messages[start:],
+                self.message_timestamps[start:],
+            )
         ]
 
     def queue_pending_user_message(self, message: dict[str, Any]) -> None:

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -166,7 +166,38 @@ def test_autosave_bounds_checkpoint_growth_and_flushes_latest(monkeypatch):
     asyncio.run(scenario())
 
     assert saved_sizes[-1] == 1000
-    assert len(saved_sizes) <= 3
+    assert len(saved_sizes) <= 12
+    assert sum(saved_sizes) <= 3000
+
+
+def test_autosave_growth_stays_linear_during_sustained_fast_events(monkeypatch):
+    current = {"generation": 0}
+    saved_sizes: list[int] = []
+
+    async def immediate_to_thread(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", immediate_to_thread)
+
+    def prepare():
+        frozen_size = current["generation"]
+        return lambda: saved_sizes.append(frozen_size)
+
+    subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
+
+    async def scenario():
+        for generation in range(1, 1001):
+            current["generation"] = generation
+            await subscriber.emit(SessionEvent(type="step_end"))
+            await asyncio.sleep(0.001)
+        final = subscriber.enqueue()
+        assert final is not None
+        await final
+
+    asyncio.run(scenario())
+
+    assert saved_sizes[-1] == 1000
+    assert len(saved_sizes) <= 12
     assert sum(saved_sizes) <= 3000
 
 

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 
@@ -12,9 +13,11 @@ import pytest
 # added to sys.path by pytest's rootdir discovery).
 from test_session_characterization import FakeAgent, FakeLLMClient
 
+from opencollab.adapters.storage import SessionStore
 from opencollab.application.autosave import SAVE_TRIGGERS, AutoSaveSubscriber
 from opencollab.application.event_bus import EventBus
 from opencollab.bootstrap import build_session as Session
+from opencollab.bootstrap import load_session
 from opencollab.domain.events import SessionRuntimeEvent as SessionEvent
 
 
@@ -140,65 +143,86 @@ def test_autosave_coalesces_pending_generations_without_blocking_emit():
     assert saved == ["0", "9"]
 
 
-def test_autosave_bounds_checkpoint_growth_and_flushes_latest(monkeypatch):
-    current = {"generation": 0}
-    saved_sizes: list[int] = []
+class _CountingSessionStore(SessionStore):
+    def __init__(self):
+        self.persisted_bytes = 0
 
-    async def immediate_to_thread(function, *args, **kwargs):
-        return function(*args, **kwargs)
+    def _atomic_json_write(self, path, value):
+        self.persisted_bytes += len(
+            json.dumps(value, ensure_ascii=False, indent=2).encode("utf-8")
+        )
+        return super()._atomic_json_write(path, value)
 
-    monkeypatch.setattr(asyncio, "to_thread", immediate_to_thread)
-
-    def prepare():
-        frozen_size = current["generation"]
-        return lambda: saved_sizes.append(frozen_size)
-
-    subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
-
-    async def scenario():
-        for generation in range(1, 1001):
-            current["generation"] = generation
-            await subscriber.emit(SessionEvent(type="step_end"))
-        final = subscriber.enqueue()
-        assert final is not None
-        await final
-
-    asyncio.run(scenario())
-
-    assert saved_sizes[-1] == 1000
-    assert len(saved_sizes) <= 12
-    assert sum(saved_sizes) <= 3000
+    def _append_journal_record(self, path, record):
+        self.persisted_bytes += len(
+            (
+                json.dumps(
+                    record,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            ).encode("utf-8")
+        )
+        return super()._append_journal_record(path, record)
 
 
-def test_autosave_growth_stays_linear_during_sustained_fast_events(monkeypatch):
-    current = {"generation": 0}
-    saved_sizes: list[int] = []
+@pytest.mark.parametrize("trigger", sorted(SAVE_TRIGGERS))
+def test_autosave_journal_recovers_every_trigger_with_linear_write_growth(
+    tmp_path,
+    trigger,
+):
+    def persist_steps(name: str, count: int):
+        path = tmp_path / name
+        store = _CountingSessionStore()
+        session = Session(
+            agent=FakeAgent(),
+            llm=FakeLLMClient(),
+            auto_save_path=str(path),
+            store=store,
+        )
 
-    async def immediate_to_thread(function, *args, **kwargs):
-        return function(*args, **kwargs)
+        async def scenario():
+            for step in range(1, count + 1):
+                session.state.append_message(
+                    {
+                        "role": (
+                            "assistant"
+                            if trigger == "step_end"
+                            else "user"
+                        ),
+                        "content": f"durable {trigger} {step}: " + ("x" * 128),
+                    }
+                )
+                session.state.turn.seen_result_hashes.add(f"result-hash-{step:04d}")
+                session.step_count = step
+                await session.event_bus.emit(SessionEvent(type=trigger))
+                pending = session.pending_cleanup_tasks
+                if pending:
+                    await asyncio.gather(*pending)
 
-    monkeypatch.setattr(asyncio, "to_thread", immediate_to_thread)
+        asyncio.run(scenario())
+        restored = load_session(
+            str(path),
+            agent=FakeAgent(),
+            llm=FakeLLMClient(),
+        )
+        return store.persisted_bytes, restored
 
-    def prepare():
-        frozen_size = current["generation"]
-        return lambda: saved_sizes.append(frozen_size)
+    bytes_500, restored_500 = persist_steps(f"{trigger}-500.json", 500)
+    bytes_1000, restored_1000 = persist_steps(f"{trigger}-1000.json", 1000)
 
-    subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
-
-    async def scenario():
-        for generation in range(1, 1001):
-            current["generation"] = generation
-            await subscriber.emit(SessionEvent(type="step_end"))
-            await asyncio.sleep(0.001)
-        final = subscriber.enqueue()
-        assert final is not None
-        await final
-
-    asyncio.run(scenario())
-
-    assert saved_sizes[-1] == 1000
-    assert len(saved_sizes) <= 12
-    assert sum(saved_sizes) <= 3000
+    assert restored_500.step_count == 500
+    assert restored_500.messages[-1]["content"].startswith(
+        f"durable {trigger} 500:"
+    )
+    assert len(restored_500.state.turn.seen_result_hashes) == 500
+    assert restored_1000.step_count == 1000
+    assert restored_1000.messages[-1]["content"].startswith(
+        f"durable {trigger} 1000:"
+    )
+    assert len(restored_1000.state.turn.seen_result_hashes) == 1000
+    assert bytes_1000 <= bytes_500 * 2.5
 
 
 def test_cancelling_owned_worker_finishes_submitted_save():

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -45,7 +45,11 @@ def test_autosave_subscriber_records_save_errors(caplog):
 
     sub = AutoSaveSubscriber(boom)
     with caplog.at_level(logging.WARNING):
-        asyncio.run(sub.emit(SessionEvent(type="step_end")))
+        async def scenario():
+            await sub.emit(SessionEvent(type="step_end"))
+            await asyncio.gather(*sub.pending_tasks, return_exceptions=True)
+
+        asyncio.run(scenario())
 
     assert sub.last_error is error
     assert sub.failure_count == 1
@@ -59,7 +63,11 @@ def test_autosave_wraps_worker_base_exceptions_without_escaping(fatal):
 
     sub = AutoSaveSubscriber(boom)
 
-    asyncio.run(sub.emit(SessionEvent(type="step_end")))
+    async def scenario():
+        await sub.emit(SessionEvent(type="step_end"))
+        await asyncio.gather(*sub.pending_tasks, return_exceptions=True)
+
+    asyncio.run(scenario())
 
     assert isinstance(sub.last_error, RuntimeError)
     assert type(fatal).__name__ in str(sub.last_error)

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 
 import pytest
 
@@ -87,7 +88,7 @@ def test_session_surfaces_autosave_persistence_error():
     assert session.persistence_errors == (error,)
 
 
-def test_autosave_queues_frozen_operations_in_order():
+def test_autosave_coalesces_generations_not_yet_started():
     current = {"value": "first"}
     saved: list[str] = []
 
@@ -105,26 +106,62 @@ def test_autosave_queues_frozen_operations_in_order():
         await asyncio.gather(first, second)
 
     asyncio.run(scenario())
-    assert saved == ["first", "second"]
+    assert saved == ["second"]
     assert subscriber.pending_tasks == ()
 
 
-def test_cancelling_emit_keeps_submitted_save_owned():
+def test_autosave_coalesces_pending_generations_without_blocking_emit():
+    current = {"value": ""}
+    saved: list[str] = []
+
+    def prepare():
+        frozen = current["value"]
+
+        def save():
+            time.sleep(0.02)
+            saved.append(frozen)
+
+        return save
+
+    subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
+
+    async def scenario():
+        started = time.monotonic()
+        for index in range(10):
+            current["value"] = str(index)
+            await subscriber.emit(SessionEvent(type="step_end"))
+        emit_elapsed = time.monotonic() - started
+        await asyncio.gather(*subscriber.pending_tasks)
+        return emit_elapsed
+
+    elapsed = asyncio.run(scenario())
+
+    assert elapsed < 0.05
+    assert saved == ["0", "9"]
+
+
+def test_cancelling_owned_worker_finishes_submitted_save():
     prepared = asyncio.Event()
     saved: list[str] = []
 
     def prepare():
         prepared.set()
-        return lambda: saved.append("saved")
+
+        def save():
+            time.sleep(0.02)
+            saved.append("saved")
+
+        return save
 
     subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
 
     async def scenario():
-        emit = asyncio.create_task(subscriber.emit(SessionEvent(type="step_end")))
+        owner = subscriber.enqueue()
+        assert owner is not None
         await prepared.wait()
-        emit.cancel()
+        owner.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await emit
+            await owner
         pending = subscriber.pending_tasks
         if pending:
             await pending[0]

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -140,6 +140,36 @@ def test_autosave_coalesces_pending_generations_without_blocking_emit():
     assert saved == ["0", "9"]
 
 
+def test_autosave_bounds_checkpoint_growth_and_flushes_latest(monkeypatch):
+    current = {"generation": 0}
+    saved_sizes: list[int] = []
+
+    async def immediate_to_thread(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", immediate_to_thread)
+
+    def prepare():
+        frozen_size = current["generation"]
+        return lambda: saved_sizes.append(frozen_size)
+
+    subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
+
+    async def scenario():
+        for generation in range(1, 1001):
+            current["generation"] = generation
+            await subscriber.emit(SessionEvent(type="step_end"))
+        final = subscriber.enqueue()
+        assert final is not None
+        await final
+
+    asyncio.run(scenario())
+
+    assert saved_sizes[-1] == 1000
+    assert len(saved_sizes) <= 3
+    assert sum(saved_sizes) <= 3000
+
+
 def test_cancelling_owned_worker_finishes_submitted_save():
     prepared = asyncio.Event()
     saved: list[str] = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,6 +150,35 @@ def test_max_output_tokens_defaults_and_reads_env(monkeypatch):
     assert build_config().max_output_tokens == 32768
 
 
+@pytest.mark.parametrize(
+    "field",
+    ["budget", "temperature", "top_p", "max_output_tokens", "llm_timeout"],
+)
+@pytest.mark.parametrize("value", [True, False])
+def test_numeric_config_rejects_boolean_overrides(field, value):
+    with pytest.raises(Exception, match="must not be booleans"):
+        build_config(overrides={field: value})
+
+
+def test_numeric_config_keeps_canonical_numeric_strings():
+    cfg = build_config(
+        overrides={
+            "budget": "1000",
+            "temperature": "0.5",
+            "top_p": "0.9",
+            "max_output_tokens": "256",
+            "llm_timeout": "30",
+        }
+    )
+    assert (
+        cfg.budget,
+        cfg.temperature,
+        cfg.top_p,
+        cfg.max_output_tokens,
+        cfg.llm_timeout,
+    ) == (1000, 0.5, 0.9, 256, 30.0)
+
+
 def test_provider_override_reselects_provider_specific_api_key(monkeypatch, tmp_path):
     cfg_file = tmp_path / "provider.env"
     cfg_file.write_text(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -552,6 +552,36 @@ def test_wiring_runs_relative_hook_in_runtime_workspace(tmp_path, monkeypatch):
     assert not (launch_directory / "relative-stop-fired").exists()
 
 
+def test_hook_process_cleanup_failure_reaches_scheduler_cleanup(tmp_path, monkeypatch):
+    cleanup_error = hooks_adapter.ProcessCleanupError("descendant remained alive")
+
+    async def fake_run_process(*_args, **_kwargs):
+        raise cleanup_error
+
+    monkeypatch.setattr(hooks_adapter, "run_process", fake_run_process)
+    scheduler, _sentinel = _scheduler_with_stop_hook(
+        tmp_path,
+        monkeypatch,
+        enable_hooks=True,
+    )
+
+    asyncio.run(
+        scheduler._event_sink.emit(
+            SchedulerEvent(
+                type="agent_completed",
+                data={"aid": 0, "parent_aid": None},
+            )
+        )
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="technical scheduler cleanup failed: hook processes did not quiesce",
+    ) as caught:
+        asyncio.run(scheduler.cleanup())
+    assert caught.value.__cause__ is cleanup_error
+
+
 def test_wiring_disabled_when_enable_hooks_false(tmp_path, monkeypatch):
     scheduler, sentinel = _scheduler_with_stop_hook(tmp_path, monkeypatch, enable_hooks=False)
     bus = scheduler._event_sink

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -96,6 +96,28 @@ def test_subscriber_splits_completed_by_parent():
     assert _emit(SchedulerEvent(type="agent_completed", data={"aid": 5, "parent_aid": 0}))[0][0] == "SubagentStop"
 
 
+@pytest.mark.parametrize(
+    ("event_type", "aid", "expected_hook", "expected_disposition"),
+    [
+        ("agent_failed", 0, "Stop", "failed"),
+        ("agent_cancelled", 0, "Stop", "cancelled"),
+        ("agent_failed", 5, "SubagentStop", "failed"),
+        ("agent_cancelled", 5, "SubagentStop", "cancelled"),
+    ],
+)
+def test_subscriber_maps_all_terminal_dispositions(
+    event_type,
+    aid,
+    expected_hook,
+    expected_disposition,
+):
+    calls = _emit(SchedulerEvent(type=event_type, data={"aid": aid, "role": "coder"}))
+
+    assert len(calls) == 1
+    assert calls[0][0] == expected_hook
+    assert calls[0][1]["disposition"] == expected_disposition
+
+
 def test_subscriber_ignores_unmapped_events():
     assert _emit(SessionRuntimeEvent(type="step_end", data={"step": 1})) == []
     assert _emit(SessionRuntimeEvent(type="text_delta", data={"content": "x"})) == []

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -475,6 +475,17 @@ def test_config_rejects_unbounded_or_nonpositive_hook_timeout(
         load_team_config(str(tmp_path))
 
 
+@pytest.mark.parametrize("timeout", ["true", "false", "yes", "no"])
+def test_config_rejects_boolean_hook_timeout(tmp_path, monkeypatch, timeout):
+    team = (
+        "roles:\n  lead:\n    tools: [bash]\n    prompt: x\n"
+        f"hooks:\n  Stop:\n    - command: echo\n      timeout: {timeout}\n"
+    )
+    _write_team(tmp_path, monkeypatch, team)
+    with pytest.raises(Exception, match="must not be a boolean"):
+        load_team_config(str(tmp_path))
+
+
 @pytest.mark.parametrize("action_type", ["prompt", "agent"])
 def test_config_rejects_reserved_action_types_until_runner_supports_them(
     tmp_path, monkeypatch, action_type

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -475,14 +475,17 @@ def test_config_rejects_unbounded_or_nonpositive_hook_timeout(
         load_team_config(str(tmp_path))
 
 
-def test_config_reserved_action_type_parses(tmp_path, monkeypatch):
+@pytest.mark.parametrize("action_type", ["prompt", "agent"])
+def test_config_rejects_reserved_action_types_until_runner_supports_them(
+    tmp_path, monkeypatch, action_type
+):
     team = (
         "roles:\n  lead:\n    tools: [bash]\n    prompt: x\n"
         "hooks:\n  Stop:\n    - command: echo\n      type: agent\n"
-    )
+    ).replace("type: agent", f"type: {action_type}")
     _write_team(tmp_path, monkeypatch, team)
-    cfg = load_team_config(str(tmp_path))
-    assert cfg.hooks[0].action_type == "agent"
+    with pytest.raises(ValueError, match="not implemented"):
+        load_team_config(str(tmp_path))
 
 
 def test_config_without_hooks_is_empty(tmp_path, monkeypatch):

--- a/tests/test_session_construction.py
+++ b/tests/test_session_construction.py
@@ -13,6 +13,7 @@ import os
 
 from opencollab.adapters.storage import SessionStore
 from opencollab.application.autosave import AutoSaveSubscriber
+from opencollab.application.scheduler_types import LaunchSpec
 from opencollab.application.session_run import SessionRunUseCase
 from opencollab.application.tool_execution import ToolExecutionUseCase
 from opencollab.bootstrap import build_session as Session
@@ -150,6 +151,39 @@ def test_session_user_message_appended_triggers_autosave(tmp_path):
         saved = json.load(f)
     user_msgs = [m for m in saved["messages"] if m["role"] == "user"]
     assert any(m["content"] == "hello" and "timestamp" in m for m in user_msgs)
+
+
+def test_apply_launch_recovers_journal_when_atomic_base_is_absent(tmp_path):
+    path = tmp_path / "journal-only.json"
+    store = SessionStore()
+    store.append_snapshot_delta(
+        str(path),
+        sequence=1,
+        replace_from=0,
+        messages=[
+            {"role": "system", "content": "You are a fake agent."},
+            {"role": "assistant", "content": "durable step"},
+        ],
+        meta={
+            "snapshot_version": 1,
+            "session_state": {
+                "step_count": 7,
+                "phase": "idle",
+            },
+        },
+    )
+    assert not path.exists()
+
+    session = _new_session(auto_save_path=str(path), store=store)
+    session.apply_launch(
+        LaunchSpec(
+            session_file=str(path),
+            auto_save_path=str(path),
+        )
+    )
+
+    assert session.step_count == 7
+    assert session.messages[-1]["content"] == "durable step"
 
 
 def test_session_snapshot_returns_independent_session_without_autosave(tmp_path):

--- a/tests/test_session_construction.py
+++ b/tests/test_session_construction.py
@@ -186,6 +186,69 @@ def test_apply_launch_recovers_journal_when_atomic_base_is_absent(tmp_path):
     assert session.messages[-1]["content"] == "durable step"
 
 
+def test_apply_launch_checkpoints_restore_into_distinct_autosave_target(tmp_path):
+    source = tmp_path / "source.json"
+    target = tmp_path / "target.json"
+    store = SessionStore()
+    store.checkpoint_snapshot(
+        str(source),
+        [
+            {"role": "system", "content": "You are a fake agent."},
+            {"role": "user", "content": "resume me"},
+        ],
+        meta={
+            "snapshot_version": 1,
+            "session_state": {
+                "step_count": 2,
+                "phase": "idle",
+            },
+        },
+        sequence=2,
+    )
+
+    session = _new_session(auto_save_path=str(target), store=store)
+    session.apply_launch(
+        LaunchSpec(
+            session_file=str(source),
+            auto_save_path=str(target),
+        )
+    )
+
+    checkpoint = store.load_snapshot(str(target), session.agent.system_prompt)
+    assert checkpoint["_autosave_sequence"] == 2
+    assert checkpoint["messages"][-1]["content"] == "resume me"
+
+    async def append_and_flush():
+        await session.add_user_message("continue here")
+        pending = session.pending_cleanup_tasks
+        if pending:
+            await asyncio.gather(*pending)
+
+    run(append_and_flush())
+    restored = load_session(
+        str(target),
+        agent=_FakeAgent(),
+        llm=_FakeLLM(),
+        store=store,
+    )
+    assert restored._auto_save_sequence == 3
+    assert restored.messages[-1]["content"] == "continue here"
+
+
+def test_relative_save_alias_uses_autosave_checkpoint(tmp_path, monkeypatch):
+    target = tmp_path / "alias.json"
+    session = _new_session(auto_save_path=str(target))
+    session._auto_save_sequence = 4
+    session.messages.append({"role": "user", "content": "durable"})
+    monkeypatch.chdir(tmp_path)
+
+    session.save("alias.json")
+
+    saved = json.loads(target.read_text())
+    assert saved["_autosave_sequence"] == 4
+    assert (tmp_path / "alias.json.journal").read_bytes() == b""
+
+
 def test_session_snapshot_returns_independent_session_without_autosave(tmp_path):
     path = tmp_path / "auto.jsonl"
     session = _new_session(auto_save_path=str(path), env=_ForkableEnvironment())

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -75,6 +75,108 @@ def test_store_loads_legacy_jsonl_and_empty_fallback(tmp_path) -> None:
     ]
 
 
+def test_store_replays_durable_journal_and_ignores_partial_tail(tmp_path) -> None:
+    path = tmp_path / "session.json"
+    journal = tmp_path / "session.json.journal"
+    store = SessionStore()
+    base = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "step 1"},
+    ]
+    store.checkpoint_snapshot(
+        str(path),
+        base,
+        meta={"session_state": {"step_count": 1}},
+        sequence=1,
+    )
+    store.append_snapshot_delta(
+        str(path),
+        sequence=2,
+        replace_from=2,
+        messages=[{"role": "assistant", "content": "step 2"}],
+        meta={"session_state": {"step_count": 2}},
+    )
+    with journal.open("ab") as handle:
+        handle.write(b'{"journal_version":1,"sequence":3')
+
+    restored = store.load_snapshot(str(path), "fallback")
+
+    assert restored["session_state"]["step_count"] == 2
+    assert [message["content"] for message in restored["messages"]] == [
+        "sys",
+        "step 1",
+        "step 2",
+    ]
+
+    store.append_snapshot_delta(
+        str(path),
+        sequence=3,
+        replace_from=3,
+        messages=[{"role": "assistant", "content": "step 3"}],
+        meta={"session_state": {"step_count": 3}},
+    )
+    resumed = store.load_snapshot(str(path), "fallback")
+    assert resumed["session_state"]["step_count"] == 3
+    assert resumed["messages"][-1]["content"] == "step 3"
+
+
+def test_store_replay_ignores_journal_records_covered_by_atomic_base(tmp_path) -> None:
+    path = tmp_path / "session.json"
+    store = SessionStore()
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "step 1"},
+        {"role": "assistant", "content": "step 2"},
+    ]
+    store.checkpoint_snapshot(
+        str(path),
+        messages,
+        meta={"session_state": {"step_count": 2}},
+        sequence=2,
+    )
+    # Models a crash after the base rename but before journal compaction:
+    # the covered absolute record must not duplicate its message suffix.
+    store.append_snapshot_delta(
+        str(path),
+        sequence=2,
+        replace_from=2,
+        messages=[messages[-1]],
+        meta={"session_state": {"step_count": 2}},
+    )
+    store.append_snapshot_delta(
+        str(path),
+        sequence=3,
+        replace_from=3,
+        messages=[{"role": "assistant", "content": "step 3"}],
+        meta={"session_state": {"step_count": 3}},
+    )
+
+    restored = store.load_snapshot(str(path), "fallback")
+
+    assert restored["session_state"]["step_count"] == 3
+    assert [message["content"] for message in restored["messages"]] == [
+        "sys",
+        "step 1",
+        "step 2",
+        "step 3",
+    ]
+
+
+def test_store_rejects_complete_invalid_journal_record(tmp_path) -> None:
+    path = tmp_path / "session.json"
+    store = SessionStore()
+    store.checkpoint_snapshot(
+        str(path),
+        [{"role": "system", "content": "sys"}],
+        meta={},
+        sequence=0,
+    )
+    (tmp_path / "session.json.journal").write_text("not-json\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="journal record at line 1"):
+        store.load_snapshot(str(path), "fallback")
+
+
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
 def test_store_rejects_fifo_without_blocking(tmp_path) -> None:
     path = tmp_path / "snapshot.fifo"

--- a/tests/test_structured_output_schema.py
+++ b/tests/test_structured_output_schema.py
@@ -208,6 +208,71 @@ def test_tool_rejects_non_object_top_level_schema(schema):
         StructuredOutputTool(schema)
 
 
+@pytest.mark.parametrize(
+    ("schema", "value", "error_fragment"),
+    [
+        (
+            {
+                "type": ["object", "null"],
+                "required": ["name"],
+                "properties": {"name": {"type": "string"}},
+            },
+            {},
+            "$.name: required property is missing",
+        ),
+        (
+            {
+                "type": ["null", "object"],
+                "properties": {"name": {"type": "string"}},
+            },
+            {"name": 7},
+            "$.name: expected type 'string'",
+        ),
+        (
+            {
+                "type": ["array", "null"],
+                "items": {"type": "integer"},
+            },
+            [1, "two"],
+            "$[1]: expected type 'integer'",
+        ),
+    ],
+)
+def test_validate_union_type_still_applies_container_constraints(
+    schema, value, error_fragment
+):
+    errors = validate(value, schema)
+    assert any(error_fragment in error for error in errors)
+    assert validate(None, schema) == []
+
+
+@pytest.mark.parametrize("value", [1, 1.0, -0.0])
+def test_validate_integer_accepts_mathematically_integral_numbers(value):
+    assert validate(value, {"type": "integer"}) == []
+
+
+@pytest.mark.parametrize("value", [1.5, True, False])
+def test_validate_integer_rejects_non_integral_or_boolean_values(value):
+    assert validate(value, {"type": "integer"})
+
+
+@pytest.mark.parametrize(
+    ("value", "enum", "matches"),
+    [
+        (1, [True], False),
+        (0, [False], False),
+        (True, [1], False),
+        (False, [0], False),
+        (1.0, [1], True),
+        ({"x": 1}, [{"x": True}], False),
+        ([0], [[False]], False),
+    ],
+)
+def test_validate_enum_uses_json_type_aware_equality(value, enum, matches):
+    errors = validate(value, {"enum": enum})
+    assert (errors == []) is matches
+
+
 # --------------------------------------------------------------------------- #
 # agent(schema=...)
 # --------------------------------------------------------------------------- #

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -205,6 +205,23 @@ def test_role_thinking_params_reject_yaml_native_dates(tmp_path):
     with pytest.raises(ValueError, match="JSON-serializable"):
         load_team_config(str(tmp_path), path=config)
 
+@pytest.mark.parametrize("yaml_boolean", ["true", "false", "yes", "no"])
+def test_role_temperature_rejects_yaml_booleans(
+    tmp_path, monkeypatch, yaml_boolean
+):
+    _write_team(
+        tmp_path,
+        monkeypatch,
+        yaml_text=(
+            "roles:\n"
+            "  lead:\n"
+            "    prompt: Lead prompt.\n"
+            f"    temperature: {yaml_boolean}\n"
+        ),
+    )
+    with pytest.raises(Exception, match="must not be a boolean"):
+        load_team_config(str(tmp_path))
+
 
 def test_prompt_file_is_resolved_relative_to_team_file(tmp_path, monkeypatch):
     _write_team(tmp_path, monkeypatch, coder_prompt="Resolved coder body.")

--- a/tests/test_team_event_emission.py
+++ b/tests/test_team_event_emission.py
@@ -593,6 +593,48 @@ def test_spawn_with_review_iterates_when_reviewer_fails(monkeypatch):
     assert "Reapply the previous implementation" in second_coder_task
 
 
+def test_spawn_with_review_retains_final_reviewer_feedback(monkeypatch):
+    scheduler, _ = _build_scheduler(
+        monkeypatch,
+        {
+            "coder": ["final implementation"],
+            "reviewer": ["Critical race remains.\nVERDICT: FAIL"],
+        },
+    )
+
+    result = run(scheduler.spawn_with_review(0, "write fn", max_iterations=1))
+
+    assert "final implementation" in result
+    assert "Last reviewer feedback:\nCritical race remains.\nVERDICT: FAIL" in result
+
+
+def test_spawn_with_review_returns_artifact_when_reviewer_spawn_fails(monkeypatch):
+    scheduler, events = _build_scheduler(
+        monkeypatch,
+        {"coder": ["recoverable implementation"]},
+    )
+    real_spawn = scheduler.spawn
+
+    async def fail_reviewer(parent_aid, role, task, context="", **kwargs):
+        if role == "reviewer":
+            raise RuntimeError("reviewer infrastructure unavailable")
+        return await real_spawn(parent_aid, role, task, context, **kwargs)
+
+    monkeypatch.setattr(scheduler, "spawn", fail_reviewer)
+
+    result = run(scheduler.spawn_with_review(0, "write fn", max_iterations=1))
+
+    assert "recoverable implementation" in result
+    assert "Failure stage: reviewer_spawn" in result
+    assert "reviewer infrastructure unavailable" in result
+    review_events = [
+        event.type
+        for event in _scheduler_events(events)
+        if event.type.startswith("review_")
+    ]
+    assert review_events == ["review_started", "review_completed"]
+
+
 def test_spawn_with_review_passes_context_and_constraints_to_reviewer(monkeypatch):
     scheduler, _ = _build_scheduler(
         monkeypatch,

--- a/tests/test_team_event_emission.py
+++ b/tests/test_team_event_emission.py
@@ -635,6 +635,45 @@ def test_spawn_with_review_returns_artifact_when_reviewer_spawn_fails(monkeypatc
     assert review_events == ["review_started", "review_completed"]
 
 
+@pytest.mark.parametrize("failure_mode", ["wait", "terminal"])
+def test_spawn_with_review_retains_prior_artifact_when_next_coder_is_empty(
+    monkeypatch,
+    failure_mode,
+):
+    scheduler, _ = _build_scheduler(
+        monkeypatch,
+        {
+            "coder": ["best first implementation", ""],
+            "reviewer": ["Needs another fix.\nVERDICT: FAIL"],
+        },
+    )
+    real_wait = scheduler.wait_until_terminal
+    coder_waits = 0
+
+    async def fail_empty_second_coder(aid):
+        nonlocal coder_waits
+        scb = scheduler.table.get(aid)
+        is_coder = scb is not None and scb.agent.name == "coder"
+        if is_coder:
+            coder_waits += 1
+        await real_wait(aid)
+        if not is_coder or coder_waits != 2:
+            return
+        assert scb is not None
+        scb.result = ""
+        if failure_mode == "wait":
+            raise RuntimeError("second coder wait failed")
+        scb.state.fail("second coder terminal failed")
+
+    monkeypatch.setattr(scheduler, "wait_until_terminal", fail_empty_second_coder)
+
+    result = run(scheduler.spawn_with_review(0, "write fn", max_iterations=2))
+
+    assert f"Failure stage: coder_{failure_mode}" in result
+    assert "Last implementation:\nbest first implementation" in result
+    assert "Last reviewer feedback:\nNeeds another fix.\nVERDICT: FAIL" in result
+
+
 def test_spawn_with_review_passes_context_and_constraints_to_reviewer(monkeypatch):
     scheduler, _ = _build_scheduler(
         monkeypatch,

--- a/tests/test_team_event_emission.py
+++ b/tests/test_team_event_emission.py
@@ -205,11 +205,8 @@ def test_cleanup_drains_queued_autosaves_before_final_snapshot(tmp_path):
         second_waiter = asyncio.create_task(
             lead.event_bus.emit(SessionRuntimeEvent(type="step_end"))
         )
-        while len(subscriber.pending_tasks) < 2:
-            await asyncio.sleep(0)
-        first_waiter.cancel()
-        second_waiter.cancel()
-        await asyncio.gather(first_waiter, second_waiter, return_exceptions=True)
+        await asyncio.gather(first_waiter, second_waiter)
+        assert len(subscriber.pending_tasks) == 1
 
         cleanup = asyncio.create_task(scheduler.cleanup(cleanup_timeout=1.0))
         await asyncio.sleep(0.02)
@@ -295,9 +292,7 @@ def test_cleanup_reports_nonquiescent_autosave_before_late_release(tmp_path):
             lead.event_bus.emit(SessionRuntimeEvent(type="step_end"))
         )
         assert await asyncio.to_thread(started.wait, 1.0)
-        waiter.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await waiter
+        await waiter
 
         with pytest.raises(
             RuntimeError,

--- a/tests/test_tool_execution_use_case.py
+++ b/tests/test_tool_execution_use_case.py
@@ -632,6 +632,32 @@ def test_tool_observations_bound_large_nested_arguments():
     assert tool.runtime_calls[0][0] == arguments
 
 
+def test_tool_observation_budget_accounts_for_large_numeric_scalars():
+    huge_integer = int("9" * 4000)
+    arguments = {"values": [huge_integer] * 64}
+    tool = RuntimeNativeTool()
+    tracer = FakeTracer()
+    use_case, publisher = build_use_case(
+        agent=FakeAgent(tools=[tool]),
+        tracer=tracer,
+    )
+
+    run(use_case.process([tool_call(arguments=json.dumps(arguments))]))
+
+    event_args = publisher.events[0].data["args"]
+    trace_args = tracer.steps[0]["payload"]["args"]
+    serialized = json.dumps(event_args, ensure_ascii=False).encode("utf-8")
+    assert event_args == trace_args
+    assert len(serialized) <= tool_execution_runtime.OBSERVATION_PAYLOAD_BUDGET_BYTES
+    assert any(
+        isinstance(value, dict)
+        and value.get("__opencollab_truncated__") is True
+        and value.get("original_type") == "int"
+        for value in event_args["values"]
+    )
+    assert tool.runtime_calls[0][0] == arguments
+
+
 def test_tool_execution_use_case_persists_full_tool_output():
     # The full result is appended/persisted; bounding what the model sees is the
     # job of the call-time per-tool-result budget shaper, not tool execution.

--- a/tests/test_tool_execution_use_case.py
+++ b/tests/test_tool_execution_use_case.py
@@ -14,6 +14,7 @@ from tool_execution_test_support import (
     RecordingEventPublisher as FakeEventPublisher,
 )
 
+import opencollab.application.tool_execution_runtime as tool_execution_runtime
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
 from opencollab.application.structured_output import StructuredOutputTool
 from opencollab.application.submit_findings import SubmitFindingsTool

--- a/tests/test_tool_execution_use_case.py
+++ b/tests/test_tool_execution_use_case.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -600,6 +602,34 @@ def test_tool_execution_use_case_preserves_trace_payload_capping():
     assert payload["args"] == {"value": 1}
     assert payload["result_len"] == len(raw_output)
     assert "\n...[truncated]...\n" in payload["result"]
+
+
+def test_tool_observations_bound_large_nested_arguments():
+    content = "x" * (4 * 1024 * 1024)
+    arguments = {"content": content, "nested": {"small": "kept"}}
+    tool = RuntimeNativeTool()
+    tracer = FakeTracer()
+    use_case, publisher = build_use_case(
+        agent=FakeAgent(tools=[tool]),
+        tracer=tracer,
+    )
+
+    run(use_case.process([tool_call(arguments=json.dumps(arguments))]))
+
+    event_args = publisher.events[0].data["args"]
+    trace_args = tracer.steps[0]["payload"]["args"]
+    assert event_args == trace_args
+    assert len(json.dumps(event_args).encode("utf-8")) < 16 * 1024
+    assert content not in json.dumps(event_args)
+    assert event_args["content"] == {
+        "__opencollab_truncated__": True,
+        "preview": "x" * 512,
+        "original_length": len(content),
+        "original_bytes": len(content),
+        "sha256": hashlib.sha256(content.encode()).hexdigest(),
+    }
+    assert event_args["nested"] == {"small": "kept"}
+    assert tool.runtime_calls[0][0] == arguments
 
 
 def test_tool_execution_use_case_persists_full_tool_output():

--- a/tests/test_workflow_runtime_cleanup.py
+++ b/tests/test_workflow_runtime_cleanup.py
@@ -269,18 +269,14 @@ async def test_workflow_cleanup_marks_cancelled_blocking_autosave_nonquiescent()
     second_waiter = asyncio.create_task(
         event_bus.emit(SessionRuntimeEvent(type="step_end"))
     )
-    while len(subscriber.pending_tasks) < 2:
-        await asyncio.sleep(0)
-    first_waiter.cancel()
-    second_waiter.cancel()
     waiter_results = await asyncio.gather(
         first_waiter,
         second_waiter,
         return_exceptions=True,
     )
-    assert all(isinstance(result, asyncio.CancelledError) for result in waiter_results)
+    assert waiter_results == [None, None]
     owners = subscriber.pending_tasks
-    assert len(owners) == 2
+    assert len(owners) == 1
     assert event_bus.pending_tasks == owners
 
     cleanup = asyncio.create_task(
@@ -322,7 +318,9 @@ async def test_workflow_cleanup_reports_completed_autosave_failure():
     event_bus = EventBus(subscriber)
 
     class SessionWithFailedAutosave:
-        pending_cleanup_tasks = ()
+        @property
+        def pending_cleanup_tasks(self):
+            return event_bus.pending_tasks
 
         @property
         def persistence_errors(self):


### PR DESCRIPTION
## Logical layer

This branch now targets `main` directly. It remains a cumulative review prefix until PR #54 is merged. After that merge, PR #55 will be rebased onto the latest `main` so its three-dot diff contains only this logical layer. The bug map below records the original audited source commits; the current branch replays the same patches on the new base.

This PR adds durable autosave/checkpoint behavior, observability payload
limits, review-artifact retention, and terminal hook reporting. It is a
persistence/diagnostics layer on top of bootstrap and configuration.

- GitHub base: `main`
- head: `codex/layer-persistence-observability`
- current direct range: `150995ffde07..25343a615f8f`
- commits in this slice: 16

## Bug-ID to commit map

| Bug-ID | Commit(s) |
|---|---|
| OC-051 | `0711127e6354` |
| OC-082 | `f507adeb48af` |
| OC-090 | `0711127e6354` |
| OC-091 | `b469a84f5cf1`, `3c5477b79af4`, `ce46f689bf2f`, `e3460b0e3c09` |
| OC-111 | `597ca8be9d6f`, `d563b93e7bf3` |
| OC-146 | `044f4285b1ac`, `8c6f58864d38` |
| OC-159 | `67e3d29c2085` |
| OC-160 | `78c36645a582` |
| OC-218 | `a10803956759` |

## Per-bug description

### OC-051 — JSON Schema union types skipped object/array deep validation

- **Problem and trigger:** When a schema used type=[object, null] or type=[array, null], an object with missing required fields or an array with invalid elements passed the top-level type check. Because the validator compared the raw type list with the single strings object/array, required, properties, and items checks were skipped.
- **Impact:** Invalid structured output was reported as successful, causing later business errors or incomplete data to enter subsequent workflow stages.
- **Actual fix and evidence:** The validator now separates union-type acceptance from recursive validation by dispatching on the runtime dict/list value and validates schema keyword shapes. The retained structured-output regression (commit 99af2974450ec628c4c39d6b5ab64946ddaeb4e4) and the complete suite pass.

### OC-082 — Accepted prompt/agent hooks failed at runtime and EventBus swallowed the error

- **Problem and trigger:** A team could configure a prompt or agent hook and trigger its lifecycle event. Configuration accepted these reserved types, but ShellHookRunner registered only command execution, raised NotImplementedError, and EventBus isolation let the main task continue.
- **Impact:** Required review, notification, or agent side effects silently did not occur and the run exposed no reliable failure signal.
- **Actual fix and evidence:** Configuration now rejects hook action types that the runner cannot execute (until a shared action registry can drive both schema and runner). The retained test_hooks regression (commit 7fa66cd02c9c4ce621e3b6a548ab83a77a3905eb) and complete suite pass.

### OC-090 — JSON Schema used Python numeric/boolean equality instead of JSON semantics

- **Problem and trigger:** A schema requiring integer rejected a finite 1.0, while enum=[true] accepted integer 1 (and the false/0 converse), because Python equality was used directly.
- **Impact:** Valid structured results were retried unnecessarily while invalid values could be accepted with a type different from the schema contract.
- **Actual fix and evidence:** Integer and enum validation now use JSON-type-aware rules (including recursive JSON equality and rejection of non-finite numbers). The retained schema matrix in commit 99af2974450ec628c4c39d6b5ab64946ddaeb4e4 and the complete suite pass.

### OC-091 — Each autosave blocked the event loop and rewrote the full history

- **Problem and trigger:** In a long session with growing SAVE_TRIGGERS transcripts and slow storage, every save deep-copied and serialized the complete messages/meta snapshot while EventBus waited for the save owner; cumulative work approached O(n²).
- **Impact:** Per-turn latency and disk write amplification grew with transcript length, reducing multi-agent throughput and risking upper-layer timeouts.
- **Actual fix and evidence:** Terminal run_loop now waits for the queued autosave and compacts a journal-backed base snapshot after DONE, STOPPED, or ERROR. Terminal-phase and autosave/session/persistence regressions pass, and the base file contains the terminal phase.

### OC-111 — Tool arguments in trace and event logs had no size bound

- **Problem and trigger:** A normal file_write or patch with a large string, with runtime events and tracing enabled, copied the full argument dictionary into tool_start and trace payloads and serialized it repeatedly; only result fields were capped.
- **Impact:** Large edits caused memory spikes, event-loop delay, and bloated JSONL traces, amplified by concurrent tools.
- **Actual fix and evidence:** Event and trace argument payloads now use bounded structured truncation with numeric metadata while execution still receives all original integers. The repaired 64×4000-digit regression shrank serialization from 256,140 to 7,677 bytes; the tool/dispatch/event-log gate passed 86 tests.

### OC-146 — Self-collaboration failure exits lost the final review feedback or coder artifact

- **Problem and trigger:** If every review iteration failed, the final string contained only last_result; if a coder had produced a usable patch but reviewer spawn/wait failed, the exception escaped without returning the artifact or a review outcome event.
- **Impact:** A paid, potentially usable patch and the most important failure explanation could be lost, leaving monitoring with an orphaned review_started iteration.
- **Actual fix and evidence:** Failure exits now return a unified outcome retaining the first implementation and reviewer feedback and emit the corresponding terminal event. Independent second-iteration regressions and the team-event/scheduler-awaiting gate (49 tests) pass.

### OC-159 — Failed or cancelled agents never fired Stop/SubagentStop hooks

- **Problem and trigger:** Hook subscription mapped only agent_completed; agent_failed and agent_cancelled terminal events therefore triggered no stop hook.
- **Impact:** Cleanup, notification, and evidence-copy hooks were skipped on the failure paths where they were most needed.
- **Actual fix and evidence:** All terminal dispositions are mapped to one stop-hook payload with exactly-once delivery. test_subscriber_maps_all_terminal_dispositions covers lead/child failure and cancellation; focused and full gates pass.

### OC-160 — Hook-process cleanup failure stayed in an unreachable runner flag

- **Problem and trigger:** When a hook timed out or was cancelled and process-group quiescence could not be proven, ShellHookRunner set cleanup_quiesced=False and raised, but EventBus isolated the exception and scheduler cleanup never read the private runner state.
- **Impact:** OpenCollab could report a clean completion while a hook process might still be alive.
- **Actual fix and evidence:** Cleanup failures now propagate to scheduler/programmatic cleanup as ProcessCleanupError and preserve the cleanup cause. The integration regression passes; the hook/scheduler-cleanup gate passed 75 tests.

### OC-218 — Boolean numeric configuration was silently coerced to 1 or 1.0

- **Problem and trigger:** Programmatic or team configuration could pass True/False for budget, max_output_tokens, temperature, top_p, or hook timeout. Pydantic coerced these booleans before validation, so True became 1 and False became 0.0.
- **Impact:** A type mistake could reduce a run to a one-token budget/output or a one-second hook timeout while configuration appeared valid; top_p=False also changed sampling silently.
- **Actual fix and evidence:** Shared pre-coercion validators now reject booleans across configuration, hook, and team numeric fields while still parsing explicit environment strings. Commit fb07017b78c226ce05bd61a33e887f544f6263ab retains the regressions and the complete suite passes.

### PR55-R1 — Restoring into a different autosave path could leave only an incremental journal

- **Problem and trigger:** A session restored from an existing checkpoint with auto_save_path redirected to a new path inherited the source cursor and appended a suffix journal without creating a complete base snapshot at the target.
- **Impact:** Opening the target alone lacked its base and could fail with replace_from exceeding restored messages, making autosave recovery impossible.
- **Actual fix and evidence:** Commit b2036742a60f creates a complete target checkpoint on launch for a different target and treats relative/absolute aliases as the same path. Focused regressions and the PR55 head suite passed 2014 tests with one skip.

## Validation

- Current head: `25343a615f8f22ad39417784a6b0c1e7c86074b5`
- Current base: `150995ffde071e931bbd8234ef211d54c24837f0`
- Slice commits: `16`
- Complete local suite recorded for this head: `2014 passed, 1 skipped`.
- `ruff check .` and the pairwise layer file-hygiene checks passed.
- Required GitHub checks are rerunning for the rewritten direct-to-main head.

## Stack boundary

Every open layer PR targets `main`. Merge them in numerical order. After each merge, the next branch will be rebased onto the latest `main` and verified before it is merged. Review and merge decisions remain human-owned.

