### PR TITLE
fix(llm): harden compatible gateway response handling

### DIFF
--- a/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/adapters/llm/anthropic_provider.py
@@ -234,9 +234,9 @@ def _parse_response(resp: Any) -> LLMResponse:
     for block in resp.content:
         provider_content.append(_serialize_content_block(block))
         if block.type == "text":
-            content += block.text
+            content += _text_or_empty(getattr(block, "text", None))
         elif block.type == "thinking":
-            thinking_text += getattr(block, "thinking", "")
+            thinking_text += _text_or_empty(getattr(block, "thinking", None))
             has_thinking = True
         elif block.type == "redacted_thinking":
             has_thinking = True
@@ -266,18 +266,30 @@ def _parse_response(resp: Any) -> LLMResponse:
     )
 
 
+def _text_or_empty(value: Any) -> str:
+    """Normalize nullable text fields emitted by compatible gateways."""
+    return value if isinstance(value, str) else ""
+
+
 def _serialize_content_block(block: Any) -> dict[str, Any]:
     """Return a JSON-safe Anthropic block for an unchanged later request."""
     if hasattr(block, "model_dump"):
         payload = block.model_dump(mode="json", exclude_none=True)
         if isinstance(payload, dict):
+            if payload.get("type") == "text":
+                payload["text"] = _text_or_empty(payload.get("text"))
+            elif payload.get("type") == "thinking":
+                payload["thinking"] = _text_or_empty(payload.get("thinking"))
             return payload
     if isinstance(block, dict):
         return copy.deepcopy(block)
     if block.type == "text":
-        return {"type": "text", "text": getattr(block, "text", "")}
+        return {"type": "text", "text": _text_or_empty(getattr(block, "text", None))}
     if block.type == "thinking":
-        payload = {"type": "thinking", "thinking": getattr(block, "thinking", "")}
+        payload = {
+            "type": "thinking",
+            "thinking": _text_or_empty(getattr(block, "thinking", None)),
+        }
         signature = getattr(block, "signature", None)
         if signature is not None:
             payload["signature"] = signature

--- a/opencollab/adapters/llm/retry.py
+++ b/opencollab/adapters/llm/retry.py
@@ -15,7 +15,50 @@ from opencollab.adapters.llm.errors import is_context_overflow_error
 RETRYABLE_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504}
 
 # Error-message fragments that signal a transient failure when no status is set.
-RETRYABLE_MESSAGE_FRAGMENTS = ("rate limit", "429", "timeout", "temporarily unavailable", "overloaded")
+RETRYABLE_MESSAGE_FRAGMENTS = (
+    "rate limit",
+    "429",
+    "timeout",
+    "temporarily unavailable",
+    "overloaded",
+)
+
+# The Anthropic/OpenAI SDKs wrap transport failures in provider-specific
+# exception classes (for example ``APIConnectionError``) without attaching an
+# HTTP status.  Compatible gateways commonly stringify those exceptions as
+# simply ``Connection error``.  Keep the classification narrow: retry known
+# transport exception class names and transport-layer message fragments, but
+# do not retry an arbitrary application ``ValueError`` that happens to mention
+# a connection.
+_TRANSIENT_TRANSPORT_CLASS_NAMES = frozenset(
+    {
+        "apiconnectionerror",
+        "apitimeouterror",
+        "connecterror",
+        "connecttimeout",
+        "connectionabortederror",
+        "connectionrefusederror",
+        "connectionreseterror",
+        "brokenpipeerror",
+        "pooltimeout",
+        "readerror",
+        "readtimeout",
+        "remoteprotocolerror",
+        "sockettimeout",
+        "timeouterror",
+        "writeerror",
+        "writetimeout",
+    }
+)
+_TRANSIENT_TRANSPORT_MESSAGE_FRAGMENTS = (
+    "connection error",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "broken pipe",
+    "server disconnected",
+    "remote protocol error",
+)
 
 # Small random jitter (seconds) added to each backoff to reduce thundering herd.
 RETRY_JITTER_MAX_SECONDS = 0.25
@@ -63,7 +106,34 @@ def is_retryable_error(error: Exception) -> bool:
             return True
 
     msg = str(error).lower()
-    return any(k in msg for k in RETRYABLE_MESSAGE_FRAGMENTS)
+    if any(k in msg for k in RETRYABLE_MESSAGE_FRAGMENTS):
+        return True
+
+    # Follow the exception cause/context chain because SDK wrappers often
+    # preserve the useful transport error only as ``__cause__``.
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        class_name = type(current).__name__.lower()
+        if class_name in _TRANSIENT_TRANSPORT_CLASS_NAMES:
+            return True
+        message = str(current).lower()
+        if any(
+            fragment in message
+            for fragment in _TRANSIENT_TRANSPORT_MESSAGE_FRAGMENTS
+        ) and class_name in {
+            "apiconnectionerror",
+            "apitimeouterror",
+            "connecterror",
+            "connectionerror",
+            "connectionreseterror",
+            "remoteprotocolerror",
+            "timeouterror",
+        }:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def extract_retry_after_seconds(

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 from llm_provider_test_support import _openai_resp
 
+from opencollab.adapters.llm.anthropic_provider import _parse_response as parse_anthropic_response
 from opencollab.adapters.llm.anthropic_provider import _parse_usage as parse_anthropic_usage
 from opencollab.adapters.llm.openai_provider import _parse_response as parse_openai_response
 from opencollab.adapters.llm.providers import (
@@ -169,3 +170,30 @@ def test_openai_normal_usage_unchanged_and_no_double_count():
     assert result.usage.raw_usage["prompt_tokens_details"]["cached_tokens"] == 800
     assert result.usage.total_tokens == 1050
     assert result.usage.estimated is False
+
+
+def test_anthropic_tolerates_null_text_and_thinking_blocks():
+    """Compatible Anthropic gateways may emit nullable content fields."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                type="thinking",
+                thinking=None,
+                signature="signed-thinking",
+            ),
+            SimpleNamespace(type="text", text=None),
+        ],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        stop_reason="end_turn",
+    )
+
+    result = parse_anthropic_response(response)
+
+    assert result.content is None
+    assert result.reasoning is None
+    assert result.provider_state == {
+        "anthropic_content": [
+            {"type": "thinking", "thinking": "", "signature": "signed-thinking"},
+            {"type": "text", "text": ""},
+        ]
+    }

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -1,0 +1,32 @@
+"""Transport retry classification tests."""
+
+from __future__ import annotations
+
+from opencollab.adapters.llm.retry import is_retryable_error
+
+
+class APIConnectionError(Exception):
+    """Small stand-in for an SDK connection wrapper."""
+
+
+class APITimeoutError(Exception):
+    """Small stand-in for an SDK timeout wrapper."""
+
+
+def test_sdk_connection_wrapper_is_retryable_without_http_status():
+    assert is_retryable_error(APIConnectionError("Connection error.")) is True
+
+
+def test_sdk_timeout_wrapper_is_retryable_without_http_status():
+    assert is_retryable_error(APITimeoutError("request stalled")) is True
+
+
+def test_transport_cause_chain_is_retryable():
+    wrapper = RuntimeError("provider request failed")
+    wrapper.__cause__ = ConnectionResetError("connection reset by peer")
+
+    assert is_retryable_error(wrapper) is True
+
+
+def test_unrelated_application_error_is_not_retryable():
+    assert is_retryable_error(ValueError("connection error in candidate schema")) is False


### PR DESCRIPTION
## Summary

The AROC run uses the OpenCollab `anthropic` adapter with the GLM-5.2 compatible gateway. That route can legally return nullable `text` or `thinking` fields, and transient SDK transport failures can arrive without an HTTP status. The current adapter/parser and retry classifier allowed those responses to abort structured candidate generation before any B200 dispatch.

This PR hardens the control path without changing the public workflow contract:

- Normalize nullable Anthropic text/thinking fields to empty strings before concatenation and replay serialization.
- Classify narrowly identified SDK/transport connection failures as retryable, following cause/context chains while preserving the context-overflow non-retry rule.
- Add regressions for nullable Anthropic blocks and transport retry classification.

## Evidence / validation

- Targeted provider and retry tests: 29 passed.
- Full suite: 1749 passed, 1 skipped.
- Ruff: passed.
- `git diff --check`: passed.

The commits and author/committer identity are KaiEureka. This PR does not contain credentials or experiment artifacts.