### PR TITLE
fix(workflow): harden orchestration and message flow

### DIFF
--- a/opencollab/adapters/llm/openai_provider.py
+++ b/opencollab/adapters/llm/openai_provider.py
@@ -15,7 +15,6 @@ from opencollab.adapters.llm.types import (
     LLMResponse,
     Usage,
     estimate_messages_tokens,
-    estimate_tokens,
     model_capabilities,
     rescue_empty_turn,
 )
@@ -218,7 +217,9 @@ def _normalize_tool_arguments(arguments: str | None) -> str:
     return raw
 
 
-def _parse_response(resp: Any, request_messages: list[dict]) -> LLMResponse:
+def _parse_response(
+    resp: Any, request_messages: list[dict], tools: list[dict] | None = None
+) -> LLMResponse:
     choice = resp.choices[0]
     message = choice.message
 
@@ -255,7 +256,7 @@ def _parse_response(resp: Any, request_messages: list[dict]) -> LLMResponse:
                 reasoning = cleaned_reasoning
                 markup_recovered = True
 
-    usage = _parse_usage(resp, request_messages, message)
+    usage = _parse_usage(resp, request_messages, message, tools)
     # Surface the P6 recovery as an observability counter (summed up the chain
     # into the run metrics) without altering the recovered response itself.
     usage.markup_recovered = 1 if markup_recovered else 0
@@ -273,7 +274,12 @@ def _parse_response(resp: Any, request_messages: list[dict]) -> LLMResponse:
     )
 
 
-def _parse_usage(resp: Any, request_messages: list[dict], message: Any) -> Usage:
+def _parse_usage(
+    resp: Any,
+    request_messages: list[dict],
+    message: Any,
+    tools: list[dict] | None = None,
+) -> Usage:
     """Build a ``Usage`` from an OpenAI-compatible response, with estimate fallback.
 
     Some OpenAI-compatible endpoints (proxies, certain streaming configs,
@@ -297,7 +303,7 @@ def _parse_usage(resp: Any, request_messages: list[dict], message: Any) -> Usage
 
     estimated = False
     if input_tokens <= 0:
-        input_tokens = estimate_messages_tokens(request_messages)
+        input_tokens = estimate_messages_tokens(request_messages, tools)
         estimated = True
     if output_tokens <= 0:
         output_tokens = _estimate_output_tokens(message)
@@ -357,18 +363,11 @@ def _usage_to_plain(value: Any) -> Any:
 
 
 def _estimate_output_tokens(message: Any) -> int:
-    """Estimate output tokens from response text + serialized tool-call args."""
-    text = message.content or ""
-    for tool_call in message.tool_calls or []:
-        # Some OpenAI-compatible gateways emit partially formed tool calls with
-        # ``arguments=null`` (or, more rarely, ``name=null``). Usage estimation
-        # is observational and must not turn that provider response into a
-        # Python TypeError before the normal structured-output retry can act.
-        text += (
-            (getattr(tool_call.function, "name", None) or "")
-            + (getattr(tool_call.function, "arguments", None) or "")
-        )
-    return estimate_tokens(text) if text else 0
+    """Estimate output tokens from all serialized assistant response fields."""
+    plain_message = _usage_to_plain(message)
+    if not isinstance(plain_message, dict):
+        return 0
+    return estimate_messages_tokens([{"role": "assistant", **plain_message}])
 
 
 async def complete_openai(
@@ -400,4 +399,4 @@ async def complete_openai(
         lambda: client.chat.completions.create(**kwargs),
         max_retries=max_retries,
     )
-    return _parse_response(resp, messages)
+    return _parse_response(resp, kwargs["messages"], kwargs.get("tools"))

--- a/opencollab/adapters/llm/types.py
+++ b/opencollab/adapters/llm/types.py
@@ -7,6 +7,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from opencollab.domain.agent import DEFAULT_MAX_TOKENS_PER_STEP
+from opencollab.domain.token_estimation import (  # noqa: F401 - compatibility re-export
+    estimate_messages_tokens,
+    estimate_tokens,
+)
 
 # ---------------------------------------------------------------------------
 # Response containers
@@ -165,27 +169,3 @@ def model_capabilities(model: str | None) -> ModelCapabilities:
 def model_context_window(model: str | None) -> int | None:
     """The known context window for ``model``, or ``None`` if unrecognised."""
     return model_capabilities(model).context_window
-
-
-# ---------------------------------------------------------------------------
-# Token estimation
-# ---------------------------------------------------------------------------
-
-
-def estimate_tokens(text: str) -> int:
-    """Rough token estimation: ~4 chars per token for English, ~2 for CJK."""
-    return max(1, len(text) // 3)
-
-
-def estimate_messages_tokens(messages: list[dict]) -> int:
-    """Estimate total tokens across a message list."""
-    total = 0
-    for m in messages:
-        content = m.get("content", "")
-        if isinstance(content, str):
-            total += estimate_tokens(content)
-        elif isinstance(content, list):
-            for part in content:
-                if isinstance(part, dict) and "text" in part:
-                    total += estimate_tokens(part["text"])
-    return total

--- a/opencollab/adapters/tools/apply_patch.py
+++ b/opencollab/adapters/tools/apply_patch.py
@@ -104,7 +104,7 @@ class ApplyPatchTool(Tool):
         mode = params["mode"]
         env = runtime.environment
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
 
         path = checked_path(runtime, path)

--- a/opencollab/adapters/tools/bash.py
+++ b/opencollab/adapters/tools/bash.py
@@ -101,7 +101,7 @@ class BashTool(Tool):
         env = runtime.environment
         safety_policy = runtime.safety_policy
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
         if self.require_process_isolation and not getattr(
             env, "process_isolated", False

--- a/opencollab/adapters/tools/fs.py
+++ b/opencollab/adapters/tools/fs.py
@@ -95,7 +95,7 @@ class FileReadTool(Tool):
         limit = params.get("limit", 500)
         env = runtime.environment
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
 
         path = checked_path(runtime, path)
@@ -226,7 +226,7 @@ class FileWriteTool(Tool):
         mode = params["mode"]
         env = runtime.environment
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
 
         if not self.allow_create and mode == "create":
@@ -400,7 +400,7 @@ class GrepTool(Tool):
         raw_max_results = params.get("max_results", 50)
         env = runtime.environment
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
         try:
             search_path = checked_path(runtime, search_path)

--- a/opencollab/adapters/tools/git_diff.py
+++ b/opencollab/adapters/tools/git_diff.py
@@ -92,7 +92,7 @@ class GitDiffTool(Tool):
         include_status = params.get("include_status", True)
         env = runtime.environment
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
 
         pathspec = f" -- {shlex.quote(path)}" if path else ""

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -221,7 +221,7 @@ class RunTestsTool(Tool):
         env = runtime.environment
         safety_policy = runtime.safety_policy
 
-        if not env:
+        if env is None:
             return "Error: no execution environment available."
         if self.require_process_isolation and not getattr(
             env, "process_isolated", False

--- a/opencollab/adapters/tools/spawn.py
+++ b/opencollab/adapters/tools/spawn.py
@@ -62,10 +62,15 @@ class SpawnAgentTool(Tool):
         task = params["task"]
         context = params.get("context", "")
         parent_aid = runtime.aid
-        # Single-flight guard: if this exact (role, task) is already running,
-        # refuse and tell the model to wait rather than spawn a duplicate. The
-        # string return resolves this tool call synchronously (no pending row).
-        existing = self._scheduler.inflight_spawn(role, task)
+        # Single-flight guard: only this parent's exact (role, task, context)
+        # delegation is deduped. The string return resolves this tool call
+        # synchronously (no pending row).
+        existing = self._scheduler.inflight_spawn(
+            role,
+            task,
+            parent_aid=parent_aid,
+            context=context,
+        )
         if existing is not None:
             return (
                 f"Not spawned: this task is already being handled by agent "

--- a/opencollab/application/_scheduler_cleanup.py
+++ b/opencollab/application/_scheduler_cleanup.py
@@ -40,7 +40,20 @@ class SchedulerCleanupMixin:
         timeout = self._validate_cleanup_timeout(cleanup_timeout)
         if self._cleanup_task is None:
             self._cleanup_task = asyncio.create_task(self._cleanup_impl(timeout=timeout))
-        await await_owned_operation(self._cleanup_task, propagate_cancellation=True)
+        task = self._cleanup_task
+        try:
+            await await_owned_operation(task, propagate_cancellation=True)
+        except BaseException:
+            # Share one in-flight teardown across concurrent callers, but do not
+            # permanently memoize a transient failure. Caller cancellation alone
+            # is not a retry signal: await_owned_operation keeps the owner alive
+            # and may re-raise cancellation after that owner succeeded.
+            failed = task.done() and (
+                task.cancelled() or task.exception() is not None
+            )
+            if failed and self._cleanup_task is task:
+                self._cleanup_task = None
+            raise
 
     @staticmethod
     def _validate_cleanup_timeout(value: object) -> float:
@@ -59,20 +72,23 @@ class SchedulerCleanupMixin:
         startup_aids = set(self._startup_tasks)
         origins = {**self._startup_origin, **self._spawn_origin}
         interrupted_deliveries = set(self._message_delivery_tasks)
+        public_run_tasks = _unique_task_owners(
+            ((aid, task) for task, aid in self._active_run_tasks.items()),
+        )
         execution_tasks = _unique_task_owners(
             self._tasks.items(),
             self._startup_tasks.items(),
         )
         delivery_tasks = _unique_task_owners(
             self._message_delivery_tasks.items(),
-            ((0, task) for task in self._active_run_tasks),
+            public_run_tasks,
         )
         tracked_tasks = _unique_task_owners(execution_tasks, delivery_tasks)
         running_execution = {
             (aid, task) for aid, task in execution_tasks if not task.done()
         }
-        running_delivery = {
-            (aid, task) for aid, task in delivery_tasks if not task.done()
+        running_public_turns = {
+            (aid, task) for aid, task in public_run_tasks if not task.done()
         }
         all_tasks = {task for _aid, task in tracked_tasks}
         pending = await cancel_tasks_and_wait(all_tasks, timeout=timeout)
@@ -97,8 +113,8 @@ class SchedulerCleanupMixin:
         for aid, task in running_execution:
             if task.cancelled() or task in pending or (task.done() and task.exception() is not None):
                 self._finalize_cleanup_failure(aid, origin_override=origins.get(aid))
-        if any(aid == 0 for aid, _task in running_delivery):
-            self._finalize_cleanup_failure(0)
+        for aid, _task in running_public_turns:
+            self._finalize_cleanup_failure(aid)
         for aid in startup_aids:
             self._finalize_cleanup_failure(aid, origin_override=origins.get(aid))
             self.table.entries.pop(aid, None)
@@ -135,13 +151,13 @@ class SchedulerCleanupMixin:
         if persistence_errors:
             failures.append("session persistence failed")
 
-        release_safe = not pending and environments_aborted
+        release_safe = not pending and environments_aborted and persistence_quiesced
         worktrees_released = release_safe and await self._release_worktree_pool_bounded(timeout=timeout)
         if not worktrees_released:
             failures.append(
                 "worktree pool release failed or timed out"
                 if release_safe
-                else "worktree pool release skipped because scheduler work did not quiesce"
+                else "worktree pool release skipped because owned work did not quiesce"
             )
         if failures:
             failure = RuntimeError("technical scheduler cleanup failed: " + "; ".join(failures))

--- a/opencollab/application/_scheduler_constants.py
+++ b/opencollab/application/_scheduler_constants.py
@@ -3,3 +3,12 @@
 WORKTREE_DIFF_MAX_CHARS = 12_000
 WORKTREE_DIFF_KEEP_CHARS = 6_000
 DEFAULT_SCHEDULER_CLEANUP_TIMEOUT = 10.0
+
+# Teammate messages are persisted both in a session sidecar and in the
+# scheduler inbox. Keep each representation and every model-bound delivery
+# finite, using encoded bytes because that is stable across Python strings and
+# directly bounds the serialized prompt payload.
+MAX_TEAMMATE_MESSAGE_BYTES = 8 * 1024
+MAX_TEAMMATE_INBOX_MESSAGES = 32
+MAX_TEAMMATE_INBOX_BYTES = 64 * 1024
+MAX_TEAMMATE_DELIVERY_BYTES = 16 * 1024

--- a/opencollab/application/_scheduler_review.py
+++ b/opencollab/application/_scheduler_review.py
@@ -46,9 +46,7 @@ class SchedulerReviewMixin:
             if task is not None and not task.done():
                 await asyncio.shield(task)
             else:
-                # A child completion may be between filling the pending table
-                # and publishing the replacement driving task.
-                await asyncio.sleep(0)
+                await self._wait_for_scheduler_progress(aid)
 
     async def spawn_with_review(
         self,

--- a/opencollab/application/_scheduler_run.py
+++ b/opencollab/application/_scheduler_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from opencollab.application.scheduler_types import SchedulerStalledError, SchedulerTurnError
 from opencollab.domain.session import SessionPhase
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ class SchedulerRunMixin:
         """
         current_task = asyncio.current_task()
         if current_task is not None:
-            self._active_run_tasks.add(current_task)
+            self._active_run_tasks[current_task] = aid
         try:
             async with self._run_lock:
                 return await self._run_turn_exclusive(aid, user_message)
@@ -35,12 +36,14 @@ class SchedulerRunMixin:
             # driver and descendants running after that owner is cancelled.
             if not self._shutting_down:
                 if current_task is not None:
-                    self._active_run_tasks.discard(current_task)
+                    if self._active_run_tasks.get(current_task) == aid:
+                        self._active_run_tasks.pop(current_task, None)
                 await self.cleanup()
             raise
         finally:
             if current_task is not None:
-                self._active_run_tasks.discard(current_task)
+                if self._active_run_tasks.get(current_task) == aid:
+                    self._active_run_tasks.pop(current_task, None)
 
     async def _run_turn_exclusive(self, aid: int, user_message: str) -> str:
         """Drive one externally visible agent turn under ``_run_lock``."""
@@ -102,15 +105,11 @@ class SchedulerRunMixin:
                     logger.debug("background task for aid %s was cancelled", done_aid)
                 except Exception as exc:
                     logger.error("background task for aid %s failed: %s", done_aid, exc)
-            pending = list(self._tasks.values())
+            pending = self._active_scheduler_tasks()
             if not pending:
                 if self._quiescent():
                     break
-                # All tasks drained but a wake's resume task may be mid-creation
-                # (or a pending table is still open) — yield and re-check rather
-                # than exit early. Non-empty pending tables keep us looping
-                # without busy-spinning.
-                await asyncio.sleep(0)
+                await self._wait_for_scheduler_progress(aid)
                 continue
             await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
 
@@ -119,15 +118,54 @@ class SchedulerRunMixin:
         # Limit the answer lookup to messages appended during this invocation.
         # This keeps the public return value free of the worktree diff stored on
         # the SCB and prevents a precheck-only turn from leaking an old answer.
+        partial_answer = ""
         for message in reversed(session.state.messages[turn_start:]):
             if message.get("role") == "assistant" and message.get("content"):
-                return message["content"]
-        return ""
+                partial_answer = message["content"]
+                break
+        phase = scb.state.phase
+        if phase in {SessionPhase.ERROR, SessionPhase.STOPPED}:
+            raise SchedulerTurnError(
+                aid,
+                phase,
+                scb.state.terminal_reason,
+                partial_answer or None,
+            )
+        return partial_answer
+
+    def _active_scheduler_tasks(self) -> set[asyncio.Task]:
+        """Return live scheduler-owned producers, excluding the current waiter."""
+        current = asyncio.current_task()
+        return {
+            task
+            for task in (
+                *self._tasks.values(),
+                *self._startup_tasks.values(),
+                *self._message_delivery_tasks.values(),
+            )
+            if not task.done() and task is not current
+        }
+
+    async def _wait_for_scheduler_progress(self, aid: int) -> None:
+        """Block for a producer completion or report a state with no producer."""
+        producers = self._active_scheduler_tasks()
+        if not producers:
+            raise SchedulerStalledError(aid)
+        await asyncio.wait(producers, return_when=asyncio.FIRST_COMPLETED)
 
     def _quiescent(self) -> bool:
         """True when no session is mid-flight: none is awaiting events, none has
         an outstanding pending table, and every phase is terminal or idle.
         """
+        if any(
+            not task.done()
+            for task in (
+                *self._tasks.values(),
+                *self._startup_tasks.values(),
+                *self._message_delivery_tasks.values(),
+            )
+        ):
+            return False
         for scb in self.table.entries.values():
             if self._message_inbox.get(scb.aid):
                 return False

--- a/opencollab/application/_session_run_completion.py
+++ b/opencollab/application/_session_run_completion.py
@@ -12,6 +12,7 @@ from opencollab.application._session_run_shared import (
     GenerationTimeoutError,
     _ContextOverflowStop,
     _submit_tool_choice,
+    _TokenBudgetStop,
 )
 from opencollab.application.async_timeout import CallerTimeoutError, abandon_on_timeout
 from opencollab.application.ports import CompletionResponse
@@ -24,6 +25,7 @@ from opencollab.application.steering import (
 from opencollab.domain.agent import DEFAULT_MAX_TOKENS_PER_STEP
 from opencollab.domain.pending import PendingEventTable, PendingRow, RowKind, RowStatus
 from opencollab.domain.session import SessionPhase
+from opencollab.domain.token_estimation import request_tokens_upper_bound
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +177,7 @@ class _SessionRunCompletionMixin:
         steering, tool_choice_override, steering_level = build_steering_block(
             used_tokens=self.state.used_tokens,
             max_budget_tokens=self.max_budget_tokens or 0,
-            step_count=self.state.step_count,
+            step_count=self.state.step_count + 1,
             max_steps=self.max_steps,
             reads=self.state.turn.reads_since_last_edit,
             has_write=bool(tool_names & _WRITE_TOOLS),
@@ -284,7 +286,26 @@ class _SessionRunCompletionMixin:
         top_p = getattr(self.agent, "top_p", None)
         if top_p is not None:
             extra["top_p"] = top_p
-        max_output_tokens = getattr(self.agent, "max_tokens_per_step", DEFAULT_MAX_TOKENS_PER_STEP)
+        configured_output_tokens = getattr(
+            self.agent,
+            "max_tokens_per_step",
+            DEFAULT_MAX_TOKENS_PER_STEP,
+        )
+        remaining_budget = int(self.max_budget_tokens) - int(self.state.used_tokens)
+        reserved_input_tokens = request_tokens_upper_bound(messages, tools)
+        output_budget = remaining_budget - reserved_input_tokens
+        if output_budget < 1:
+            raise _TokenBudgetStop(
+                reserved_input_tokens=reserved_input_tokens,
+                remaining_budget=remaining_budget,
+            )
+        # Precheck guarantees positive headroom before entering this call. Clamp
+        # the provider's output ceiling to the live remainder after reserving an
+        # upper bound for request messages and registered tool schemas.
+        max_output_tokens = min(
+            max(1, int(configured_output_tokens)),
+            output_budget,
+        )
         if max_output_tokens != DEFAULT_MAX_TOKENS_PER_STEP:
             extra["max_output_tokens"] = max_output_tokens
         if not getattr(self.agent, "thinking", False):
@@ -314,6 +335,7 @@ class _SessionRunCompletionMixin:
         workflow/agent wrapper as a dead step (the run continues with whatever is
         already in the working tree). ``None`` disables the ceiling.
         """
+        await self._start_llm_step()
         if self._per_call_timeout is None:
             return await self.llm.complete(**kwargs)
         try:
@@ -326,6 +348,16 @@ class _SessionRunCompletionMixin:
             raise GenerationTimeoutError(
                 f"LLM generation exceeded the {self._per_call_timeout}s per-call timeout"
             ) from exc
+
+    async def _start_llm_step(self) -> None:
+        """Record one step immediately before the first provider attempt."""
+        if self._llm_step_started:
+            return
+        self.state.advance_step()
+        await self.event_publisher.emit(
+            self.event_factory.step_start(self.state.step_count)
+        )
+        self._llm_step_started = True
 
     async def _stop_on_context_overflow(self) -> None:
         """Graceful terminal stop when a prompt overflows the model window even

--- a/opencollab/application/_session_run_shared.py
+++ b/opencollab/application/_session_run_shared.py
@@ -24,6 +24,18 @@ class _ContextOverflowStop(Exception):
     """
 
 
+class _TokenBudgetStop(Exception):
+    """Internal signal that a request has no reserved output headroom."""
+
+    def __init__(self, *, reserved_input_tokens: int, remaining_budget: int) -> None:
+        self.reserved_input_tokens = reserved_input_tokens
+        self.remaining_budget = remaining_budget
+        super().__init__(
+            "conservative input reservation requires "
+            f"{reserved_input_tokens} of {remaining_budget} remaining tokens"
+        )
+
+
 @dataclass
 class PendingStep:
     """The LLM response carried across HANDLING_RESPONSE → EXECUTING_TOOLS →

--- a/opencollab/application/ports.py
+++ b/opencollab/application/ports.py
@@ -294,9 +294,18 @@ class SchedulerPort(Protocol):
         """
         ...
 
-    def inflight_spawn(self, role: str, task: str) -> int | None:
-        """The aid already handling this (role, task) if a spawn is in flight,
-        else ``None``. Lets the spawn tool refuse a duplicate single-flight.
+    def inflight_spawn(
+        self,
+        role: str,
+        task: str,
+        *,
+        parent_aid: int = 0,
+        context: str = "",
+    ) -> int | None:
+        """The aid handling this parent's exact delegated work, if any.
+
+        Lets the spawn tool refuse only a duplicate single-flight from the same
+        parent/context, not distinct delegations that happen to share task text.
         """
         ...
 

--- a/opencollab/application/scheduler.py
+++ b/opencollab/application/scheduler.py
@@ -43,6 +43,8 @@ from opencollab.application.scheduler_lifecycle import LifecycleMixin
 from opencollab.application.scheduler_messaging import MessagingMixin
 from opencollab.application.scheduler_types import LaunchSpec as LaunchSpec
 from opencollab.application.scheduler_types import QueuedTeammateMessage as QueuedTeammateMessage
+from opencollab.application.scheduler_types import SchedulerStalledError as SchedulerStalledError
+from opencollab.application.scheduler_types import SchedulerTurnError as SchedulerTurnError
 from opencollab.domain.identity import role_collision_key, validate_role_identity
 from opencollab.domain.scheduler import SessionTable
 from opencollab.domain.team import Topology
@@ -136,7 +138,9 @@ class Scheduler(
         self._sessions: dict[int, Any] = {}
         self._locks: dict[int, asyncio.Lock] = {}
         self._run_lock = asyncio.Lock()
-        self._active_run_tasks: set[asyncio.Task[Any]] = set()
+        # A public run_turn owner must retain its addressed aid through cleanup:
+        # cancelling a child turn must never terminalize the Lead by default.
+        self._active_run_tasks: dict[asyncio.Task[Any], int] = {}
         self._lead_session: Any | None = None
         # child aid -> (parent aid, tool_call_id) for deferred spawns: lets a
         # child's completion fill the exact pending row that suspended its
@@ -147,12 +151,9 @@ class Scheduler(
         # post-delivery event; this marker preserves the already-committed child /
         # parent terminal pair instead of rewriting only the child to CANCELLED.
         self._delivery_committed: set[int] = set()
-        # Single-flight spawn dedup: task key -> the aid currently handling it,
-        # plus the reverse map for release. A (role, task) is reserved at spawn
-        # and freed when the child reaches a terminal phase, so a model that
-        # re-issues an identical spawn is refused (see ``inflight_spawn``) rather
-        # than spinning up a duplicate — tool-level enforcement of "don't spawn
-        # the same task twice", which prompt guidance alone cannot guarantee.
+        # Single-flight spawn dedup: delegated-work identity -> the handling aid,
+        # plus the reverse map for release. A (parent, role, task, context) is
+        # reserved at spawn and freed when the child reaches a terminal phase.
         self._inflight: dict[str, int] = {}
         self._inflight_key_of: dict[int, str] = {}
         # Per-active-turn token leases. A lease records the session's token count
@@ -188,4 +189,10 @@ class Scheduler(
             tuple[int, dict[str, int]] | None
         ] = contextvars.ContextVar("review_parent_lease_tracker", default=None)
 
-__all__ = ["LaunchSpec", "QueuedTeammateMessage", "Scheduler"]
+__all__ = [
+    "LaunchSpec",
+    "QueuedTeammateMessage",
+    "Scheduler",
+    "SchedulerStalledError",
+    "SchedulerTurnError",
+]

--- a/opencollab/application/scheduler_dedup.py
+++ b/opencollab/application/scheduler_dedup.py
@@ -1,10 +1,9 @@
 """Single-flight spawn dedup for the Scheduler.
 
-A (role, task) is reserved synchronously at spawn and freed when the child
-reaches a terminal phase, so a model that re-issues an identical spawn is
-refused (see ``inflight_spawn``) rather than spinning up a duplicate —
-tool-level enforcement of "don't spawn the same task twice", which prompt
-guidance alone cannot guarantee.
+A (parent, role, task, context) identity is reserved synchronously at spawn and
+freed when the child reaches a terminal phase, so a model that re-issues the
+same delegated work is refused (see ``inflight_spawn``) rather than spinning up
+a duplicate. Different parents and contexts remain independent.
 
 ``InflightDedupMixin`` is composed into ``Scheduler`` and relies on the
 ``_inflight`` / ``_inflight_key_of`` maps created in ``Scheduler.__init__``.
@@ -16,24 +15,45 @@ import hashlib
 
 
 class InflightDedupMixin:
-    """Reserve/lookup/release for in-flight (role, task) spawns."""
+    """Reserve/lookup/release for in-flight delegated-work identities."""
 
     @staticmethod
-    def _task_key(role: str, task: str) -> str:
-        """Stable dedup key for a (role, task). Whitespace is collapsed so a
-        reflowed re-prompt of the same instruction maps to the same key.
-        """
-        normalized = " ".join(task.split())
-        return hashlib.md5(f"{role}\x00{normalized}".encode()).hexdigest()
+    def _task_key(parent_aid: int, role: str, task: str, context: str) -> str:
+        """Stable identity for one parent's exact delegated work.
 
-    def inflight_spawn(self, role: str, task: str) -> int | None:
-        """The aid already handling this (role, task) if a spawn is in flight,
-        else ``None``. The spawn tool consults this to refuse duplicates.
+        Newline encodings are normalized for cross-platform stability, but all
+        other whitespace remains significant: indentation can change a code
+        block or shell command's meaning.
         """
-        return self._inflight.get(self._task_key(role, task))
+        normalized_task = task.replace("\r\n", "\n").replace("\r", "\n")
+        normalized_context = context.replace("\r\n", "\n").replace("\r", "\n")
+        digest = hashlib.sha256()
+        for value in (str(parent_aid), role, normalized_task, normalized_context):
+            encoded = value.encode()
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+        return digest.hexdigest()
 
-    def _reserve_inflight(self, aid: int, role: str, task: str) -> None:
-        key = self._task_key(role, task)
+    def inflight_spawn(
+        self,
+        role: str,
+        task: str,
+        *,
+        parent_aid: int = 0,
+        context: str = "",
+    ) -> int | None:
+        """The aid already handling this parent's exact delegation, if any."""
+        return self._inflight.get(self._task_key(parent_aid, role, task, context))
+
+    def _reserve_inflight(
+        self,
+        aid: int,
+        parent_aid: int,
+        role: str,
+        task: str,
+        context: str,
+    ) -> None:
+        key = self._task_key(parent_aid, role, task, context)
         self._inflight[key] = aid
         self._inflight_key_of[aid] = key
 

--- a/opencollab/application/scheduler_lifecycle.py
+++ b/opencollab/application/scheduler_lifecycle.py
@@ -136,7 +136,7 @@ class LifecycleMixin:
                 parent_lease = self._release_turn_lease(parent_aid)
                 if parent_lease is not None:
                     self._track_review_parent_lease_release(parent_aid, 1)
-            self._reserve_inflight(aid, role, task)
+            self._reserve_inflight(aid, parent_aid, role, task, context)
             budget = self._reserve_child_budget(aid)
             if budget <= 0:
                 raise RuntimeError(
@@ -272,10 +272,11 @@ class LifecycleMixin:
 
         The loop returns either suspended on ``AWAITING_EVENTS`` (the session
         spawned its own children — leave it; a child wake re-enters here later)
-        or terminal. On terminal completion it emits ``agent_completed`` and, if
-        the session was itself a deferred child, fills its parent's pending row
-        and re-activates the parent. Used for both the initial run and every
-        event-driven resume, at any depth of the delegation tree.
+        or terminal. A DONE terminal emits ``agent_completed``; STOPPED/ERROR
+        terminals emit ``agent_failed``. If the session was itself a deferred
+        child, its outcome fills the parent's pending row and re-activates the
+        parent. Used for both the initial run and every event-driven resume, at
+        any depth of the delegation tree.
         """
         scb = self.table.get(aid)
         if scb is None:
@@ -298,24 +299,26 @@ class LifecycleMixin:
                 logger.error(
                     "agent_cancelled event failed for aid %s: %s", aid, event_exc
                 )
-            await self._deliver_to_parent(aid, reason, RowStatus.FAILED)
+            await self._deliver_to_parent(aid, reason, RowStatus.FAILED, error=reason)
             if not self._shutting_down:
                 await self._drain_message_inbox(aid, allow_current_task=True)
                 await self._drain_ready_message_inboxes()
             raise
         except Exception as exc:
             self._release_leases(aid)
-            scb.state.fail()
-            scb.result = f"Error: {exc}"
+            terminal_reason = scb.state.terminal_reason or f"{type(exc).__name__}: {exc}"
+            scb.state.fail(terminal_reason)
+            reason = f"Error: {terminal_reason}"
+            scb.result = reason
             try:
                 await self.emit_scheduler_event(
-                    self._events.agent_failed(aid, scb.agent.name, str(exc))
+                    self._events.agent_failed(aid, scb.agent.name, terminal_reason)
                 )
             except Exception as event_exc:
                 logger.error(
                     "agent_failed event failed for aid %s: %s", aid, event_exc
                 )
-            await self._deliver_to_parent(aid, f"Error: {exc}", RowStatus.FAILED)
+            await self._deliver_to_parent(aid, reason, RowStatus.FAILED, error=reason)
             await self._drain_message_inbox(aid, allow_current_task=True)
             await self._drain_ready_message_inboxes()
             return
@@ -340,6 +343,23 @@ class LifecycleMixin:
         # delivering, so a later spawn can reuse this child's unspent headroom.
         self._release_leases(aid)
 
+        terminal_failure = self._terminal_failure_result(scb, result)
+        if terminal_failure is not None:
+            scb.result = terminal_failure
+            await self._safe_emit_scheduler_event(
+                self._events.agent_failed(aid, scb.agent.name, terminal_failure)
+            )
+            await self._deliver_to_parent(
+                aid,
+                terminal_failure,
+                RowStatus.FAILED,
+                error=terminal_failure,
+            )
+            await self._drain_message_inbox(aid, allow_current_task=True)
+            if not self._shutting_down:
+                await self._drain_ready_message_inboxes()
+            return
+
         # A completed coding task still needs its patch evidence. Tracing and
         # event delivery are observational, but a missing diff is a technical
         # failure because the parent cannot verify what changed.
@@ -355,7 +375,7 @@ class LifecycleMixin:
                 await self._safe_emit_scheduler_event(
                     self._events.agent_failed(aid, scb.agent.name, str(exc))
                 )
-                await self._deliver_to_parent(aid, result, RowStatus.FAILED)
+                await self._deliver_to_parent(aid, result, RowStatus.FAILED, error=result)
                 await self._drain_message_inbox(aid, allow_current_task=True)
                 if not self._shutting_down:
                     await self._drain_ready_message_inboxes()
@@ -395,13 +415,28 @@ class LifecycleMixin:
             self._finalize_cleanup_failure(aid)
             return
 
-        status = RowStatus.FAILED if scb.state.phase is SessionPhase.ERROR else RowStatus.DONE
-        await self._deliver_to_parent(aid, result, status)
+        await self._deliver_to_parent(aid, result, RowStatus.DONE)
         await self._drain_message_inbox(aid, allow_current_task=True)
         if not self._shutting_down:
             await self._drain_ready_message_inboxes()
 
-    async def _deliver_to_parent(self, child_aid: int, result: str, status: RowStatus) -> None:
+    @staticmethod
+    def _terminal_failure_result(scb: Any, result: str) -> str | None:
+        phase = scb.state.phase
+        if phase not in {SessionPhase.ERROR, SessionPhase.STOPPED}:
+            return None
+        disposition = "failed" if phase is SessionPhase.ERROR else "stopped"
+        reason = scb.state.terminal_reason or result.strip() or phase.value
+        return f"Error: agent {disposition}: {reason}"
+
+    async def _deliver_to_parent(
+        self,
+        child_aid: int,
+        result: str,
+        status: RowStatus,
+        *,
+        error: str | None = None,
+    ) -> None:
         """Route a finished child's result to the pending row that suspended its
         parent, then re-activate the parent. No-op for fire-and-forget spawns.
         """
@@ -416,14 +451,115 @@ class LifecycleMixin:
                 result,
                 status,
                 child_aid=child_aid,
+                error=error,
             )
         except PendingRowError as exc:
-            self._spawn_origin.pop(child_aid, None)
+            retry_tool_call_id = await self._recover_delivery_route(
+                child_aid,
+                parent_aid,
+                exc,
+            )
+            if retry_tool_call_id is not None:
+                try:
+                    await self._wake(
+                        parent_aid,
+                        retry_tool_call_id,
+                        result,
+                        status,
+                        child_aid=child_aid,
+                        error=error,
+                    )
+                    return
+                except PendingRowError as retry_exc:
+                    # The unique row disappeared or changed between discovery
+                    # and fill. Count that as the bounded final route failure.
+                    exc = retry_exc
+                    await self._recover_delivery_route(child_aid, parent_aid, retry_exc)
             # A misrouted completion must surface loudly, never silently succeed.
             logger.error("misrouted completion from child %s: %s", child_aid, exc)
             await self._safe_emit_scheduler_event(
                 self._events.agent_failed(parent_aid, self._role_of(parent_aid), str(exc))
             )
+
+    async def _recover_delivery_route(
+        self,
+        child_aid: int,
+        parent_aid: int,
+        cause: PendingRowError,
+    ) -> str | None:
+        """Route a unique child row or close the parent batch explicitly.
+
+        A pending row is identified only by its ``ref`` pointing to the child;
+        this never writes the child's result into an unrelated tool row.  The
+        only safe recovery is a single such row.  Any other shape is terminal:
+        atomically fail the parent's open batch so it cannot remain suspended
+        waiting for a child whose completion no longer has a valid route.
+        """
+        parent_scb = self.table.get(parent_aid)
+        parent_session = self._sessions.get(parent_aid)
+        if parent_scb is None or parent_session is None:
+            self._spawn_origin.pop(child_aid, None)
+            return None
+
+        lock = self._locks.setdefault(parent_aid, asyncio.Lock())
+        should_resume = False
+        async with lock:
+            table = parent_scb.state.pending_events
+            child_rows = [
+                tool_call_id
+                for tool_call_id, row in table.rows.items()
+                if row.status is RowStatus.PENDING and row.ref == child_aid
+            ]
+            if len(child_rows) == 1:
+                return child_rows[0]
+
+            reason = f"Error: child completion routing failed: {cause}"
+            # No unique target exists. This is a terminal parent-side routing
+            # failure, not a child result for a different row: fail every open
+            # row atomically so no producer-less PENDING row survives.
+            for tool_call_id, row in tuple(table.rows.items()):
+                if row.status is RowStatus.PENDING:
+                    table.fill(
+                        tool_call_id,
+                        result=reason,
+                        status=RowStatus.FAILED,
+                        error=reason,
+                    )
+            self._spawn_origin.pop(child_aid, None)
+            in_flight = self._tasks.get(parent_aid)
+            should_resume = (
+                not self._shutting_down
+                and parent_scb.state.phase is SessionPhase.AWAITING_EVENTS
+                and table.is_complete()
+                and (in_flight is None or in_flight.done())
+            )
+            if should_resume:
+                self._reserve_turn_lease(parent_aid)
+                self._tasks[parent_aid] = asyncio.create_task(
+                    self._drive_agent(parent_aid, parent_session)
+                )
+            elif (
+                not self._shutting_down
+                and parent_scb.state.phase is SessionPhase.AWAITING_EVENTS
+                and table.is_complete()
+                and in_flight is not None
+                and not in_flight.done()
+            ):
+                in_flight.add_done_callback(
+                    lambda finished: asyncio.create_task(
+                        self._resume_after_parent_task(
+                            parent_aid,
+                            parent_session,
+                            finished,
+                        )
+                    )
+                )
+
+        if should_resume:
+            await self._safe_emit_scheduler_event(
+                self._events.agent_resumed(parent_aid, self._role_of(parent_aid))
+            )
+        return None
 
     async def _wake(
         self,
@@ -433,6 +569,7 @@ class LifecycleMixin:
         status: RowStatus,
         *,
         child_aid: int | None = None,
+        error: str | None = None,
     ) -> None:
         """Fill the parent's pending row and, if that completes the batch while
         the parent is suspended, create a resume task. Fill + completeness check
@@ -451,7 +588,7 @@ class LifecycleMixin:
         async with lock:
             table = parent_scb.state.pending_events
             cleanup_forced = False
-            fill_error: str | None = None
+            fill_error = error
             if child_aid is not None:
                 child_scb = self.table.get(child_aid)
                 cleanup_forced = self._shutting_down

--- a/opencollab/application/scheduler_messaging.py
+++ b/opencollab/application/scheduler_messaging.py
@@ -15,10 +15,17 @@ helpers defined on ``Scheduler``.
 from __future__ import annotations
 
 import asyncio
+import uuid
 import xml.etree.ElementTree as ET
 from typing import Any
 from xml.sax.saxutils import escape, quoteattr
 
+from opencollab.application._scheduler_constants import (
+    MAX_TEAMMATE_DELIVERY_BYTES,
+    MAX_TEAMMATE_INBOX_BYTES,
+    MAX_TEAMMATE_INBOX_MESSAGES,
+    MAX_TEAMMATE_MESSAGE_BYTES,
+)
 from opencollab.application.scheduler_types import QueuedTeammateMessage
 from opencollab.domain.session import SessionPhase
 
@@ -55,7 +62,27 @@ class MessagingMixin:
         async with lock:
             if self._shutting_down:
                 return "Error: scheduler is shutting down."
-            xml = self._format_teammate_message(from_aid, summary, content)
+            message_id = uuid.uuid4().hex
+            xml = self._format_teammate_message(
+                from_aid,
+                summary,
+                content,
+                message_id=message_id,
+            )
+            message_bytes = self._encoded_size(xml)
+            if message_bytes > MAX_TEAMMATE_MESSAGE_BYTES:
+                return (
+                    "Error: teammate message exceeds the "
+                    f"{MAX_TEAMMATE_MESSAGE_BYTES}-byte limit."
+                )
+            inbox = self._message_inbox.get(to_aid, [])
+            if len(inbox) >= MAX_TEAMMATE_INBOX_MESSAGES:
+                return f"Error: teammate inbox for aid {to_aid} is full (backpressure)."
+            if self._inbox_size(inbox) + message_bytes > MAX_TEAMMATE_INBOX_BYTES:
+                return (
+                    f"Error: teammate inbox for aid {to_aid} exceeds the "
+                    f"{MAX_TEAMMATE_INBOX_BYTES}-byte limit (backpressure)."
+                )
             target.state.queue_pending_user_message(
                 {
                     "role": "user",
@@ -64,6 +91,7 @@ class MessagingMixin:
                     "from_aid": from_aid,
                     "to_aid": to_aid,
                     "summary": summary,
+                    "message_id": message_id,
                 }
             )
             sent_at = str(target.state.pending_user_messages[-1]["timestamp"])
@@ -74,8 +102,10 @@ class MessagingMixin:
                 content=content,
                 xml=xml,
                 sent_at=sent_at,
+                message_id=message_id,
             )
-            self._message_inbox.setdefault(to_aid, []).append(message)
+            inbox.append(message)
+            self._message_inbox[to_aid] = inbox
             self._autosave_session(to_aid)
             delivered_events = await self._drain_message_inbox_locked(to_aid)
         # Scheduler events are observational and may re-enter send_message. Emit
@@ -127,11 +157,18 @@ class MessagingMixin:
         pending = getattr(state, "pending_user_messages", None)
         if not isinstance(pending, list) or not pending:
             return
+        committed_ids = self._message_ids_in_history(state)
         restored: list[QueuedTeammateMessage] = []
-        for item in pending:
+        for item in list(pending):
             if not isinstance(item, dict) or not item.get("content"):
                 continue
             xml = str(item["content"])
+            message_id = str(item.get("message_id") or self._message_id_from_xml(xml) or "")
+            if message_id and message_id in committed_ids:
+                state.discard_pending_user_message_id(message_id)
+                continue
+            if message_id and not item.get("message_id"):
+                item["message_id"] = message_id
             restored.append(
                 QueuedTeammateMessage(
                     from_aid=self._restored_aid(item.get("from_aid"), default=-1),
@@ -143,6 +180,7 @@ class MessagingMixin:
                     ),
                     xml=xml,
                     sent_at=str(item.get("timestamp") or ""),
+                    message_id=message_id,
                 )
             )
         if restored:
@@ -167,11 +205,44 @@ class MessagingMixin:
         return content
 
     @staticmethod
-    def _format_teammate_message(from_aid: int, summary: str, content: str) -> str:
+    def _message_id_from_xml(xml: str) -> str | None:
+        try:
+            return ET.fromstring(xml).attrib.get("message_id")
+        except ET.ParseError:
+            return None
+
+    @staticmethod
+    def _message_ids_in_history(state: object) -> set[str]:
+        message_ids: set[str] = set()
+        for message in getattr(state, "messages", ()):
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if not isinstance(content, str):
+                continue
+            try:
+                root = ET.fromstring(content)
+            except ET.ParseError:
+                continue
+            for element in root.iter():
+                message_id = element.attrib.get("message_id")
+                if message_id:
+                    message_ids.add(message_id)
+        return message_ids
+
+    @staticmethod
+    def _format_teammate_message(
+        from_aid: int,
+        summary: str,
+        content: str,
+        *,
+        message_id: str = "",
+    ) -> str:
         sender = f"A{from_aid}"
+        message_id_attr = f" message_id={quoteattr(message_id)}" if message_id else ""
         return (
             f"<teammate-message teammate_id={quoteattr(sender)} "
-            f"summary={quoteattr(summary)}>\n"
+            f"summary={quoteattr(summary)}{message_id_attr}>\n"
             f"{escape(content)}\n"
             "</teammate-message>"
         )
@@ -184,7 +255,8 @@ class MessagingMixin:
             envelopes.append(
                 f"<teammate-message teammate_id={quoteattr(sender)} "
                 f"summary={quoteattr(message.summary)} "
-                f"sent_at={quoteattr(message.sent_at)}>\n"
+                f"sent_at={quoteattr(message.sent_at)}"
+                f"{f' message_id={quoteattr(message.message_id)}' if message.message_id else ''}>\n"
                 f"{escape(message.content)}\n"
                 "</teammate-message>"
             )
@@ -193,6 +265,32 @@ class MessagingMixin:
             + "\n".join(envelopes)
             + "\n</teammate-messages>"
         )
+
+    @staticmethod
+    def _encoded_size(value: str) -> int:
+        return len(value.encode("utf-8"))
+
+    @classmethod
+    def _inbox_size(cls, inbox: list[QueuedTeammateMessage]) -> int:
+        return sum(cls._encoded_size(message.xml) for message in inbox)
+
+    @classmethod
+    def _bounded_message_batch(
+        cls, inbox: list[QueuedTeammateMessage]
+    ) -> list[QueuedTeammateMessage]:
+        """Select the largest FIFO prefix whose rendered prompt is bounded."""
+        batch: list[QueuedTeammateMessage] = []
+        for message in inbox:
+            candidate = [*batch, message]
+            delivery = (
+                candidate[0].xml
+                if len(candidate) == 1
+                else cls._format_teammate_message_batch(candidate)
+            )
+            if cls._encoded_size(delivery) > MAX_TEAMMATE_DELIVERY_BYTES:
+                break
+            batch = candidate
+        return batch
 
     async def _drain_message_inbox(self, aid: int, *, allow_current_task: bool = False) -> None:
         lock = self._locks.setdefault(aid, asyncio.Lock())
@@ -232,11 +330,13 @@ class MessagingMixin:
             return []
         if scb.state.phase is SessionPhase.AWAITING_EVENTS or not scb.state.pending_events.is_empty():
             return []
+        messages = self._bounded_message_batch(inbox)
+        if not messages or self._shutting_down:
+            return []
         prior_lease = self._current_turn_lease(aid)
-        if self._shutting_down or not self._reserve_message_budget(aid):
+        if not self._reserve_message_budget(aid):
             return []
 
-        messages = list(inbox)
         delivery = (
             messages[0].xml
             if len(messages) == 1
@@ -244,13 +344,20 @@ class MessagingMixin:
         )
         await self._append_user_turn_txn(aid, session, delivery, prior_lease)
 
+        # Commit the durable dequeue immediately after the history append. A
+        # shutdown may stop the follow-on driver, but it must never leave the
+        # already-appended message in a sidecar that restore would re-deliver.
+        del inbox[: len(messages)]
+        for message in messages:
+            if message.message_id:
+                session.state.discard_pending_user_message_id(message.message_id)
+            else:
+                session.state.discard_pending_user_message(message.xml)
+        self._autosave_session(aid)
+
         if self._shutting_down:
             self._release_turn_lease(aid)
             return []
-        del inbox[: len(messages)]
-        for message in messages:
-            session.state.discard_pending_user_message(message.xml)
-        self._autosave_session(aid)
 
         self._tasks[aid] = asyncio.create_task(self._drive_agent(aid, session))
         return [

--- a/opencollab/application/scheduler_types.py
+++ b/opencollab/application/scheduler_types.py
@@ -11,6 +11,34 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypedDict
 
+from opencollab.domain.session import SessionPhase
+
+
+class SchedulerTurnError(RuntimeError):
+    """A targeted public turn reached a non-success terminal session phase."""
+
+    def __init__(
+        self,
+        aid: int,
+        phase: SessionPhase,
+        terminal_reason: str | None,
+        partial_answer: str | None,
+    ) -> None:
+        self.aid = aid
+        self.phase = phase
+        self.terminal_reason = terminal_reason
+        self.partial_answer = partial_answer
+        reason = terminal_reason or phase.value
+        super().__init__(f"Agent aid {aid} {phase.value}: {reason}")
+
+
+class SchedulerStalledError(RuntimeError):
+    """No scheduler-owned task can advance a non-terminal session."""
+
+    def __init__(self, aid: int) -> None:
+        self.aid = aid
+        super().__init__(f"Scheduler stalled for aid {aid}: no active producer can advance it")
+
 
 class RosterEntry(TypedDict):
     """One row of a team roster (``Scheduler.team_snapshot``/``team_roster``).
@@ -66,11 +94,14 @@ class QueuedTeammateMessage:
     content: str
     xml: str
     sent_at: str = ""
+    message_id: str = ""
 
 
 __all__ = [
     "LaunchSpec",
     "QueuedTeammateMessage",
     "RosterEntry",
+    "SchedulerStalledError",
+    "SchedulerTurnError",
     "roster_display_state",
 ]

--- a/opencollab/application/schema_validate.py
+++ b/opencollab/application/schema_validate.py
@@ -1,10 +1,12 @@
 """Minimal stdlib JSON-Schema validator for workflow structured output.
 
-A deliberately tiny subset — ``type`` (object/array/string/number/integer/
-boolean), ``required``, ``properties``, ``items``, and ``enum`` — enough to
-shape one-shot agent output without pulling ``jsonschema`` (a third-party
-import is forbidden in the application layer). ``validate`` returns a list of
-human-readable error strings; an empty list means the value conforms.
+The supported subset covers the constraints that OpenCollab sends to providers:
+``type``, ``required``, ``properties``, ``additionalProperties``, ``items``,
+``enum``, string length/pattern bounds, numeric bounds, array length bounds,
+and ``oneOf``. Unsupported assertion keywords are rejected during schema
+validation instead of being silently claimed to a provider. ``validate``
+returns a list of human-readable error strings; an empty list means the value
+conforms.
 
 Pure application layer: stdlib only.
 """
@@ -12,6 +14,7 @@ Pure application layer: stdlib only.
 from __future__ import annotations
 
 import math
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -32,6 +35,33 @@ _TYPE_CHECKS = {
     "null": lambda v: v is None,
 }
 
+_SUPPORTED_KEYWORDS = frozenset({
+    "additionalProperties",
+    "description",
+    "enum",
+    "examples",
+    "items",
+    "maxItems",
+    "maxLength",
+    "maximum",
+    "minItems",
+    "minLength",
+    "minimum",
+    "oneOf",
+    "pattern",
+    "properties",
+    "required",
+    "title",
+    "type",
+})
+
+
+def validate_schema(schema: Any) -> list[str]:
+    """Return deterministic errors for unsupported or malformed schema nodes."""
+    errors: list[str] = []
+    _validate_schema(schema, "$schema", errors)
+    return errors
+
 
 def validate(value: Any, schema: dict[str, Any]) -> list[str]:
     """Validate ``value`` against ``schema``; return a list of error strings.
@@ -39,8 +69,7 @@ def validate(value: Any, schema: dict[str, Any]) -> list[str]:
     An empty list means the value is valid. Errors are collected (not raised)
     and carry a dotted path so the model can self-correct from the message.
     """
-    errors: list[str] = []
-    _validate_schema(schema, "$schema", errors)
+    errors = validate_schema(schema)
     if errors:
         return errors
     _validate(value, schema, "$", errors)
@@ -51,6 +80,9 @@ def _validate_schema(schema: Any, path: str, errors: list[str]) -> None:
     if not isinstance(schema, dict):
         errors.append(f"{path}: schema node must be an object")
         return
+    for keyword in schema:
+        if keyword not in _SUPPORTED_KEYWORDS:
+            errors.append(f"{path}.{keyword}: unsupported schema keyword")
     expected_type = schema.get("type")
     if expected_type is not None:
         members = (
@@ -76,6 +108,43 @@ def _validate_schema(schema: Any, path: str, errors: list[str]) -> None:
             _validate_schema(child, f"{path}.properties.{name}", errors)
     if "items" in schema:
         _validate_schema(schema["items"], f"{path}.items", errors)
+    if "additionalProperties" in schema:
+        additional_properties = schema["additionalProperties"]
+        if isinstance(additional_properties, dict):
+            _validate_schema(
+                additional_properties,
+                f"{path}.additionalProperties",
+                errors,
+            )
+        elif not isinstance(additional_properties, bool):
+            errors.append(f"{path}.additionalProperties: must be a boolean or schema object")
+    for keyword in ("minLength", "maxLength", "minItems", "maxItems"):
+        if keyword in schema:
+            _validate_nonnegative_integer(schema[keyword], f"{path}.{keyword}", errors)
+    for keyword in ("minimum", "maximum"):
+        if keyword in schema and not _is_number(schema[keyword]):
+            errors.append(f"{path}.{keyword}: must be a finite number")
+    if "pattern" in schema:
+        pattern = schema["pattern"]
+        if not isinstance(pattern, str):
+            errors.append(f"{path}.pattern: must be a string")
+        else:
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                errors.append(f"{path}.pattern: invalid regular expression: {exc}")
+    if "oneOf" in schema:
+        one_of = schema["oneOf"]
+        if not isinstance(one_of, list) or not one_of:
+            errors.append(f"{path}.oneOf: must be a non-empty array of schema objects")
+        else:
+            for index, branch in enumerate(one_of):
+                _validate_schema(branch, f"{path}.oneOf[{index}]", errors)
+
+
+def _validate_nonnegative_integer(value: Any, path: str, errors: list[str]) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        errors.append(f"{path}: must be a non-negative integer")
 
 
 def _validate(value: Any, schema: dict[str, Any], path: str, errors: list[str]) -> None:
@@ -89,9 +158,28 @@ def _validate(value: Any, schema: dict[str, Any], path: str, errors: list[str]) 
     if enum is not None and value not in enum:
         errors.append(f"{path}: value {value!r} not in enum {enum!r}")
 
-    if expected_type == "object" or (expected_type is None and isinstance(value, dict)):
+    one_of = schema.get("oneOf")
+    if one_of is not None:
+        matching_schemas = 0
+        for branch in one_of:
+            branch_errors: list[str] = []
+            _validate(value, branch, path, branch_errors)
+            if not branch_errors:
+                matching_schemas += 1
+        if matching_schemas != 1:
+            errors.append(
+                f"{path}: must match exactly one schema in oneOf "
+                f"(matched {matching_schemas})"
+            )
+
+    if isinstance(value, str):
+        _validate_string(value, schema, path, errors)
+    if _is_number(value):
+        _validate_number(value, schema, path, errors)
+
+    if isinstance(value, dict):
         _validate_object(value, schema, path, errors)
-    elif expected_type == "array" or (expected_type is None and isinstance(value, list)):
+    elif isinstance(value, list):
         _validate_array(value, schema, path, errors)
 
 
@@ -106,16 +194,64 @@ def _validate_object(
     for prop_name, prop_schema in properties.items():
         if prop_name in value:
             _validate(value[prop_name], prop_schema, f"{path}.{prop_name}", errors)
+    additional_properties = schema.get("additionalProperties", True)
+    for prop_name, prop_value in value.items():
+        if prop_name in properties:
+            continue
+        if additional_properties is False:
+            errors.append(f"{path}.{prop_name}: unexpected property")
+        elif isinstance(additional_properties, dict):
+            _validate(
+                prop_value,
+                additional_properties,
+                f"{path}.{prop_name}",
+                errors,
+            )
 
 
 def _validate_array(
     value: list[Any], schema: dict[str, Any], path: str, errors: list[str]
 ) -> None:
+    min_items = schema.get("minItems")
+    if min_items is not None and len(value) < min_items:
+        errors.append(f"{path}: must contain at least {min_items} items")
+    max_items = schema.get("maxItems")
+    if max_items is not None and len(value) > max_items:
+        errors.append(f"{path}: must contain at most {max_items} items")
     item_schema = schema.get("items")
     if item_schema is None:
         return
     for index, item in enumerate(value):
         _validate(item, item_schema, f"{path}[{index}]", errors)
+
+
+def _validate_string(value: str, schema: dict[str, Any], path: str, errors: list[str]) -> None:
+    min_length = schema.get("minLength")
+    if min_length is not None and len(value) < min_length:
+        errors.append(f"{path}: must have length >= {min_length}")
+    max_length = schema.get("maxLength")
+    if max_length is not None and len(value) > max_length:
+        errors.append(f"{path}: must have length <= {max_length}")
+    pattern = schema.get("pattern")
+    if pattern is not None and re.search(pattern, value) is None:
+        errors.append(f"{path}: must match pattern {pattern!r}")
+
+
+def _validate_number(value: int | float, schema: dict[str, Any], path: str, errors: list[str]) -> None:
+    minimum = schema.get("minimum")
+    if minimum is not None and value < minimum:
+        errors.append(f"{path}: must be >= {minimum}")
+    maximum = schema.get("maximum")
+    if maximum is not None and value > maximum:
+        errors.append(f"{path}: must be <= {maximum}")
+
+
+def _is_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
 
 
 def _check_type(value: Any, expected_type: Any) -> bool:
@@ -146,4 +282,4 @@ def _type_name(value: Any) -> str:
     return type(value).__name__
 
 
-__all__ = ["validate"]
+__all__ = ["validate", "validate_schema"]

--- a/opencollab/application/self_collaboration.py
+++ b/opencollab/application/self_collaboration.py
@@ -15,6 +15,7 @@ from typing import Protocol
 from opencollab.application.events import SchedulerEventFactory
 from opencollab.domain.events import SchedulerEvent
 from opencollab.domain.scheduler import ReviewVerdict, SessionTable
+from opencollab.domain.session import SessionPhase
 
 logger = logging.getLogger(__name__)
 MAX_REVIEW_ITERATIONS = 3
@@ -101,29 +102,53 @@ async def run_spawn_with_review(
         await scheduler.wait_until_terminal(coder_aid)
         coder_scb = scheduler.table.get(coder_aid)
         code_result = coder_scb.result if coder_scb else ""
+        if coder_scb is None or coder_scb.state.phase is not SessionPhase.DONE:
+            phase = "missing" if coder_scb is None else coder_scb.state.phase.value
+            reason = None if coder_scb is None else coder_scb.state.terminal_reason
+            await _emit_review_event(
+                scheduler,
+                scheduler.events.review_completed(iteration, False),
+            )
+            return (
+                f"[Self-Collaboration: FAILED after {iteration} iteration(s)]\n\n"
+                f"Coder terminal phase: {phase}\n"
+                f"Coder terminal reason: {reason or 'none'}\n\n"
+                f"Last implementation:\n{code_result}"
+            )
 
         # Spawn reviewer and wait
         review_prompt = (
-            f"Review the following implementation for task: '{task}'\n\n"
-            f"Implementation result:\n{code_result}\n\n"
+            "Review the artifact against the original task and required context.\n\n"
+            f"Original task:\n{task}\n\n"
+            f"Required context:\n{context or '(none provided)'}\n\n"
+            f"Artifact to review:\n{code_result}\n\n"
             f"Your response MUST end with a verdict line in exactly this format:\n"
             f"VERDICT: PASS\n"
             f"or\n"
             f"VERDICT: FAIL\n\n"
             f"If FAIL, provide detailed fix instructions before the verdict line."
         )
-        reviewer_aid = await scheduler.spawn(parent_aid, "reviewer", review_prompt)
+        reviewer_aid = await scheduler.spawn(
+            parent_aid,
+            "reviewer",
+            review_prompt,
+            context,
+        )
         await scheduler.wait_until_terminal(reviewer_aid)
         reviewer_scb = scheduler.table.get(reviewer_aid)
         review_result = reviewer_scb.result if reviewer_scb else ""
 
         verdict = ReviewVerdict.parse(review_result)
+        reviewer_completed = (
+            reviewer_scb is not None
+            and reviewer_scb.state.phase is SessionPhase.DONE
+        )
+        passed = reviewer_completed and verdict.passed
         await _emit_review_event(
-            scheduler,
-            scheduler.events.review_completed(iteration, verdict.passed)
+            scheduler, scheduler.events.review_completed(iteration, passed)
         )
 
-        if verdict.passed:
+        if passed:
             return (
                 f"[Self-Collaboration: PASSED after {iteration} iteration(s)]\n\n"
                 f"{code_result}"

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -23,6 +23,7 @@ from opencollab.application._session_run_shared import (
     PendingStep,
     _ContextOverflowStop,
     _submit_tool_choice,
+    _TokenBudgetStop,
 )
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
 from opencollab.application.ports import (
@@ -31,7 +32,10 @@ from opencollab.application.ports import (
     ShaperPort,
     TracePort,
 )
-from opencollab.application.tool_execution import ToolExecutionUseCase
+from opencollab.application.tool_execution import (
+    TERMINAL_CAPTURE_SKIP_MESSAGE,
+    ToolExecutionUseCase,
+)
 from opencollab.domain.pending import PendingEventTable, PendingRow, RowKind, RowStatus
 from opencollab.domain.session import SessionPhase, SessionState
 from opencollab.domain.tools import ToolProcessingResult
@@ -161,6 +165,7 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         # deferred suspend/resume so the returned answer is scoped to this turn.
         self._turn_start_message_index: int | None = None
         self._provider_tasks: set[asyncio.Task[Any]] = set()
+        self._llm_step_started = False
 
     @property
     def pending_cleanup_tasks(self) -> tuple[asyncio.Task[Any], ...]:
@@ -478,13 +483,20 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         gracefully (CONTEXT_OVERFLOW) instead of letting it crash as an
         unhandled ERROR — mirroring the BUDGET_EXCEEDED degradation.
         """
-        self.state.advance_step()
-        await self.event_publisher.emit(self.event_factory.step_start(self.state.step_count))
+        self._llm_step_started = False
         start = time.monotonic()
 
         tools = self.build_tool_schemas()
         try:
             response = await self.call_llm(tools)
+        except _TokenBudgetStop as exc:
+            reason = (
+                "budget exhausted before model call: conservative input reservation "
+                f"requires {exc.reserved_input_tokens} of {exc.remaining_budget} "
+                "remaining tokens, leaving no output headroom"
+            )
+            await self._stop_precheck(reason)
+            return
         except _ContextOverflowStop:
             await self._stop_on_context_overflow()
             return
@@ -494,6 +506,21 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         self.state.set_context_tokens(response.usage.input_tokens)
 
         self.record_llm_trace(response, latency)
+        if self.state.used_tokens > self.max_budget_tokens:
+            reason = (
+                "budget exceeded after model call: "
+                f"{self.state.used_tokens} tokens used"
+            )
+            self.state.append_message(
+                {
+                    "role": "system",
+                    "content": f"[{reason.capitalize()}. Session stopped.]",
+                }
+            )
+            await self.event_publisher.emit(self.event_factory.error(reason))
+            await self.finish_step(latency)
+            self.state.transition_to(SessionPhase.STOPPED, reason=reason)
+            return
         self.append_assistant_message(response)
         self._pending = PendingStep(response=response, latency=latency)
         self.state.transition_to(SessionPhase.HANDLING_RESPONSE)
@@ -603,7 +630,33 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         table = self.state.pending_events
         order = {tc["id"]: i for i, tc in enumerate(original_tool_calls)}
         completed_messages = list(blocked_messages)
-        if immediate:
+        terminal_capture_tools = {"structured_output", self._submit_tool_name}
+        terminal_capture_in_batch = any(
+            tc.get("function", {}).get("name") in terminal_capture_tools
+            for tc in tool_calls
+        )
+        if terminal_capture_in_batch:
+            terminal_capture_accepted = False
+            for tc in tool_calls:
+                if terminal_capture_accepted:
+                    completed_messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc["id"],
+                            "content": TERMINAL_CAPTURE_SKIP_MESSAGE,
+                        }
+                    )
+                    continue
+                if tc.get("function", {}).get("name") in self.deferrable_tool_names:
+                    await self._execute_deferred_tools(table, order, [tc])
+                    continue
+                proc = await self.tool_execution.process([tc])
+                proc.apply_hashes_to(self.state)
+                proc.apply_read_write_counter_to(self.state)
+                proc.apply_evidence_counter_to(self.state)
+                completed_messages.extend(proc.messages_to_append)
+                terminal_capture_accepted = proc.terminal_capture_accepted
+        elif immediate:
             proc = await self.tool_execution.process(immediate)
             proc.apply_hashes_to(self.state)  # hashes now; messages buffered
             # The reads/edit steering counter must still fold in even though the
@@ -615,7 +668,8 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
             proc.apply_evidence_counter_to(self.state)
             completed_messages = [*proc.messages_to_append, *completed_messages]
         self._buffer_completed_rows(table, order, completed_messages)
-        await self._execute_deferred_tools(table, order, deferred)
+        if not terminal_capture_in_batch:
+            await self._execute_deferred_tools(table, order, deferred)
 
         self._pending_tool_allowlist = None
         self._pending_tool_gate_label = None

--- a/opencollab/application/shaping/pipeline.py
+++ b/opencollab/application/shaping/pipeline.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from typing import Any, Iterator
 
 from opencollab.application.ports import ShaperPort
+from opencollab.domain.token_estimation import estimate_messages_tokens
 
 # History-compaction thresholds (token estimates over the whole view). The
 # trigger/target gap is deliberate: a layer compacts down to ``TARGET`` (well
@@ -53,21 +54,14 @@ def history_trigger_target(
 
 
 def approx_messages_tokens(messages: list[dict[str, Any]]) -> int:
-    """Cheap, additive context-size estimate (~chars/4) over a message list.
+    """Cheap, additive context-size estimate over a message list.
 
     Additive per message so subtracting a group's estimate equals the estimate
     of the remainder — lets the history layers re-estimate incrementally. A
-    real tokenizer-backed estimator is injected at wiring time; this is the
-    dependency-free fallback (the spec only needs an approximation).
+    real tokenizer-backed estimator is injected at wiring time; this fallback
+    uses the same serialized request fields as budget accounting.
     """
-    total = 0
-    for message in messages:
-        content = message.get("content")
-        if isinstance(content, str):
-            total += len(content)
-        for call in message.get("tool_calls") or ():
-            total += len(str(call.get("function", {}).get("arguments", "")))
-    return total // 4
+    return estimate_messages_tokens(messages)
 
 
 @contextmanager

--- a/opencollab/application/structured_output.py
+++ b/opencollab/application/structured_output.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from opencollab.application.schema_validate import validate
+from opencollab.application.schema_validate import validate, validate_schema
 from opencollab.application.tool_execution import ToolRuntime
 
 TOOL_NAME = "structured_output"
@@ -49,10 +49,16 @@ class StructuredOutputTool:
         schema: dict[str, Any],
         on_capture: Callable[[], None] | None = None,
     ) -> None:
+        schema_errors = validate_schema(schema)
+        if schema_errors:
+            raise ValueError(
+                "structured output schema is unsupported: " + "; ".join(schema_errors)
+            )
         self._schema = schema
         self._on_capture = on_capture
         self.parameters = schema
         self.captured: dict[str, Any] | None = None
+        self.terminal_capture_accepted = False
 
     def to_openai_schema(self) -> dict[str, Any]:
         return {
@@ -69,6 +75,7 @@ class StructuredOutputTool:
         params: dict[str, Any],
         runtime: ToolRuntime,
     ) -> str:
+        self.terminal_capture_accepted = False
         errors = validate(params, self._schema)
         if errors:
             joined = "; ".join(errors)
@@ -77,6 +84,7 @@ class StructuredOutputTool:
                 f"Fix and call {self.name} again. Errors: {joined}"
             )
         self.captured = params
+        self.terminal_capture_accepted = True
         if self._on_capture is not None:
             self._on_capture()
         return "Recorded. Structured output accepted. Your task is complete."

--- a/opencollab/application/submit_findings.py
+++ b/opencollab/application/submit_findings.py
@@ -93,6 +93,7 @@ class SubmitFindingsTool:
         self._on_capture = on_capture
         self.parameters = SUBMIT_FINDINGS_SCHEMA
         self.captured: dict[str, Any] | None = None
+        self.terminal_capture_accepted = False
 
     def to_openai_schema(self) -> dict[str, Any]:
         return {
@@ -105,6 +106,7 @@ class SubmitFindingsTool:
         }
 
     async def execute_with_runtime(self, params: dict[str, Any], runtime: ToolRuntime) -> str:
+        self.terminal_capture_accepted = False
         errors = validate(params, SUBMIT_FINDINGS_SCHEMA)
         if errors:
             joined = "; ".join(errors)
@@ -129,6 +131,7 @@ class SubmitFindingsTool:
                 "verified=false, then call submit_findings again. Do NOT fabricate an anchor."
             )
         self.captured = params
+        self.terminal_capture_accepted = True
         if self._on_capture is not None:
             self._on_capture()
         return "Recorded. Findings accepted. Your reconnaissance is complete."

--- a/opencollab/application/tool_execution.py
+++ b/opencollab/application/tool_execution.py
@@ -76,6 +76,9 @@ _WRITE_TOOLS = frozenset({"file_write", "apply_patch"})
 # these prefixes — see execute_tool's PermissionError/Exception mapping and the
 # tools' own "Error: ..." returns.
 _TOOL_ERROR_PREFIXES = ("Error", "Tool execution error", "Permission denied")
+TERMINAL_CAPTURE_SKIP_MESSAGE = (
+    "Skipped: terminal structured output accepted earlier in this batch."
+)
 
 # Information-gain sensor (STEP 1). Each EXECUTED tool result is classified as
 # informative vs low-yield so later brakes can key on information GAIN, not raw
@@ -294,7 +297,7 @@ class ToolExecutionUseCase(ToolExecutionRuntimeMixin):
             return result
         recent_call_hashes = list(self.state.turn.recent_call_hashes)
 
-        for tc in tool_calls:
+        for index, tc in enumerate(tool_calls):
             func = tc["function"]
             tool_name = func["name"]
             tool_id = tc["id"]
@@ -375,6 +378,25 @@ class ToolExecutionUseCase(ToolExecutionRuntimeMixin):
                 })
                 continue
 
+            schema = getattr(tool, "parameters", None)
+            if isinstance(schema, dict):
+                schema_errors = validate(args, schema)
+                if schema_errors:
+                    detail = "; ".join(schema_errors)[:1_000]
+                    self._trace_short_circuit(
+                        "tool_error",
+                        tool_name,
+                        {"error": "schema_validation_failed", "args": args},
+                    )
+                    result.messages_to_append.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_id,
+                            "content": "Error: schema validation failed: " + detail,
+                        }
+                    )
+                    continue
+
             await self._emit_observation(
                 lambda: self.event_factory.tool_start(tool_name, args),
                 label="tool_start",
@@ -439,6 +461,17 @@ class ToolExecutionUseCase(ToolExecutionRuntimeMixin):
                 lambda: self.event_factory.tool_end(tool_name, tool_latency),
                 label="tool_end",
             )
+            if getattr(tool, "terminal_capture_accepted", False):
+                result.terminal_capture_accepted = True
+                for skipped in tool_calls[index + 1 :]:
+                    result.messages_to_append.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": skipped["id"],
+                            "content": TERMINAL_CAPTURE_SKIP_MESSAGE,
+                        }
+                    )
+                break
 
         return result
 

--- a/opencollab/application/workflow.py
+++ b/opencollab/application/workflow.py
@@ -49,6 +49,7 @@ from opencollab.application.ports import (
 )
 from opencollab.application.session_run import DEFAULT_COMMIT_RESERVE, ENFORCEMENT_OFF
 from opencollab.application.workflow_agents import WorkflowAgentsMixin
+from opencollab.application.workflow_budget import WorkflowBudget, _BudgetLease
 from opencollab.application.workflow_structured import (
     WorkflowStructuredMixin,
 )
@@ -94,55 +95,6 @@ class WorkflowEvent:
 
     kind: str
     message: str
-
-
-class WorkflowBudget:
-    """Read-only view over token spend across all sessions created so far.
-
-    ``spent`` sums each tracked session's live ``used_tokens``; ``remaining``
-    has infinity semantics when ``total`` is ``None`` (unbounded).
-    """
-
-    def __init__(self, total: int | None, sessions: list[Any]) -> None:
-        self._total = total
-        self._sessions = sessions
-        self._leases: list[_BudgetLease] = []
-
-    @property
-    def total(self) -> int | None:
-        return self._total
-
-    def spent(self) -> int:
-        return sum(int(getattr(s, "used_tokens", 0)) for s in self._sessions)
-
-    def remaining(self) -> float:
-        if self._total is None:
-            return float("inf")
-        reserved_unspent = sum(lease.remaining() for lease in self._leases)
-        return self._total - self.spent() - reserved_unspent
-
-    def reserve(self, lease: _BudgetLease) -> None:
-        self._leases.append(lease)
-
-    def release(self, lease: _BudgetLease) -> None:
-        try:
-            self._leases.remove(lease)
-        except ValueError:
-            pass
-
-
-@dataclass
-class _BudgetLease:
-    """A per-call token allocation held while one workflow agent is active."""
-
-    total: int
-    reserved: int
-    sessions: list[Any]
-    pending_tasks: list[asyncio.Task[Any]] | None = None
-
-    def remaining(self) -> int:
-        spent = sum(max(0, int(getattr(s, "used_tokens", 0))) for s in self.sessions)
-        return max(0, self.total - spent)
 
 
 class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
@@ -417,42 +369,38 @@ class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
         controlled way inside the workflow (its on-disk edits survive) rather than
         being truncated by the outer wall.
         """
+        if isolation:
+            raise ValueError("workflow agent isolation is not available")
         timeout = self._normalize_timeout(timeout)
         call_task = asyncio.current_task()
         if call_task is not None:
             self._active_call_tasks.add(call_task)
         slot_acquired = False
         slot_handed_to_cleanup = False
+        lease: _BudgetLease | None = None
+        token = None
         try:
+            # Reserve before the concurrency gate so every agent declared in a
+            # parallel fan-out registers with the shared allocator, even when
+            # only one of them may run at a time.
+            lease = await self._acquire_budget_lease(
+                budget,
+                over_budget_ok=over_budget_ok,
+            )
+            token = self._active_budget_lease.set(lease)
             await self._semaphore.acquire()
             slot_acquired = True
-            lease = await self._acquire_budget_lease(budget, over_budget_ok=over_budget_ok)
-            token = self._active_budget_lease.set(lease)
-            try:
-                if schema is not None:
-                    return await self._run_structured_agent(
-                        prompt, schema=schema, label=label, tools=tools,
-                        isolation=isolation, timeout=timeout, budget=budget,
-                    )
-                # Enforcement wind-down (STEP 0): the scout path injects submit_findings
-                # and the structural commit brake. OFF (the default) routes to the
-                # unchanged ``_run_agent``, so every existing caller is byte-for-byte
-                # identical — the new path is reachable only when explicitly requested.
-                if enforcement_strength != ENFORCEMENT_OFF:
-                    return await self._run_enforced_agent(
-                        prompt,
-                        label=label,
-                        tools=tools,
-                        isolation=isolation,
-                        tool_choice=tool_choice,
-                        thinking=thinking,
-                        timeout=timeout,
-                        budget=budget,
-                        enforcement_strength=enforcement_strength,
-                        commit_reserve=commit_reserve,
-                        harvest_fallback=harvest_fallback,
-                    )
-                return await self._run_agent(
+            if schema is not None:
+                return await self._run_structured_agent(
+                    prompt, schema=schema, label=label, tools=tools,
+                    isolation=isolation, timeout=timeout, budget=budget,
+                )
+            # Enforcement wind-down (STEP 0): the scout path injects submit_findings
+            # and the structural commit brake. OFF (the default) routes to the
+            # unchanged ``_run_agent``, so every existing caller is byte-for-byte
+            # identical — the new path is reachable only when explicitly requested.
+            if enforcement_strength != ENFORCEMENT_OFF:
+                return await self._run_enforced_agent(
                     prompt,
                     label=label,
                     tools=tools,
@@ -461,11 +409,25 @@ class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
                     thinking=thinking,
                     timeout=timeout,
                     budget=budget,
+                    enforcement_strength=enforcement_strength,
+                    commit_reserve=commit_reserve,
+                    harvest_fallback=harvest_fallback,
                 )
-            finally:
-                self._active_budget_lease.reset(token)
-                slot_handed_to_cleanup = self._release_lease_when_quiescent(lease)
+            return await self._run_agent(
+                prompt,
+                label=label,
+                tools=tools,
+                isolation=isolation,
+                tool_choice=tool_choice,
+                thinking=thinking,
+                timeout=timeout,
+                budget=budget,
+            )
         finally:
+            if token is not None:
+                self._active_budget_lease.reset(token)
+            if lease is not None:
+                slot_handed_to_cleanup = self._release_lease_when_quiescent(lease)
             if slot_acquired and not slot_handed_to_cleanup:
                 self._semaphore.release()
             if call_task is not None:
@@ -719,17 +681,32 @@ class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
     async def parallel(self, thunks: Sequence[Thunk]) -> list[Any]:
         """Run thunks concurrently behind the shared semaphore.
 
-        A thunk that raises yields ``None`` in its slot; the gather always
-        completes. Result order matches input order.
+        A thunk that raises yields ``None`` in its slot, except a budget stop
+        which is re-raised after every started slot has settled. Result order
+        matches input order.
         """
 
         async def guard(thunk: Thunk) -> Any:
             try:
                 return await thunk()
+            except WorkflowBudgetExceeded:
+                raise
             except Exception:  # noqa: BLE001 — failures localize to one slot
                 return None
 
-        return list(await asyncio.gather(*(guard(t) for t in thunks)))
+        results = list(
+            await asyncio.gather(
+                *(guard(thunk) for thunk in thunks),
+                return_exceptions=True,
+            )
+        )
+        for result in results:
+            if isinstance(result, WorkflowBudgetExceeded):
+                raise result
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+        return results
 
     # -- pipeline ---------------------------------------------------------- #
 
@@ -739,7 +716,8 @@ class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
         There is NO barrier between stages: item A may be in stage 2 while item
         B is still in stage 1. A stage raising drops that item's result to
         ``None`` and skips its remaining stages; other items are unaffected.
-        Result order matches input order.
+        Result order matches input order. A budget stop is re-raised only after
+        every started item has settled.
         """
 
         async def flow(item: Any, idx: int) -> Any:
@@ -747,13 +725,25 @@ class WorkflowContext(WorkflowAgentsMixin, WorkflowStructuredMixin):
             for stage in stages:
                 try:
                     result = await stage(result, item, idx)
+                except WorkflowBudgetExceeded:
+                    raise
                 except Exception:  # noqa: BLE001 — drop this item, skip its rest
                     return None
             return result
 
-        return list(
-            await asyncio.gather(*(flow(item, i) for i, item in enumerate(items)))
+        results = list(
+            await asyncio.gather(
+                *(flow(item, i) for i, item in enumerate(items)),
+                return_exceptions=True,
+            )
         )
+        for result in results:
+            if isinstance(result, WorkflowBudgetExceeded):
+                raise result
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+        return results
 
     # -- observability ----------------------------------------------------- #
 

--- a/opencollab/application/workflow_agents.py
+++ b/opencollab/application/workflow_agents.py
@@ -108,15 +108,19 @@ class WorkflowAgentsMixin:
         # triggers ONE bounded transcript-only synthesizer call (submit_findings
         # only, forced, cite-or-abstain). With STEP 0's wind-down live this fires
         # seldom (scouts are force-committed at ~80%); it salvages the chopped /
-        # errored / strayed tail. Gated by construction: this method only runs when
-        # enforcement is on.
+        # errored / strayed tail. The original caller deadline still bounds the
+        # recovery. Gated by construction: this method only runs when enforcement
+        # is on.
         if (
             submit_tool.captured is None
             and ledger
             and not self._active_call_has_pending_cleanup()
         ):
             synthesized = await self._synthesize_dead_scout(
-                session, label, commit_reserve=commit_reserve
+                session,
+                label,
+                commit_reserve=commit_reserve,
+                caller_deadline=deadline,
             )
             if synthesized and synthesized.strip():
                 report = synthesized
@@ -124,7 +128,12 @@ class WorkflowAgentsMixin:
         return report if report else text
 
     async def _synthesize_dead_scout(
-        self, dead_session: Any, label: str | None, *, commit_reserve: int
+        self,
+        dead_session: Any,
+        label: str | None,
+        *,
+        commit_reserve: int,
+        caller_deadline: float | None,
     ) -> str | None:
         """Salvage a dead/empty scout with ONE bounded transcript-only LLM call.
 
@@ -135,7 +144,8 @@ class WorkflowAgentsMixin:
         findings (or a valid ``insufficient_evidence`` abstention) on a successful
         capture, else ``None`` so the caller keeps the harvested partial. Bounded by
         ``commit_reserve`` (the reserve sized for a single submit turn) and clamped
-        to the live global remaining.
+        to the live global remaining. A caller-supplied absolute deadline is
+        clamped with the internal commit cap, never replaced by it.
         """
         ledger = self._scout_ledger(dead_session)
         messages = self._session_messages(dead_session)
@@ -161,6 +171,8 @@ class WorkflowAgentsMixin:
         self._track_session(session)
         try:
             deadline = self._internal_commit_deadline()
+            if caller_deadline is not None:
+                deadline = min(deadline, caller_deadline)
             await self._run_session_turn(
                 session,
                 prompt,

--- a/opencollab/application/workflow_budget.py
+++ b/opencollab/application/workflow_budget.py
@@ -1,0 +1,52 @@
+"""Shared token-budget bookkeeping for deterministic workflows."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+
+class WorkflowBudget:
+    """Read-only view over token spend across all sessions created so far."""
+
+    def __init__(self, total: int | None, sessions: list[Any]) -> None:
+        self._total = total
+        self._sessions = sessions
+        self._leases: list[_BudgetLease] = []
+
+    @property
+    def total(self) -> int | None:
+        return self._total
+
+    def spent(self) -> int:
+        return sum(int(getattr(s, "used_tokens", 0)) for s in self._sessions)
+
+    def remaining(self) -> float:
+        if self._total is None:
+            return float("inf")
+        reserved_unspent = sum(lease.remaining() for lease in self._leases)
+        return self._total - self.spent() - reserved_unspent
+
+    def reserve(self, lease: _BudgetLease) -> None:
+        self._leases.append(lease)
+
+    def release(self, lease: _BudgetLease) -> None:
+        try:
+            self._leases.remove(lease)
+        except ValueError:
+            pass
+
+
+@dataclass
+class _BudgetLease:
+    """A per-call token allocation held while one workflow agent is active."""
+
+    total: int
+    reserved: int
+    sessions: list[Any]
+    pending_tasks: list[asyncio.Task[Any]] | None = None
+
+    def remaining(self) -> int:
+        spent = sum(max(0, int(getattr(s, "used_tokens", 0))) for s in self.sessions)
+        return max(0, self.total - spent)

--- a/opencollab/bootstrap/_workflow_runtime_discovery.py
+++ b/opencollab/bootstrap/_workflow_runtime_discovery.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import importlib.abc
+import importlib.machinery
+import importlib.util
 import os
 import stat
-import types
+import sys
+import threading
 import uuid
+from functools import wraps
+from types import ModuleType
 
 from opencollab.adapters.safe_files import read_regular_text
 from opencollab.application.workflow_registry import Registry, WorkflowSpec
@@ -14,6 +20,165 @@ from opencollab.bootstrap._workflow_runtime_state import (
     MAX_WORKFLOW_FILES,
     MAX_WORKFLOW_SOURCE_BYTES,
 )
+
+_WORKFLOW_IMPORT_STATE_LOCK = threading.RLock()
+
+
+class _WorkflowSourceLoader(importlib.abc.Loader):
+    """Execute the already bounded source through an importlib module spec."""
+
+    def __init__(self, path: str, source: str) -> None:
+        self._path = path
+        self._source = source
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> None:
+        return None
+
+    def exec_module(self, module: ModuleType) -> None:
+        exec(compile(self._source, self._path, "exec"), module.__dict__)
+
+
+class _WorkflowImportFinder(importlib.abc.MetaPathFinder):
+    """Resolve local workflow imports through the bounded source loader."""
+
+    def __init__(self) -> None:
+        self._package_roots: dict[str, str] = {}
+
+    def register(self, package_name: str, directory: str) -> None:
+        with _WORKFLOW_IMPORT_STATE_LOCK:
+            self._package_roots[package_name] = directory
+            if self not in sys.meta_path:
+                sys.meta_path.insert(0, self)
+
+    def unregister(self, package_name: str) -> None:
+        with _WORKFLOW_IMPORT_STATE_LOCK:
+            self._package_roots.pop(package_name, None)
+            if not self._package_roots:
+                try:
+                    sys.meta_path.remove(self)
+                except ValueError:
+                    pass
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        del path, target
+        package_name, separator, relative_name = fullname.partition(".")
+        with _WORKFLOW_IMPORT_STATE_LOCK:
+            directory = self._package_roots.get(package_name)
+        if directory is None or not separator:
+            return None
+        parts = relative_name.split(".")
+        if not parts or any(not part.isidentifier() for part in parts):
+            return None
+
+        module_path = os.path.join(directory, *parts) + ".py"
+        package_path = os.path.join(directory, *parts, "__init__.py")
+        for candidate, is_package in ((package_path, True), (module_path, False)):
+            if not os.path.lexists(candidate):
+                continue
+            source = read_regular_text(candidate, max_bytes=MAX_WORKFLOW_SOURCE_BYTES)
+            loader = _WorkflowSourceLoader(candidate, source)
+            spec = importlib.util.spec_from_loader(
+                fullname,
+                loader,
+                origin=candidate,
+                is_package=is_package,
+            )
+            if spec is None:
+                raise ImportError(f"could not create import spec for workflow source: {candidate}")
+            if is_package:
+                spec.submodule_search_locations = []
+            return spec
+        package_directory = os.path.join(directory, *parts)
+        if os.path.lexists(package_directory):
+            current = directory
+            for part in parts:
+                current = os.path.join(current, part)
+                inspected = os.lstat(current)
+                if not stat.S_ISDIR(inspected.st_mode):
+                    raise ValueError(f"workflow package is not a real directory: {current}")
+            spec = importlib.machinery.ModuleSpec(
+                fullname,
+                loader=None,
+                is_package=True,
+            )
+            spec.submodule_search_locations = []
+            return spec
+        return None
+
+
+_WORKFLOW_IMPORT_FINDER = _WorkflowImportFinder()
+
+
+def _remove_workflow_package(package_name: str) -> None:
+    with _WORKFLOW_IMPORT_STATE_LOCK:
+        prefix = f"{package_name}."
+        for registered_name in tuple(sys.modules):
+            if registered_name == package_name or registered_name.startswith(prefix):
+                sys.modules.pop(registered_name, None)
+        _WORKFLOW_IMPORT_FINDER.unregister(package_name)
+
+
+class _WorkflowModuleOwner:
+    """Keep workflow modules alive while exposing them only during execution."""
+
+    def __init__(self, package_name: str, directory: str) -> None:
+        self.package_name = package_name
+        self.directory = directory
+        self._modules: dict[str, ModuleType] = {}
+        self._active_calls = 0
+        self._lock = threading.Lock()
+
+    def capture_modules(self) -> None:
+        prefix = f"{self.package_name}."
+        with _WORKFLOW_IMPORT_STATE_LOCK:
+            modules = sys.modules.copy()
+        self._modules = {
+            name: module
+            for name, module in modules.items()
+            if isinstance(module, ModuleType)
+            and (name == self.package_name or name.startswith(prefix))
+        }
+
+    def acquire(self) -> None:
+        with self._lock:
+            if self._active_calls == 0:
+                with _WORKFLOW_IMPORT_STATE_LOCK:
+                    _WORKFLOW_IMPORT_FINDER.register(self.package_name, self.directory)
+                    sys.modules.update(self._modules)
+            self._active_calls += 1
+
+    def release(self) -> None:
+        with self._lock:
+            self._active_calls -= 1
+            if self._active_calls == 0:
+                self.capture_modules()
+                _remove_workflow_package(self.package_name)
+
+
+def _bind_runtime_package(spec: WorkflowSpec, owner: _WorkflowModuleOwner) -> WorkflowSpec:
+    original = spec.fn
+
+    @wraps(original)
+    async def run(ctx, args):
+        owner.acquire()
+        try:
+            return await original(ctx, args)
+        finally:
+            owner.release()
+
+    bound = WorkflowSpec(
+        name=spec.name,
+        description=spec.description,
+        fn=run,
+        phases=spec.phases,
+    )
+    run.__workflow_spec__ = bound  # type: ignore[attr-defined]
+    return bound
 
 
 def discover_workflows(directory: str) -> Registry:
@@ -57,26 +222,71 @@ def discover_workflows(directory: str) -> Registry:
     return registry
 
 
-def load_workflow_specs(path: str) -> list[WorkflowSpec]:
-    """Import a single python file and collect its workflow specs."""
-    module_name = f"_opencollab_workflow_{uuid.uuid4().hex}"
+def _load_workflow_specs(path: str) -> list[WorkflowSpec]:
+    """Import one workflow file and bind its package to returned specs."""
     source = read_regular_text(path, max_bytes=MAX_WORKFLOW_SOURCE_BYTES)
-    module = types.ModuleType(module_name)
-    module.__file__ = path
-    exec(compile(source, path, "exec"), module.__dict__)
+    package_name = f"_opencollab_workflow_{uuid.uuid4().hex}"
+    module_name = f"{package_name}.workflow"
+    package_spec = importlib.machinery.ModuleSpec(
+        package_name,
+        loader=None,
+        is_package=True,
+    )
+    package_spec.submodule_search_locations = []
+    package = importlib.util.module_from_spec(package_spec)
+    loader = _WorkflowSourceLoader(path, source)
+    module_spec = importlib.util.spec_from_loader(
+        module_name,
+        loader,
+        origin=path,
+    )
+    if module_spec is None:
+        raise ImportError(f"could not create import spec for workflow source: {path}")
+    module = importlib.util.module_from_spec(module_spec)
 
-    # Dedupe by spec identity: a decorated function bound under more than one
-    # module-level name (an alias or a re-export) carries the SAME spec object
-    # under each name. Collecting both would register the same name twice and
-    # abort discovery of the whole directory, so keep one entry per spec.
-    found: list[WorkflowSpec] = []
-    seen: set[int] = set()
-    for value in vars(module).values():
-        wf_spec = getattr(value, "__workflow_spec__", None)
-        if isinstance(wf_spec, WorkflowSpec) and id(wf_spec) not in seen:
-            seen.add(id(wf_spec))
-            found.append(wf_spec)
-    return found
+    with _WORKFLOW_IMPORT_STATE_LOCK:
+        _WORKFLOW_IMPORT_FINDER.register(
+            package_name,
+            os.path.dirname(os.path.abspath(path)),
+        )
+        sys.modules[package_name] = package
+        sys.modules[module_name] = module
+    try:
+        loader.exec_module(module)
+
+        # Dedupe by spec identity: a decorated function bound under more than one
+        # module-level name (an alias or a re-export) carries the SAME spec object
+        # under each name. Collecting both would register the same name twice and
+        # abort discovery of the whole directory, so keep one entry per spec.
+        found: list[WorkflowSpec] = []
+        seen: set[int] = set()
+        for value in vars(module).values():
+            wf_spec = getattr(value, "__workflow_spec__", None)
+            if isinstance(wf_spec, WorkflowSpec) and id(wf_spec) not in seen:
+                seen.add(id(wf_spec))
+                found.append(wf_spec)
+    except BaseException:
+        _remove_workflow_package(package_name)
+        raise
+    owner = _WorkflowModuleOwner(
+        package_name,
+        os.path.dirname(os.path.abspath(path)),
+    )
+    owner.capture_modules()
+    bound = [_bind_runtime_package(spec, owner) for spec in found]
+    _remove_workflow_package(package_name)
+    return bound
+
+
+def load_workflow_specs(path: str) -> list[WorkflowSpec]:
+    """Import one bounded workflow file and collect its workflow specs.
+
+    Each workflow gets a unique execution-scoped package. This keeps normal
+    import metadata available while the workflow defines dataclasses or imports
+    sibling modules without retaining global import registrations between runs.
+    Every local source uses the same bounded, regular-file-only loader.
+    """
+    return _load_workflow_specs(path)
 
 
 _load_specs_from_file = load_workflow_specs

--- a/opencollab/bootstrap/_workflow_runtime_session.py
+++ b/opencollab/bootstrap/_workflow_runtime_session.py
@@ -36,9 +36,8 @@ class WorkflowSessionFactory:
 
     Each ``build_workflow_session`` call assembles a fresh one-shot ``Agent``
     (carrying the resolved LLM config) and a self-wiring ``Session``. ``tools``
-    from the caller become the agent's toolset; ``isolation`` is accepted for
-    forward-compatibility (a future worktree-backed environment) but currently
-    runs in a local environment.
+    from the caller become the agent's toolset. ``isolation=True`` is rejected
+    until this factory can provide a distinct worktree-backed environment.
     """
 
     def __init__(
@@ -114,6 +113,8 @@ class WorkflowSessionFactory:
         tool_choice: str | None = None,
         thinking: bool | None = None,
     ) -> Any:
+        if isolation:
+            raise ValueError("workflow agent isolation is not available")
         use_thinking = self._thinking if thinking is None else thinking
         capabilities = model_capabilities(self._model)
         if self._thinking and not capabilities.honors_workflow_thinking_override:
@@ -133,7 +134,13 @@ class WorkflowSessionFactory:
             thinking_params=self._thinking_params,
             tool_choice=tool_choice,
         )
-        env = self._env or (LocalEnvironment(self._workspace) if self._workspace else LocalEnvironment())
+        env = self._env
+        if env is None:
+            env = (
+                LocalEnvironment(self._workspace)
+                if self._workspace
+                else LocalEnvironment()
+            )
         return build_session(
             agent=agent,
             env=env,
@@ -196,7 +203,9 @@ def build_workflow_context(
     budget_total = budget if budget is not None else cfg.get("budget")
     # Working-tree probe over the same workspace the sessions edit, so the
     # workflow can verify a real edit landed before declaring success.
-    probe_env = environment or (LocalEnvironment(workspace) if workspace else LocalEnvironment())
+    probe_env = environment
+    if probe_env is None:
+        probe_env = LocalEnvironment(workspace) if workspace else LocalEnvironment()
     return WorkflowContext(
         factory,
         event_sink=event_sink,

--- a/opencollab/bootstrap/agent_runtime.py
+++ b/opencollab/bootstrap/agent_runtime.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from opencollab.application.async_timeout import (
     await_owned_operation,
+    cancel_tasks_and_wait,
     consume_task_result,
     force_task_terminal,
 )
@@ -89,6 +90,23 @@ async def _wait_session_tasks(session: Any, timeout: float) -> bool:
     if pending:
         _done, pending = await asyncio.wait(pending, timeout=timeout)
     return not pending and not session.pending_cleanup_tasks
+
+
+async def _terminate_session_tasks(session: Any, timeout: float) -> bool:
+    """Cancel overdue session owners and wait one bounded phase for quiescence."""
+    pending = {
+        task
+        for task in session.pending_cleanup_tasks
+        if not task.done() and task is not asyncio.current_task()
+    }
+    if pending:
+        pending = await await_owned_operation(
+            cancel_tasks_and_wait(pending, timeout=timeout),
+            propagate_cancellation=True,
+        )
+    return not pending and not any(
+        not task.done() for task in session.pending_cleanup_tasks
+    )
 
 
 async def _finalize_session(
@@ -174,26 +192,70 @@ async def run_agent(
         llm_timeout=llm_timeout_seconds,
     )
     owner = asyncio.create_task(_run_session(session, prompt))
-    finalization_attempted = False
-    finalization_result = False
+    finalization_task: asyncio.Task[bool] | None = None
+    finalization_succeeded = False
+    finalization_attempts = 0
+    max_finalization_attempts = 2
     stop_task: asyncio.Task[tuple[bool, bool, bool]] | None = None
 
-    async def finalize_once() -> bool:
-        nonlocal finalization_attempted, finalization_result
-        if not finalization_attempted:
-            finalization_attempted = True
-            finalization_result = await _finalize_session(
-                session,
-                environment,
-                timeout=cleanup_timeout_seconds,
-                cleanup_environment=cleanup_environment,
+    def record_finalization_result(task: asyncio.Task[bool]) -> bool:
+        nonlocal finalization_task, finalization_succeeded
+        try:
+            succeeded = task.result()
+        except BaseException:
+            succeeded = False
+        if succeeded:
+            finalization_succeeded = True
+        elif finalization_task is task:
+            finalization_task = None
+        return succeeded
+
+    async def finalize_attempt() -> bool:
+        nonlocal finalization_task, finalization_attempts
+        if finalization_succeeded:
+            return True
+        if finalization_task is None:
+            if finalization_attempts >= max_finalization_attempts:
+                return False
+            finalization_attempts += 1
+            finalization_task = asyncio.create_task(
+                _finalize_session(
+                    session,
+                    environment,
+                    timeout=cleanup_timeout_seconds,
+                    cleanup_environment=cleanup_environment,
+                )
             )
-        return finalization_result
+        task = finalization_task
+        try:
+            await await_owned_operation(task, propagate_cancellation=True)
+        except asyncio.CancelledError:
+            if task.done():
+                record_finalization_result(task)
+            raise
+        except BaseException:
+            if task.done():
+                record_finalization_result(task)
+            return False
+        return record_finalization_result(task)
+
+    async def finalize_with_retry() -> bool:
+        while not finalization_succeeded:
+            if (
+                finalization_task is None
+                and finalization_attempts >= max_finalization_attempts
+            ):
+                break
+            if await finalize_attempt():
+                return True
+            await _terminate_session_tasks(session, cleanup_timeout_seconds)
+        await _terminate_session_tasks(session, cleanup_timeout_seconds)
+        return False
 
     async def stop_owned() -> tuple[bool, bool, bool]:
         aborted = await revoke_and_abort_environment(environment, cleanup_timeout_seconds)
         terminal = await force_task_terminal(owner, timeout=cleanup_timeout_seconds)
-        finalized = await finalize_once()
+        finalized = await finalize_with_retry()
         return aborted, terminal, finalized
 
     async def stop_once(*, propagate_cancellation: bool) -> tuple[bool, bool, bool]:
@@ -226,9 +288,11 @@ async def run_agent(
         try:
             output = owner.result()
         except Exception as exc:
-            finalized = await finalize_once()
+            finalized = await finalize_with_retry()
             if not finalized:
-                raise AgentRuntimeLifecycleError("failed agent cleanup or persistence did not quiesce") from exc
+                raise AgentRuntimeLifecycleError(
+                    "failed agent cleanup or persistence did not quiesce"
+                ) from exc
             return _result(
                 session,
                 output=None,
@@ -237,7 +301,7 @@ async def run_agent(
                 cleanup_quiesced=True,
                 cleanup_environment=cleanup_environment,
             )
-        finalized = await finalize_once()
+        finalized = await finalize_with_retry()
         if not finalized:
             raise AgentRuntimeLifecycleError("agent cleanup or persistence did not quiesce")
         return _result(
@@ -252,11 +316,10 @@ async def run_agent(
         await stop_once(propagate_cancellation=False)
         raise
     except Exception:
-        if not finalization_attempted:
-            if not owner.done():
-                await stop_once(propagate_cancellation=False)
-            else:
-                await finalize_once()
+        if not owner.done():
+            await stop_once(propagate_cancellation=False)
+        elif not finalization_succeeded:
+            await finalize_with_retry()
         raise
 
 

--- a/opencollab/bootstrap/programmatic.py
+++ b/opencollab/bootstrap/programmatic.py
@@ -200,6 +200,16 @@ def _verify_artifact_claim(path: Path | None) -> None:
         )
 
 
+def _require_json_workflow_inputs(inputs: Mapping[str, Any]) -> None:
+    """Reject inputs that the workflow artifact manifest could not persist."""
+    try:
+        json.dumps(inputs)
+    except (TypeError, ValueError, OverflowError, RecursionError) as exc:
+        raise ValueError(
+            "workflow inputs must be JSON-serializable when artifacts are enabled"
+        ) from exc
+
+
 def _require_json_object(path: Path, description: str) -> dict[str, Any]:
     try:
         value = json.loads(read_regular_text(path, max_bytes=64 * 1024 * 1024))
@@ -308,7 +318,9 @@ async def run_agent(
     )
     _claim_artifacts(artifacts)
     owned_environment = environment is None
-    resolved_environment = environment or LocalEnvironment(workspace)
+    resolved_environment = (
+        environment if environment is not None else LocalEnvironment(workspace)
+    )
     transcript_path = None if artifacts is None else artifacts / "agent.json"
     tracer = None
     if artifacts is not None and trace:
@@ -426,9 +438,14 @@ async def run_workflow(
     environment: Any | None = None,
 ) -> ProgrammaticResult:
     """Run one workflow and return its live metrics directly."""
+    workflow_inputs = dict(inputs)
+    if artifacts is not None:
+        _require_json_workflow_inputs(workflow_inputs)
     _claim_artifacts(artifacts)
     owned_environment = environment is None
-    resolved_environment = environment or LocalEnvironment(workspace)
+    resolved_environment = (
+        environment if environment is not None else LocalEnvironment(workspace)
+    )
     workdir, source_root = _environment_paths(resolved_environment, workspace)
     deadline = (
         None
@@ -445,7 +462,7 @@ async def run_workflow(
         try:
             details = await _run_workflow(
                 workflow,
-                dict(inputs),
+                workflow_inputs,
                 cfg=dict(config),
                 workspace=workdir,
                 budget=max_tokens,

--- a/opencollab/domain/session.py
+++ b/opencollab/domain/session.py
@@ -59,9 +59,8 @@ TERMINAL_PHASES = frozenset(
 # cancel gates) and from CALLING_LLM (context overflow: the provider rejected the
 # prompt as too large even after a forced maximal compaction pass + one retry —
 # e.g. the pinned identity/team/task seed alone exceeds the window). Every STOPPED
-# is a *controlled* stop that delivers a clean result to the parent, never an
-# unhandled ERROR, so a child that overflows or exhausts its budget does not crash
-# the parent's turn.
+# is a controlled stop that delivers an explicit failed result to the parent,
+# allowing it to recover without treating unfinished work as successful.
 #
 # AWAITING_EVENTS is a non-terminal *suspend* state: the loop stops there (the
 # task returns) when a step deferred work (e.g. a spawned child) and the
@@ -242,6 +241,12 @@ class SessionState:
     def discard_pending_user_message(self, content: str) -> None:
         for index, message in enumerate(self.pending_user_messages):
             if message.get("content") == content:
+                del self.pending_user_messages[index]
+                return
+
+    def discard_pending_user_message_id(self, message_id: str) -> None:
+        for index, message in enumerate(self.pending_user_messages):
+            if message.get("message_id") == message_id:
                 del self.pending_user_messages[index]
                 return
 

--- a/opencollab/domain/token_estimation.py
+++ b/opencollab/domain/token_estimation.py
@@ -1,0 +1,92 @@
+"""Dependency-free estimates for structured provider request payloads."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimation: ~4 chars per token for English, ~2 for CJK."""
+    return max(1, len(text) // 3)
+
+
+_REQUEST_MESSAGE_FIELDS = frozenset({
+    "role", "content", "reasoning_content", "tool_calls", "tool_call_id", "name",
+})
+_REQUEST_UPPER_BOUND_MESSAGE_FIELDS = _REQUEST_MESSAGE_FIELDS | {"provider_state"}
+_MESSAGE_TOKEN_OVERHEAD = 4
+_TOOLS_TOKEN_OVERHEAD = 4
+_REQUEST_PROTOCOL_TOKEN_OVERHEAD = 16
+_MESSAGE_PROTOCOL_TOKEN_OVERHEAD = 64
+_TOOLS_PROTOCOL_TOKEN_OVERHEAD = 16
+_TOOL_PROTOCOL_TOKEN_OVERHEAD = 32
+
+
+def _serialize_payload(value: Any) -> str:
+    """Serialize a provider payload deterministically."""
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    )
+
+
+def _serialized_tokens(value: Any) -> int:
+    """Estimate a provider payload after deterministic JSON serialization."""
+    return estimate_tokens(_serialize_payload(value))
+
+
+def _serialized_token_upper_bound(value: Any) -> int:
+    """Bound byte-backed tokenization by charging one token per UTF-8 byte."""
+    return len(_serialize_payload(value).encode("utf-8"))
+
+
+def estimate_messages_tokens(
+    messages: list[dict], tools: list[dict] | None = None
+) -> int:
+    """Estimate OpenAI-compatible request tokens, including structured payloads.
+
+    Usage fallbacks and history compaction receive assistant tool calls, tool
+    response IDs, and thinking traces in addition to ordinary text. Estimate
+    the same protocol fields that the provider request normalizer transmits,
+    then include registered tool schemas when they are part of the request.
+    """
+    total = 0
+    for message in messages:
+        payload = {
+            key: ("" if key == "content" and value is None else value)
+            for key, value in message.items()
+            if key in _REQUEST_MESSAGE_FIELDS
+        }
+        total += _MESSAGE_TOKEN_OVERHEAD + _serialized_tokens(payload)
+    if tools:
+        total += _TOOLS_TOKEN_OVERHEAD + _serialized_tokens(tools)
+    return total
+
+
+def request_tokens_upper_bound(
+    messages: list[dict], tools: list[dict] | None = None
+) -> int:
+    """Return a conservative upper bound for provider request input tokens.
+
+    Every serialized UTF-8 byte is reserved as one token. Explicit request,
+    message, and tool framing allowances cover provider envelopes and
+    normalization tokens outside the serialized source payload. Provider state
+    is included because Anthropic replays its native content blocks directly.
+    """
+    total = _REQUEST_PROTOCOL_TOKEN_OVERHEAD
+    for message in messages:
+        payload = {
+            key: ("" if key == "content" and value is None else value)
+            for key, value in message.items()
+            if key in _REQUEST_UPPER_BOUND_MESSAGE_FIELDS
+        }
+        total += _MESSAGE_PROTOCOL_TOKEN_OVERHEAD + _serialized_token_upper_bound(
+            payload
+        )
+    if tools:
+        total += (
+            _TOOLS_PROTOCOL_TOKEN_OVERHEAD
+            + len(tools) * _TOOL_PROTOCOL_TOKEN_OVERHEAD
+            + _serialized_token_upper_bound(tools)
+        )
+    return total

--- a/opencollab/domain/tools.py
+++ b/opencollab/domain/tools.py
@@ -52,6 +52,10 @@ class ToolProcessingResult:
     # so the card here carries only the envelope facts. Additive to STEP 1 — a
     # caller that never populates it folds counters exactly as before.
     evidence_cards: list[dict[str, Any]] = field(default_factory=list)
+    # A successful structured capture is terminal for the current tool-call
+    # batch. The session runner uses this to reject later deferred calls while
+    # still emitting a result for every provider-issued tool call id.
+    terminal_capture_accepted: bool = False
 
     def apply_to(self, state: SessionState, max_window: int = MAX_CALL_HASH_WINDOW) -> None:
         for message in self.messages_to_append:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.30.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -19,6 +19,7 @@ class Environment:
         abort_fails: bool = False,
         revoke_fails: bool = False,
         block_abort: bool = False,
+        block_cleanup: bool = False,
     ) -> None:
         self.revoked = False
         self.abort_fails = abort_fails
@@ -28,6 +29,10 @@ class Environment:
         self.block_abort = block_abort
         self.abort_started = asyncio.Event()
         self.abort_release = asyncio.Event()
+        self.block_cleanup = block_cleanup
+        self.cleanup_started = asyncio.Event()
+        self.cleanup_release = asyncio.Event()
+        self.cleanup_done = asyncio.Event()
 
     def revoke(self) -> None:
         if self.revoke_fails:
@@ -45,6 +50,10 @@ class Environment:
 
     async def cleanup(self) -> None:
         self.cleanup_calls += 1
+        self.cleanup_started.set()
+        if self.block_cleanup:
+            await self.cleanup_release.wait()
+        self.cleanup_done.set()
 
 
 class Session:
@@ -238,6 +247,68 @@ async def test_agent_runtime_double_cancellation_finishes_abort_and_save(monkeyp
     assert session.save_calls == 1
 
 
+async def test_agent_runtime_cancellation_during_finalization_keeps_cleanup_owned(monkeypatch) -> None:
+    session = Session()
+    _patch_session(monkeypatch, session)
+    environment = Environment(block_cleanup=True)
+    owner = asyncio.create_task(
+        agent_runtime.run_agent(
+            agent=_agent(),
+            environment=environment,
+            prompt="run",
+            max_tokens=100,
+            max_steps=5,
+            timeout_seconds=None,
+            cleanup_timeout_seconds=0.1,
+            transcript_path=None,
+            cleanup_environment=True,
+        )
+    )
+
+    await environment.cleanup_started.wait()
+    owner.cancel()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
+    assert not owner.done()
+    assert not environment.abort_started.is_set()
+    environment.cleanup_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await owner
+    assert environment.cleanup_done.is_set()
+    assert environment.cleanup_calls == 1
+    assert session.save_calls == 1
+
+
+async def test_agent_runtime_retries_transient_finalization_failure(monkeypatch) -> None:
+    session = Session()
+    _patch_session(monkeypatch, session)
+    attempts = 0
+
+    async def flaky_finalize(*_args, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        return attempts > 1
+
+    monkeypatch.setattr(agent_runtime, "_finalize_session", flaky_finalize)
+
+    result = await agent_runtime.run_agent(
+        agent=_agent(),
+        environment=Environment(),
+        prompt="run",
+        max_tokens=100,
+        max_steps=5,
+        timeout_seconds=None,
+        cleanup_timeout_seconds=0.1,
+        transcript_path=None,
+        cleanup_environment=True,
+    )
+
+    assert result.outcome == "completed"
+    assert attempts == 2
+
+
 async def test_agent_runtime_rejects_missing_final_save_owner(monkeypatch) -> None:
     session = Session(auto_save_path="agent.json")
     original_enqueue = session.enqueue_auto_save
@@ -261,8 +332,8 @@ async def test_agent_runtime_rejects_missing_final_save_owner(monkeypatch) -> No
             transcript_path="agent.json",
             cleanup_environment=True,
         )
-    assert session.save_calls == 1
-    assert environment.cleanup_calls == 1
+    assert session.save_calls == 2
+    assert environment.cleanup_calls == 2
     assert original_enqueue is not None
 
 
@@ -284,5 +355,6 @@ async def test_agent_runtime_attempts_cleanup_after_pending_task_timeout(monkeyp
             transcript_path=None,
             cleanup_environment=True,
         )
-    assert environment.cleanup_calls == 1
-    assert session.save_calls == 1
+    assert environment.cleanup_calls == 2
+    assert session.save_calls == 2
+    assert pending.done()

--- a/tests/test_context_overflow_delivery.py
+++ b/tests/test_context_overflow_delivery.py
@@ -1,10 +1,10 @@
-"""A context-overflowed CHILD delivers a controlled result to its parent.
+"""A context-overflowed CHILD delivers an explicit failure to its parent.
 
 The third leg of the safety net: when a spawned child's prompt overflows the
 model window even after forced compaction, the child must reach the graceful
-CONTEXT_OVERFLOW terminal and deliver a clean (DONE) result to its parent's
-pending row — re-activating the parent — rather than crashing the parent's turn
-with an unhandled exception. This exercises the real Scheduler lifecycle
+CONTEXT_OVERFLOW terminal and deliver a failed result to its parent's pending
+row — re-activating the parent — rather than crashing the parent's turn with an
+unhandled exception. This exercises the real Scheduler lifecycle
 (_drive_agent / _deliver_to_parent / _wake) with a real child SessionRunUseCase.
 """
 
@@ -206,8 +206,8 @@ def test_overflowed_child_delivers_controlled_result_not_crash():
     # The child tried the provider exactly twice (initial + one forced retry).
     assert len(child.llm.calls) == 2
 
-    # The child's completion was delivered to the parent's row as a controlled
-    # DONE result (ERROR would have made it a FAILED row).
+    # The child's controlled STOPPED outcome is an explicit failed tool result,
+    # while the parent can still recover and complete its own turn.
     child_scb = scheduler.table.get(child.state.aid)
     assert child_scb.state.phase is SessionPhase.STOPPED
 
@@ -218,10 +218,8 @@ def test_overflowed_child_delivers_controlled_result_not_crash():
     assert len(tool_results) == 1
 
 
-def test_delivery_status_of_overflowed_child_is_done_not_failed():
-    # Directly assert the lifecycle's status mapping: a CONTEXT_OVERFLOW child is
-    # delivered DONE (only an ERROR phase maps to FAILED). Verifies the row the
-    # parent ends up with carries a non-failure status.
+def test_delivery_status_of_overflowed_child_is_failed_with_terminal_reason():
+    # A STOPPED child must never be presented as a successful tool result.
     factory = OverflowChildFactory()
     scheduler = Scheduler(
         session_factory=factory,
@@ -255,15 +253,10 @@ def test_delivery_status_of_overflowed_child_is_done_not_failed():
 
     run(scheduler.run("delegate"))
 
-    # The spawn tool's result delivered to the lead carries the child's run-loop
-    # output (empty/controlled), and the lead's turn completed cleanly. The row
-    # status surfaced as DONE — verified via the filled tool message actually
-    # flowing into the lead's history rather than an error string.
+    # The spawn tool's failed result lets the lead continue, but preserves the
+    # terminal reason instead of masquerading as a successful child output.
     assert factory.child.state.phase is SessionPhase.STOPPED
     assert lead_state.phase is SessionPhase.DONE
-    # The delivered tool message exists and is not an "Error:" string (which is
-    # how a FAILED/ERROR child would have been surfaced).
     tool_msg = next(m for m in lead_state.messages if m.get("role") == "tool" and m.get("tool_call_id") == "c1")
-    assert not str(tool_msg.get("content", "")).startswith("Error:")
-    # Sanity: RowStatus exists and DONE is the success status used in delivery.
-    assert RowStatus.DONE is not RowStatus.FAILED
+    assert tool_msg["content"].startswith("Error: agent stopped: context overflow:")
+    assert RowStatus.FAILED is not RowStatus.DONE

--- a/tests/test_file_tool_contract.py
+++ b/tests/test_file_tool_contract.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 
 import pytest
-from tool_runtime_test_support import FakeRemoteEnv, SpyLock, run
+from tool_runtime_test_support import FakeRemoteEnv, FalseyFakeEnv, SpyLock, run
 
 from opencollab.adapters.env import LocalEnvironment
 from opencollab.adapters.safety import SandboxInterceptor
@@ -86,6 +86,15 @@ def test_file_read_requires_environment():
     result = run(FileReadTool().execute_with_runtime({"path": "missing.txt"}, runtime))
 
     assert result == "Error: no execution environment available."
+
+
+def test_file_read_accepts_falsey_environment():
+    env = FalseyFakeEnv()
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(FileReadTool().execute_with_runtime({"path": "note.txt"}, runtime))
+
+    assert "contents" in result
 
 
 def test_file_read_preserves_file_not_found(tmp_path):

--- a/tests/test_inter_agent_messaging.py
+++ b/tests/test_inter_agent_messaging.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
+import xml.etree.ElementTree as ET
 
 import pytest
 
 from opencollab.adapters.worktree_pool import WorktreePool
+from opencollab.application._scheduler_constants import (
+    MAX_TEAMMATE_DELIVERY_BYTES,
+    MAX_TEAMMATE_INBOX_BYTES,
+    MAX_TEAMMATE_INBOX_MESSAGES,
+    MAX_TEAMMATE_MESSAGE_BYTES,
+)
 from opencollab.application.event_bus import EventBus
 from opencollab.application.scheduler import Scheduler
 from opencollab.domain.events import SchedulerEvent
@@ -93,6 +101,16 @@ def _build_scheduler(teammate, topology=None, roles=()):
 
 def _scheduler_events(events):
     return [e for e in events if isinstance(e, SchedulerEvent)]
+
+
+def _assert_teammate_envelope(delivery, *, sender, summary, content):
+    root = ET.fromstring(delivery)
+    assert root.tag == "teammate-message"
+    assert root.attrib["teammate_id"] == sender
+    assert root.attrib["summary"] == summary
+    assert len(root.attrib["message_id"]) == 32
+    assert root.text == f"\n{content}\n"
+    return root
 
 
 def _register_child(scheduler, session, *, aid: int = 1) -> None:
@@ -188,10 +206,11 @@ def test_send_message_queues_xml_and_returns_ack():
     aid, ack = run(scenario())
 
     assert ack == f"Message queued to aid {aid}."
-    assert teammate.added[-1] == (
-        '<teammate-message teammate_id="A0" summary="follow up">\n'
-        "check &lt;this&gt; &amp; report\n"
-        "</teammate-message>"
+    _assert_teammate_envelope(
+        teammate.added[-1],
+        sender="A0",
+        summary="follow up",
+        content="check <this> & report",
     )
     assert scheduler.table.get(aid).result == "message result"
 
@@ -315,11 +334,13 @@ def test_send_message_to_busy_target_autosaves_pending_xml(tmp_path):
     with open(path) as f:
         saved = json.load(f)
     assert saved["messages"] == []
-    assert saved["pending_messages"][0]["content"] == (
-        '<teammate-message teammate_id="A0" summary="follow up">\n'
-        "check &lt;this&gt; &amp; report\n"
-        "</teammate-message>"
+    root = _assert_teammate_envelope(
+        saved["pending_messages"][0]["content"],
+        sender="A0",
+        summary="follow up",
+        content="check <this> & report",
     )
+    assert saved["pending_messages"][0]["message_id"] == root.attrib["message_id"]
 
 
 def test_delivery_final_autosave_commits_message_and_removes_pending_sidecar(tmp_path):
@@ -365,6 +386,48 @@ def test_delivery_final_autosave_commits_message_and_removes_pending_sidecar(tmp
     assert delivery_snapshots
     assert "pending_messages" not in delivery_snapshots[-1]
     assert teammate.state.pending_user_messages == []
+
+
+def test_shutdown_after_append_dequeues_and_restore_skips_committed_message():
+    class ShutdownAfterAppend(RespondingFakeSession):
+        def __init__(self):
+            super().__init__(["must not run"], role="coder")
+            self.scheduler = None
+            self.stale_pending: list[dict] = []
+
+        async def add_user_message(self, content):
+            await super().add_user_message(content)
+            self.stale_pending = copy.deepcopy(self.state.pending_user_messages)
+            self.scheduler._shutting_down = True
+
+    teammate = ShutdownAfterAppend()
+    scheduler, _ = _build_scheduler(teammate)
+    teammate.scheduler = scheduler
+    teammate.state.set_phase(SessionPhase.DONE)
+    _register_child(scheduler, teammate)
+
+    async def scenario():
+        assert "queued" in await scheduler.send_message(0, 1, "once", "do this once")
+
+    run(scenario())
+
+    assert len(teammate.state.messages) == 1
+    assert teammate.state.pending_user_messages == []
+    assert scheduler._message_inbox.get(1) == []
+    assert teammate.stale_pending
+
+    resumed = RespondingFakeSession(["must not run"], role="coder")
+    resumed.state.messages = copy.deepcopy(teammate.state.messages)
+    resumed.state.pending_user_messages = teammate.stale_pending
+    resumed.state.set_phase(SessionPhase.DONE)
+    resumed_scheduler, _ = _build_scheduler(resumed)
+    _register_child(resumed_scheduler, resumed)
+
+    resumed_scheduler._restore_message_inbox(1, resumed.state)
+
+    assert resumed.state.pending_user_messages == []
+    assert resumed_scheduler._message_inbox.get(1) in (None, [])
+    assert resumed.added == []
 
 
 def test_add_user_message_failure_rolls_back_partial_state_and_restores_budget():
@@ -485,6 +548,88 @@ def test_multiple_queued_messages_are_delivered_as_one_timestamped_user_turn():
         event for event in _scheduler_events(events) if event.type == "agent_message_delivered"
     ]
     assert len(delivered) == 2
+
+
+def test_busy_target_applies_count_backpressure_before_persisting_message():
+    teammate = FakeSession([], role="coder")
+    scheduler, _ = _build_scheduler(teammate)
+    teammate.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    _register_child(scheduler, teammate)
+
+    async def scenario():
+        acknowledgements = [
+            await scheduler.send_message(0, 1, f"message-{index}", "small")
+            for index in range(MAX_TEAMMATE_INBOX_MESSAGES + 1)
+        ]
+        return acknowledgements
+
+    acknowledgements = run(scenario())
+
+    assert all("queued" in ack for ack in acknowledgements[:-1])
+    assert "backpressure" in acknowledgements[-1]
+    assert len(scheduler._message_inbox[1]) == MAX_TEAMMATE_INBOX_MESSAGES
+    assert len(teammate.state.pending_user_messages) == MAX_TEAMMATE_INBOX_MESSAGES
+
+
+def test_busy_target_applies_byte_backpressure_and_rejects_oversized_message():
+    teammate = FakeSession([], role="coder")
+    scheduler, _ = _build_scheduler(teammate)
+    teammate.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    _register_child(scheduler, teammate)
+    large_body = "x" * (MAX_TEAMMATE_MESSAGE_BYTES - 256)
+
+    async def scenario():
+        responses = []
+        for index in range(MAX_TEAMMATE_INBOX_MESSAGES):
+            response = await scheduler.send_message(0, 1, f"large-{index}", large_body)
+            responses.append(response)
+            if "backpressure" in response:
+                break
+        oversized = await scheduler.send_message(
+            0,
+            1,
+            "oversized",
+            "x" * MAX_TEAMMATE_MESSAGE_BYTES,
+        )
+        return responses, oversized
+
+    responses, oversized = run(scenario())
+
+    assert "backpressure" in responses[-1]
+    assert "byte limit" in oversized
+    assert sum(len(message.xml.encode("utf-8")) for message in scheduler._message_inbox[1]) <= (
+        MAX_TEAMMATE_INBOX_BYTES
+    )
+    assert len(teammate.state.pending_user_messages) == len(scheduler._message_inbox[1])
+
+
+def test_message_inbox_drains_fifo_batches_under_delivery_byte_limit():
+    teammate = FakeSession(["first batch", "second batch"], role="coder")
+    scheduler, _ = _build_scheduler(teammate)
+    teammate.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    _register_child(scheduler, teammate)
+    body = "x" * (MAX_TEAMMATE_DELIVERY_BYTES // 2 - 1024)
+
+    async def scenario():
+        for summary in ("first", "second", "third"):
+            assert "queued" in await scheduler.send_message(0, 1, summary, body)
+        teammate.state.set_phase(SessionPhase.DONE)
+        await scheduler._drain_message_inbox(1)
+        seen: set[asyncio.Task] = set()
+        while (task := scheduler._tasks.get(1)) is not None and task not in seen:
+            seen.add(task)
+            await task
+
+    run(scenario())
+
+    assert len(teammate.added) == 2
+    assert all(len(delivery.encode("utf-8")) <= MAX_TEAMMATE_DELIVERY_BYTES for delivery in teammate.added)
+    assert "summary=\"first\"" in teammate.added[0]
+    assert "summary=\"second\"" in teammate.added[0]
+    assert "summary=\"third\"" not in teammate.added[0]
+    assert "summary=\"third\"" in teammate.added[1]
+    assert teammate.state.pending_user_messages == []
+    assert scheduler._message_inbox.get(1) == []
 
 
 def test_send_message_to_self_is_rejected():

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -146,6 +146,38 @@ def test_openai_usage_zero_counts_fall_back_to_estimate():
     assert result.usage.estimated is True
 
 
+def test_openai_usage_estimate_includes_tool_call_structure_and_tool_schema():
+    """Usage fallbacks must charge serialized requests, not only prose content."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "r" * 3_000,
+            "tool_calls": [{
+                "id": "call_large_payload",
+                "type": "function",
+                "function": {"name": "search_records", "arguments": "x" * 12_000},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_large_payload", "content": ""},
+    ]
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "search_records",
+            "description": "d" * 6_000,
+            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+        },
+    }]
+    resp = _openai_resp(usage=None, content="ok")
+
+    result = parse_openai_response(resp, messages, tools)
+
+    assert result.usage.input_tokens == estimate_messages_tokens(messages, tools)
+    assert result.usage.input_tokens > 6_000
+    assert result.usage.input_tokens > estimate_messages_tokens(messages)
+
+
 def test_openai_normal_usage_unchanged_and_no_double_count():
     """A normal usage block is used verbatim; cached_tokens is NOT added on top.
 

--- a/tests/test_scheduler_awaiting.py
+++ b/tests/test_scheduler_awaiting.py
@@ -15,6 +15,7 @@ from scheduler_awaiting_test_support import (
     terminal,
 )
 
+from opencollab.application.scheduler import SchedulerTurnError
 from opencollab.domain.pending import PendingRow, PendingRowError, RowKind, RowStatus
 from opencollab.domain.scheduler import SessionControlBlock
 from opencollab.domain.session import SessionPhase
@@ -63,6 +64,42 @@ def test_multiple_parallel_children_resume_exactly_once():
     # The last child to finish triggers exactly one resume — no double-wake.
     assert len(event_types(events, "agent_resumed")) == 1
     assert lead.state.pending_events.is_empty()
+
+
+@pytest.mark.parametrize(
+    ("phase", "reason", "disposition"),
+    [
+        (SessionPhase.STOPPED, "budget exceeded", "stopped"),
+        (SessionPhase.ERROR, "provider failed", "failed"),
+    ],
+)
+def test_non_done_child_delivers_failed_result_and_event(phase, reason, disposition):
+    async def terminal_child(sess: ScriptedSession) -> str:
+        sess.state.set_phase(phase)
+        sess.state.terminal_reason = reason
+        return "partial child output"
+
+    async def resume_after_failed_child(sess: ScriptedSession) -> str:
+        row = sess.state.pending_events.rows["tc-1"]
+        assert row.status is RowStatus.FAILED
+        assert row.result == f"Error: agent {disposition}: {reason}"
+        assert row.error == row.result
+        sess.state.pending_events.clear()
+        sess.state.set_phase(SessionPhase.DONE)
+        sess.state.append_message({"role": "assistant", "content": "lead recovered"})
+        return "lead recovered"
+
+    lead = ScriptedSession(
+        "lead",
+        [suspend_spawning([("coder", "do it", "tc-1")]), resume_after_failed_child],
+    )
+    child = ScriptedSession("coder", [terminal_child])
+    scheduler, events = build_scheduler(lead, [child])
+
+    assert run(scheduler.run("please delegate")) == "lead recovered"
+    assert len(event_types(events, "agent_failed")) == 1
+    assert len(event_types(events, "agent_completed")) == 1  # lead only
+
 
 def test_last_child_completion_in_parent_return_tail_still_resumes():
     lead = ScriptedSession(
@@ -157,6 +194,25 @@ def test_spawn_with_review_waits_for_nested_coder_terminal_result():
     assert "final implementation from analysis" in result
     assert "delegating" not in result
 
+
+@pytest.mark.parametrize("phase", (SessionPhase.ERROR, SessionPhase.STOPPED))
+def test_spawn_with_review_rejects_noncompleted_coder_despite_reviewer_pass(phase):
+    async def incomplete_coder(session: ScriptedSession) -> str:
+        session.state.set_phase(phase)
+        return f"coder ended in {phase.value}"
+
+    lead = ScriptedSession("lead", [])
+    coder = ScriptedSession("coder", [incomplete_coder])
+    reviewer = ScriptedSession("reviewer", [terminal("VERDICT: PASS")])
+    scheduler, _ = build_scheduler(lead, [coder, reviewer])
+
+    result = run(scheduler.spawn_with_review(0, "implement safely", max_iterations=1))
+
+    assert result.startswith("[Self-Collaboration: FAILED")
+    assert f"Coder terminal phase: {phase.value}" in result
+    assert "PASSED" not in result
+    assert len(scheduler.table.entries) == 2
+
 def test_wake_unknown_tool_call_id_raises():
     lead = ScriptedSession("lead", [])
     scheduler, _ = build_scheduler(lead, [])
@@ -168,19 +224,130 @@ def test_wake_unknown_tool_call_id_raises():
     with pytest.raises(PendingRowError):
         run(scheduler._wake(0, "tc-unknown", "x", RowStatus.DONE))
 
-def test_misrouted_completion_emits_failure_not_silent():
-    lead = ScriptedSession("lead", [])
+def test_unknown_completion_route_fails_open_parent_batch_in_one_delivery():
+    async def resume_after_routing_failure(sess: ScriptedSession) -> str:
+        row = sess.state.pending_events.rows["unrelated"]
+        assert row.status is RowStatus.FAILED
+        assert row.result is not None
+        assert "routing failed" in row.result
+        assert row.result != "child result"
+        sess.state.pending_events.clear()
+        sess.state.set_phase(SessionPhase.DONE)
+        return "parent recovered"
+
+    lead = ScriptedSession("lead", [resume_after_routing_failure])
     scheduler, events = build_scheduler(lead, [])
     lead.state.set_phase(SessionPhase.AWAITING_EVENTS)
     lead.state.pending_events.add(
-        PendingRow(tool_call_id="tc-1", kind=RowKind.CHILD_AGENT, order=0, ref=5)
+        PendingRow(tool_call_id="unrelated", kind=RowKind.CHILD_AGENT, order=0, ref=42)
     )
-    # Register a bogus origin pointing at a tool_call_id that doesn't exist.
     scheduler._spawn_origin[99] = (0, "tc-bogus")
 
-    run(scheduler._deliver_to_parent(99, "result", RowStatus.DONE))
+    async def scenario():
+        await scheduler._deliver_to_parent(99, "child result", RowStatus.DONE)
+        await scheduler._tasks[0]
+
+    run(scenario())
 
     assert len(event_types(events, "agent_failed")) == 1
+    assert scheduler._spawn_origin == {}
+    assert scheduler.table.get(0).result == "parent recovered"
+
+
+def test_misrouted_completion_retargets_the_unique_child_row():
+    lead = ScriptedSession("lead", [resume_done(lambda results: f"recovered: {results[0]}")])
+    scheduler, events = build_scheduler(lead, [])
+    lead.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    lead.state.pending_events.add(
+        PendingRow(tool_call_id="actual", kind=RowKind.CHILD_AGENT, order=0, ref=99)
+    )
+    scheduler._spawn_origin[99] = (0, "stale")
+
+    async def scenario():
+        await scheduler._deliver_to_parent(99, "result", RowStatus.DONE)
+        await scheduler._tasks[0]
+
+    run(scenario())
+
+    assert event_types(events, "agent_failed") == []
+    assert scheduler._spawn_origin == {}
+    assert scheduler.table.get(0).result == "recovered: result"
+
+
+def test_already_filled_claimed_row_retargets_unique_pending_child_row():
+    async def resume_after_retarget(sess: ScriptedSession) -> str:
+        already = sess.state.pending_events.rows["already-filled"]
+        assert already.status is RowStatus.DONE
+        assert already.result == "old result"
+        actual = sess.state.pending_events.rows["actual"]
+        assert actual.status is RowStatus.DONE
+        assert actual.result == "child result"
+        sess.state.pending_events.clear()
+        sess.state.set_phase(SessionPhase.DONE)
+        return "parent recovered"
+
+    lead = ScriptedSession("lead", [resume_after_retarget])
+    scheduler, events = build_scheduler(lead, [])
+    lead.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    lead.state.pending_events.add(
+        PendingRow(tool_call_id="already-filled", kind=RowKind.CHILD_AGENT, order=0, ref=7)
+    )
+    lead.state.pending_events.fill(
+        "already-filled",
+        result="old result",
+        status=RowStatus.DONE,
+    )
+    lead.state.pending_events.add(
+        PendingRow(tool_call_id="actual", kind=RowKind.CHILD_AGENT, order=1, ref=99)
+    )
+    scheduler._spawn_origin[99] = (0, "already-filled")
+
+    async def scenario():
+        await scheduler._deliver_to_parent(99, "child result", RowStatus.DONE)
+        await scheduler._tasks[0]
+
+    run(scenario())
+
+    assert event_types(events, "agent_failed") == []
+    assert scheduler._spawn_origin == {}
+    assert scheduler.table.get(0).result == "parent recovered"
+
+
+def test_ambiguous_completion_route_fails_open_parent_batch_in_one_delivery():
+    async def resume_after_routing_failure(sess: ScriptedSession) -> str:
+        for tool_call_id in ("duplicate-a", "duplicate-b", "unrelated"):
+            row = sess.state.pending_events.rows[tool_call_id]
+            assert row.status is RowStatus.FAILED
+            assert row.result is not None
+            assert "routing failed" in row.result
+            assert row.result != "child result"
+        sess.state.pending_events.clear()
+        sess.state.set_phase(SessionPhase.DONE)
+        return "parent recovered"
+
+    lead = ScriptedSession("lead", [resume_after_routing_failure])
+    scheduler, events = build_scheduler(lead, [])
+    lead.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    lead.state.pending_events.add(
+        PendingRow(tool_call_id="duplicate-a", kind=RowKind.CHILD_AGENT, order=0, ref=99)
+    )
+    lead.state.pending_events.add(
+        PendingRow(tool_call_id="duplicate-b", kind=RowKind.CHILD_AGENT, order=1, ref=99)
+    )
+    lead.state.pending_events.add(
+        PendingRow(tool_call_id="unrelated", kind=RowKind.CHILD_AGENT, order=2, ref=42)
+    )
+    scheduler._spawn_origin[99] = (0, "tc-bogus")
+
+    async def scenario():
+        await scheduler._deliver_to_parent(99, "child result", RowStatus.DONE)
+        await scheduler._tasks[0]
+
+    run(scenario())
+
+    assert len(event_types(events, "agent_failed")) == 1
+    assert scheduler._spawn_origin == {}
+    assert scheduler.table.get(0).result == "parent recovered"
 
 def test_send_message_queues_when_target_awaiting_events():
     lead = ScriptedSession("lead", [])
@@ -234,11 +401,11 @@ def test_queued_message_delivers_after_target_awaiting_events_resumes():
 
     run(scenario())
 
-    assert target.added == [
-        '<teammate-message teammate_id="A0" summary="follow up">\n'
-        "are you there?\n"
-        "</teammate-message>"
-    ]
+    assert len(target.added) == 1
+    assert target.added[0].startswith(
+        '<teammate-message teammate_id="A0" summary="follow up" message_id="'
+    )
+    assert "are you there?\n</teammate-message>" in target.added[0]
     assert scheduler.table.get(1).result == "message handled"
 
 def test_child_message_to_suspended_parent_does_not_stall_turn():
@@ -268,11 +435,10 @@ def test_child_message_to_suspended_parent_does_not_stall_turn():
 
     assert result == "progress message handled"
     assert scheduler._message_inbox.get(0) == []
-    assert lead.added[-1] == (
-        '<teammate-message teammate_id="A1" summary="progress">\n'
-        "analysis started\n"
-        "</teammate-message>"
+    assert lead.added[-1].startswith(
+        '<teammate-message teammate_id="A1" summary="progress" message_id="'
     )
+    assert "analysis started\n</teammate-message>" in lead.added[-1]
     assert len(event_types(events, "agent_message_sent")) == 1
     assert len(event_types(events, "agent_message_delivered")) == 1
 
@@ -297,19 +463,60 @@ def test_scheduler_run_retrieves_finished_task_exception(caplog):
     assert finished.result_called is True
     assert "background task for aid 99 failed" in caplog.text
 
-def test_scheduler_run_does_not_return_previous_turn_answer():
+
+@pytest.mark.parametrize(
+    ("existing_reason", "expected_reason"),
+    [
+        ("ProviderFailure: retry budget exhausted", "ProviderFailure: retry budget exhausted"),
+        (None, "ProviderFailure: upstream 429"),
+    ],
+)
+def test_scheduler_run_preserves_session_failure_reason_after_exception(
+    existing_reason, expected_reason
+):
+    class ProviderFailure(RuntimeError):
+        pass
+
+    async def fail_with_provider_reason(sess: ScriptedSession) -> str:
+        if existing_reason is not None:
+            sess.state.fail(existing_reason)
+        raise ProviderFailure("upstream 429")
+
+    lead = ScriptedSession("lead", [fail_with_provider_reason])
+    scheduler, _ = build_scheduler(lead, [])
+
+    with pytest.raises(SchedulerTurnError, match=expected_reason) as caught:
+        run(asyncio.wait_for(scheduler.run("new question"), timeout=0.5))
+    assert caught.value.phase is SessionPhase.ERROR
+    assert caught.value.terminal_reason == expected_reason
+
+
+@pytest.mark.parametrize(
+    ("phase", "reason"),
+    [
+        (SessionPhase.STOPPED, "step limit reached"),
+        (SessionPhase.ERROR, "provider failed"),
+    ],
+)
+def test_scheduler_run_does_not_return_partial_answer_on_terminal_failure(phase, reason):
     async def precheck_stop(sess: ScriptedSession) -> str:
-        sess.state.set_phase(SessionPhase.STOPPED)
+        sess.state.set_phase(phase)
+        sess.state.terminal_reason = reason
         sess.state.append_message(
             {"role": "system", "content": "[Step limit reached. Session stopped.]"}
         )
-        return ""
+        sess.state.append_message({"role": "assistant", "content": "partial answer"})
+        return "partial answer"
 
     lead = ScriptedSession("lead", [precheck_stop])
     lead.state.append_message({"role": "assistant", "content": "previous answer"})
     scheduler, _ = build_scheduler(lead, [])
 
-    assert run(asyncio.wait_for(scheduler.run("new question"), timeout=0.5)) == ""
+    with pytest.raises(SchedulerTurnError, match=f"{phase.value}: {reason}") as caught:
+        run(asyncio.wait_for(scheduler.run("new question"), timeout=0.5))
+    assert caught.value.aid == 0
+    assert caught.value.phase is phase
+    assert caught.value.partial_answer == "partial answer"
 
 def test_concurrent_scheduler_runs_are_serialized_on_the_lead_session():
     first_started = asyncio.Event()

--- a/tests/test_scheduler_awaiting_cleanup_races.py
+++ b/tests/test_scheduler_awaiting_cleanup_races.py
@@ -13,6 +13,7 @@ from scheduler_awaiting_test_support import (
 )
 
 from opencollab.domain.pending import PendingRow, RowKind, RowStatus
+from opencollab.domain.scheduler import SessionControlBlock
 from opencollab.domain.session import SessionPhase, SessionState
 
 
@@ -126,6 +127,100 @@ def test_cleanup_is_bounded_when_worktree_release_ignores_cancellation():
 
     run(scenario())
 
+
+def test_cleanup_does_not_release_pool_while_session_owned_task_survives():
+    class ResistantCleanupSession(ScriptedSession):
+        def __init__(self):
+            super().__init__("lead", [])
+            self._owned_tasks: set[asyncio.Task] = set()
+
+        @property
+        def pending_cleanup_tasks(self):
+            return tuple(task for task in self._owned_tasks if not task.done())
+
+    class RecordingPool:
+        def __init__(self):
+            self.release_calls = 0
+
+        async def acquire(self, role):
+            return None
+
+        async def release(self):
+            self.release_calls += 1
+
+    lead = ResistantCleanupSession()
+    scheduler, _ = build_scheduler(lead, [])
+    pool = RecordingPool()
+    scheduler._worktree_pool = pool
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+
+    async def session_owned_task():
+        started.set()
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+
+    async def scenario():
+        owner = asyncio.create_task(session_owned_task())
+        lead._owned_tasks.add(owner)
+        await started.wait()
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match="technical scheduler cleanup failed: session-owned tasks did not quiesce",
+            ):
+                await scheduler.cleanup(cleanup_timeout=0.01)
+            assert cancelled.is_set()
+            assert pool.release_calls == 0
+        finally:
+            release.set()
+            await asyncio.wait_for(owner, timeout=0.5)
+
+    run(scenario())
+
+
+@pytest.mark.parametrize("target_aid", [0, 1, 2])
+def test_cleanup_finalizes_the_actual_active_public_turn_owner(target_aid):
+    started = asyncio.Event()
+
+    async def blocked_turn(sess: ScriptedSession) -> str:
+        started.set()
+        await asyncio.Event().wait()
+
+    lead = ScriptedSession("lead", [blocked_turn] if target_aid == 0 else [])
+    scheduler, _ = build_scheduler(lead, [])
+    if target_aid:
+        target = ScriptedSession("coder", [blocked_turn])
+        target.state.aid = target_aid
+        target.scheduler = scheduler
+        scheduler.table.add(
+            SessionControlBlock(
+                aid=target_aid,
+                parent_aid=0,
+                agent=target.agent,
+                state=target.state,
+            )
+        )
+        scheduler._sessions[target_aid] = target
+
+    async def scenario():
+        turn = asyncio.create_task(scheduler.run_turn(target_aid, "block"))
+        await started.wait()
+        await scheduler.cleanup(cleanup_timeout=0.01)
+        with pytest.raises(asyncio.CancelledError):
+            await turn
+
+    run(scenario())
+
+    assert scheduler.table.get(target_aid).state.phase is SessionPhase.STOPPED
+    if target_aid:
+        assert lead.state.phase is SessionPhase.IDLE
+
+
 def test_cleanup_surfaces_synchronous_worktree_release_failure():
     error = OSError("pool release failed")
 
@@ -149,6 +244,77 @@ def test_cleanup_surfaces_synchronous_worktree_release_failure():
         assert "worktree pool" in str(caught.value)
 
     run(scenario())
+
+
+def test_cleanup_retries_transient_failure_then_caches_success():
+    class FlakyReleasePool:
+        def __init__(self):
+            self.release_calls = 0
+
+        async def acquire(self, role):
+            return None
+
+        def release(self):
+            self.release_calls += 1
+            if self.release_calls == 1:
+                raise OSError("transient release failure")
+
+    lead = ScriptedSession("lead", [])
+    scheduler, _ = build_scheduler(lead, [])
+    pool = FlakyReleasePool()
+    scheduler._worktree_pool = pool
+
+    async def scenario():
+        with pytest.raises(
+            RuntimeError,
+            match="technical scheduler cleanup failed: worktree pool release failed or timed out",
+        ):
+            await scheduler.cleanup(cleanup_timeout=0.01)
+
+        await scheduler.cleanup(cleanup_timeout=0.01)
+        await scheduler.cleanup(cleanup_timeout=0.01)
+
+        assert pool.release_calls == 2
+
+    run(scenario())
+
+
+def test_concurrent_cleanup_callers_share_the_inflight_attempt():
+    class GatedReleasePool:
+        def __init__(self):
+            self.release_calls = 0
+            self.started = asyncio.Event()
+            self.release_gate = asyncio.Event()
+
+        async def acquire(self, role):
+            return None
+
+        async def release_pool(self):
+            self.release_calls += 1
+            self.started.set()
+            await self.release_gate.wait()
+
+        def release(self):
+            return self.release_pool()
+
+    lead = ScriptedSession("lead", [])
+    scheduler, _ = build_scheduler(lead, [])
+    pool = GatedReleasePool()
+    scheduler._worktree_pool = pool
+
+    async def scenario():
+        first = asyncio.create_task(scheduler.cleanup(cleanup_timeout=0.2))
+        await pool.started.wait()
+        second = asyncio.create_task(scheduler.cleanup(cleanup_timeout=0.2))
+        await asyncio.sleep(0)
+
+        assert pool.release_calls == 1
+        pool.release_gate.set()
+        await asyncio.gather(first, second)
+        assert pool.release_calls == 1
+
+    run(scenario())
+
 
 def test_cleanup_surfaces_environment_abort_failure():
     class FailingAbortEnv:

--- a/tests/test_scheduler_awaiting_cleanup_validation.py
+++ b/tests/test_scheduler_awaiting_cleanup_validation.py
@@ -9,8 +9,10 @@ from scheduler_awaiting_test_support import (
     ScriptedSession,
     build_scheduler,
     run,
+    terminal,
 )
 
+from opencollab.application.scheduler import SchedulerStalledError
 from opencollab.domain.session import SessionPhase, SessionState
 
 
@@ -62,6 +64,52 @@ def test_cleanup_rejects_invalid_timeout_before_any_side_effect(invalid_timeout)
 
         release.set()
         await asyncio.wait_for(driver, timeout=0.5)
+
+    run(scenario())
+
+
+def test_wait_until_terminal_fails_without_active_producer():
+    lead = ScriptedSession("lead", [])
+    scheduler, _ = build_scheduler(lead, [])
+
+    with pytest.raises(SchedulerStalledError, match="aid 0"):
+        run(scheduler.wait_until_terminal(0))
+
+
+def test_active_startup_prevents_quiescence_until_child_finishes():
+    class BlockingAcquirePool:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def acquire(self, role):
+            self.started.set()
+            await self.release.wait()
+            return None
+
+        async def release(self):
+            return None
+
+    lead = ScriptedSession("lead", [terminal("lead done")])
+    child = ScriptedSession("coder", [terminal("child done")])
+    scheduler, _ = build_scheduler(lead, [child])
+    pool = BlockingAcquirePool()
+    scheduler._worktree_pool = pool
+
+    async def scenario():
+        startup = asyncio.create_task(scheduler.spawn(0, "coder", "blocked startup"))
+        await pool.started.wait()
+        assert scheduler._quiescent() is False
+
+        turn = asyncio.create_task(scheduler.run("finish the lead turn"))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert turn.done() is False
+
+        pool.release.set()
+        aid = await startup
+        assert await asyncio.wait_for(turn, timeout=0.5) == "lead done"
+        assert scheduler.table.get(aid).state.phase is SessionPhase.DONE
 
     run(scenario())
 

--- a/tests/test_sdk_runtime.py
+++ b/tests/test_sdk_runtime.py
@@ -316,6 +316,35 @@ async def test_workflow_uses_real_runtime_and_returns_live_metrics(
     assert manifest["evidence_complete"] is True
 
 
+async def test_workflow_rejects_non_json_inputs_before_claiming_artifacts(
+    tmp_path: Path,
+) -> None:
+    invoked = False
+
+    async def plain(_ctx, _inputs):
+        nonlocal invoked
+        invoked = True
+        return "completed before the old late manifest failure"
+
+    inputs = {"path": Path("not-json-serializable")}
+    result = await OpenCollab(tmp_path).workflow(plain, inputs, trace=False)
+    assert result.output == "completed before the old late manifest failure"
+    assert invoked is True
+
+    invoked = False
+    artifacts = tmp_path / "workflow-run"
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        await OpenCollab(tmp_path).workflow(
+            plain,
+            inputs,
+            artifacts=artifacts,
+            trace=False,
+        )
+
+    assert invoked is False
+    assert not artifacts.exists()
+
+
 async def test_workflow_execution_failure_is_a_result(tmp_path: Path) -> None:
     @workflow
     async def broken(_ctx, _inputs):

--- a/tests/test_session_run_loop.py
+++ b/tests/test_session_run_loop.py
@@ -19,12 +19,35 @@ from session_run_loop_test_support import (
     tool_call,
 )
 
+from opencollab.application.steering import build_steering_block
 from opencollab.domain.session import (
     SessionPhase,
     SessionState,
     TurnEnforcementState,
 )
+from opencollab.domain.token_estimation import (
+    estimate_messages_tokens,
+    request_tokens_upper_bound,
+)
 from opencollab.domain.tools import ToolProcessingResult
+
+
+def _first_call_messages(messages):
+    steering, _override, _level = build_steering_block(
+        used_tokens=0,
+        max_budget_tokens=500,
+        step_count=1,
+        max_steps=100,
+        reads=0,
+        has_write=False,
+        has_structured_output=False,
+        structured_override=None,
+    )
+    return [*messages, steering]
+
+
+def _reserved_first_call_input(messages):
+    return request_tokens_upper_bound(_first_call_messages(messages))
 
 
 @pytest.mark.parametrize(
@@ -52,6 +75,215 @@ def test_run_loop_budget_exceeded_emits_error_and_sets_phase():
         "content": "[Budget exceeded: 10 tokens used. Session stopped.]",
     }
     assert events == [("error", {"reason": "budget exceeded: 10 tokens used", "aid": -1})]
+
+
+def test_remaining_budget_caps_next_model_output_request():
+    messages = [{"role": "system", "content": "sys"}]
+    input_tokens = _reserved_first_call_input(messages)
+    state = SessionState(
+        messages=messages,
+        used_tokens=500 - input_tokens - 1,
+    )
+    llm = FakeLLM([
+        llm_response(
+            content="done",
+            input_tokens=input_tokens,
+            output_tokens=1,
+            total_tokens=input_tokens + 1,
+        )
+    ])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        max_budget_tokens=500,
+    )
+
+    assert run(runner.run_loop()) == "done"
+    assert llm.calls[0]["max_output_tokens"] == 1
+    assert state.used_tokens == 500
+
+
+def test_input_reservation_exhausting_budget_stops_before_model_call():
+    events, bus = collect_events()
+    state = SessionState(
+        messages=[{"role": "system", "content": "sys"}],
+        used_tokens=9,
+    )
+    llm = FakeLLM([
+        llm_response(
+            content="should not run",
+            input_tokens=100,
+            output_tokens=1,
+            total_tokens=101,
+        )
+    ])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        event_bus=bus,
+        max_budget_tokens=10,
+    )
+
+    assert run(runner.run_loop()) == ""
+    assert llm.calls == []
+    assert state.used_tokens == 9
+    assert state.step_count == 0
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason.startswith("budget exhausted before model call")
+    assert [event_type for event_type, _data in events] == ["error"]
+
+
+def test_conservative_input_reservation_blocks_estimator_overshoot():
+    messages = [{"role": "system", "content": "\u754c" * 3}]
+    provider_messages = _first_call_messages(messages)
+    ordinary_estimate = estimate_messages_tokens(provider_messages)
+    upper_bound = request_tokens_upper_bound(provider_messages)
+    reported_input_tokens = 143
+    assert ordinary_estimate == 43
+    assert ordinary_estimate + 1 < reported_input_tokens <= upper_bound
+
+    state = SessionState(
+        messages=messages,
+        used_tokens=456,
+    )
+    llm = FakeLLM([
+        llm_response(
+            content="should not run",
+            input_tokens=reported_input_tokens,
+            output_tokens=1,
+            total_tokens=reported_input_tokens + 1,
+        )
+    ])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        max_budget_tokens=500,
+    )
+
+    assert run(runner.run_loop()) == ""
+    assert llm.calls == []
+    assert state.used_tokens == 456
+    assert state.step_count == 0
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason.startswith("budget exhausted before model call")
+
+
+def test_anthropic_provider_state_is_reserved_before_model_call():
+    base_messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": ""},
+    ]
+    messages = [
+        base_messages[0],
+        {
+            **base_messages[1],
+            "provider_state": {
+                "anthropic_content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "\u754c" * 256,
+                        "signature": "signed-state",
+                    }
+                ]
+            },
+        },
+    ]
+    baseline_bound = request_tokens_upper_bound(_first_call_messages(base_messages))
+    provider_state_bound = request_tokens_upper_bound(_first_call_messages(messages))
+    assert provider_state_bound > baseline_bound + 700
+
+    llm = FakeLLM([llm_response(content="should not run")])
+    state = SessionState(messages=messages)
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        max_budget_tokens=baseline_bound + 1,
+    )
+
+    assert run(runner.run_loop()) == ""
+    assert llm.calls == []
+    assert state.step_count == 0
+    assert state.phase is SessionPhase.STOPPED
+
+
+def test_actual_usage_overrun_is_traced_and_response_is_discarded():
+    events, bus = collect_events()
+    tracer = FakeTracer()
+    messages = [{"role": "system", "content": "sys"}]
+    reserved_input_tokens = _reserved_first_call_input(messages)
+    state = SessionState(
+        messages=messages,
+        used_tokens=500 - reserved_input_tokens - 1,
+    )
+    calls = [tool_call()]
+    llm = FakeLLM([
+        llm_response(
+            content="discard me",
+            tool_calls=calls,
+            input_tokens=reserved_input_tokens + 100,
+            output_tokens=1,
+            total_tokens=reserved_input_tokens + 101,
+            finish_reason="tool_calls",
+        )
+    ])
+    tool_execution = FakeToolExecution()
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        event_bus=bus,
+        tool_execution=tool_execution,
+        tracer=tracer,
+        max_budget_tokens=500,
+    )
+
+    assert run(runner.run_loop()) == ""
+    assert state.used_tokens == 600
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason == "budget exceeded after model call: 600 tokens used"
+    assert [message["role"] for message in state.messages] == ["system", "system"]
+    assert tool_execution.calls == []
+    assert [event_type for event_type, _data in events] == [
+        "step_start",
+        "error",
+        "step_end",
+    ]
+    assert len(tracer.steps) == 1
+    assert tracer.steps[0]["step_type"] == "llm_call"
+    assert tracer.steps[0]["tokens"] == reserved_input_tokens + 101
+    assert tracer.steps[0]["payload"]["usage"]["input_tokens"] == (
+        reserved_input_tokens + 100
+    )
+    assert tracer.steps[0]["latency"] >= 0
+
+
+def test_remaining_budget_caps_configured_per_step_output_limit():
+    agent = FakeAgent()
+    agent.max_tokens_per_step = 100
+    messages = [{"role": "system", "content": "sys"}]
+    input_tokens = _reserved_first_call_input(messages)
+    state = SessionState(
+        messages=messages,
+        used_tokens=500 - input_tokens - 7,
+    )
+    llm = FakeLLM([
+        llm_response(
+            content="done",
+            input_tokens=input_tokens,
+            output_tokens=7,
+            total_tokens=input_tokens + 7,
+        )
+    ])
+    runner = build_runner(
+        state=state,
+        agent=agent,
+        llm=llm,
+        max_budget_tokens=500,
+    )
+
+    run(runner.run_loop())
+
+    assert llm.calls[0]["max_output_tokens"] == 7
+
 
 def test_run_loop_team_aggregate_ceiling_stops_under_own_cap():
     # Per-session cap is generous (1_000_000) and the session has spent nothing,

--- a/tests/test_session_run_loop_deferred.py
+++ b/tests/test_session_run_loop_deferred.py
@@ -126,6 +126,93 @@ def test_mixed_batch_buffers_immediate_and_resumes_in_order():
         {"role": "tool", "tool_call_id": "s1", "content": "child done"},
     ]
 
+
+def test_terminal_capture_before_deferred_spawn_rejects_spawn_and_keeps_history_complete():
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    batch = [
+        tool_call(call_id="terminal", name="structured_output", arguments='{"answer": "done"}'),
+        tool_call(call_id="spawn", name="spawn_agent", arguments="{}"),
+    ]
+    process_result = ToolProcessingResult(
+        messages_to_append=[
+            {
+                "role": "tool",
+                "tool_call_id": "terminal",
+                "content": "Recorded. Structured output accepted. Your task is complete.",
+            }
+        ]
+    )
+    process_result.terminal_capture_accepted = True
+    te = FakeToolExecutionDeferred(
+        process_result=process_result,
+        deferred_outcomes={"spawn": (9, None)},
+    )
+    runner = build_runner(state=state, tool_execution=te)
+    state.phase = SessionPhase.EXECUTING_TOOLS
+    runner._pending = PendingStep(
+        response=llm_response(content="mixed", tool_calls=batch, finish_reason="tool_calls"),
+        latency=0.0,
+    )
+
+    run(runner.execute_pending_tools())
+
+    assert te.process_calls == [[batch[0]]]
+    assert te.deferred_calls == []
+    assert state.phase is SessionPhase.AUTOSAVING
+    assert state.pending_events.is_empty()
+    assert state.messages[-2:] == [
+        {
+            "role": "tool",
+            "tool_call_id": "terminal",
+            "content": "Recorded. Structured output accepted. Your task is complete.",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "spawn",
+            "content": "Skipped: terminal structured output accepted earlier in this batch.",
+        },
+    ]
+
+
+def test_terminal_aware_mixed_batch_executes_preceding_spawn_before_capture():
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    batch = [
+        tool_call(call_id="spawn", name="spawn_agent", arguments="{}"),
+        tool_call(call_id="terminal", name="structured_output", arguments='{"answer": "done"}'),
+    ]
+    process_result = ToolProcessingResult(
+        messages_to_append=[
+            {
+                "role": "tool",
+                "tool_call_id": "terminal",
+                "content": "Recorded. Structured output accepted. Your task is complete.",
+            }
+        ]
+    )
+    process_result.terminal_capture_accepted = True
+
+    class OrderedTerminalCaptureToolExecution(FakeToolExecutionDeferred):
+        async def process(self, tool_calls):
+            assert self.deferred_calls == [batch[0]]
+            return await super().process(tool_calls)
+
+    te = OrderedTerminalCaptureToolExecution(
+        process_result=process_result,
+        deferred_outcomes={"spawn": (9, None)},
+    )
+    runner = build_runner(state=state, tool_execution=te)
+    state.phase = SessionPhase.EXECUTING_TOOLS
+    runner._pending = PendingStep(
+        response=llm_response(content="mixed", tool_calls=batch, finish_reason="tool_calls"),
+        latency=0.0,
+    )
+
+    run(runner.execute_pending_tools())
+
+    assert te.deferred_calls == [batch[0]]
+    assert te.process_calls == [[batch[1]]]
+    assert state.phase is SessionPhase.AWAITING_EVENTS
+
 def test_deferred_batch_with_blocked_tool_uses_original_order():
     state = SessionState(messages=[{"role": "system", "content": "sys"}])
     state.phase = SessionPhase.EXECUTING_TOOLS

--- a/tests/test_shaping.py
+++ b/tests/test_shaping.py
@@ -12,6 +12,7 @@ from opencollab.application.shaping import (
     PerToolResultBudgetShaper,
     ShaperPipeline,
 )
+from opencollab.application.shaping.pipeline import approx_messages_tokens
 
 
 def _tool_msg(content, tool_call_id="t1"):
@@ -146,6 +147,25 @@ def test_snip_noop_below_trigger_returns_input_identity():
     messages = [_sys(), _user(), _text("small"), _text("recent")]
     out = _snip().shape(messages)
     assert out is messages
+
+
+def test_fallback_estimator_compacts_large_tool_call_reasoning():
+    """The dependency-free estimator must trigger on request-side tool payloads."""
+    old_call = _call("large")
+    old_call["reasoning_content"] = "r" * 6_000
+    messages = [_sys(), _user(), old_call, _tool("large", "small result"), _text("recent")]
+    shaper = OldHistorySnipShaper(
+        estimate_tokens=approx_messages_tokens,
+        trigger_tokens=1_000,
+        target_tokens=500,
+        keep_recent_groups=1,
+    )
+
+    out = shaper.shape(messages)
+
+    assert approx_messages_tokens(messages) > shaper.trigger_tokens
+    assert not any(m.get("tool_calls") for m in out)
+    assert out[-1] == _text("recent")
 
 
 def test_snip_drops_old_tool_turns_when_over_trigger():

--- a/tests/test_spawn_dedup.py
+++ b/tests/test_spawn_dedup.py
@@ -1,11 +1,12 @@
 """Single-flight spawn dedup — the reliable, tool-level guard against the
-"won't stop" loop where a model re-spawns an identical task.
+"won't stop" loop where a model re-spawns an identical delegated task.
 
 Prompt-level "don't duplicate" is unreliable; the scheduler enforces it. While
-a (role, task) spawn is in flight, ``inflight_spawn`` reports the handling aid
-and ``SpawnAgentTool`` refuses to spawn again, returning a self-describing
-message instead of a second child. The reservation clears once the child
-reaches a terminal phase, so a legitimate later re-run is never blocked.
+a (parent, role, task, context) spawn is in flight, ``inflight_spawn`` reports
+the handling aid and ``SpawnAgentTool`` refuses to spawn again, returning a
+self-describing message instead of a second child. The reservation clears once
+the child reaches a terminal phase, so a legitimate later re-run is never
+blocked.
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ from opencollab.adapters.worktree_pool import WorktreePool
 from opencollab.application.event_bus import EventBus
 from opencollab.application.scheduler import Scheduler
 from opencollab.application.tool_execution import DeferredCall, ToolRuntime
+from opencollab.domain.scheduler import SessionControlBlock
 from opencollab.domain.session import SessionPhase, SessionState
 
 
@@ -47,17 +49,18 @@ class BlockingChild:
 
 
 class ChildFactory:
-    def __init__(self, child: BlockingChild):
-        self._child = child
+    def __init__(self, children: BlockingChild | list[BlockingChild]):
+        self._children = list(children) if isinstance(children, list) else [children]
 
     def build_spawn_session(
         self, *, role, env, budget, max_steps=50, aid=-1, scheduler=None, task=None, context=""
     ):
-        self._child.state.aid = aid
-        return self._child
+        child = self._children.pop(0)
+        child.state.aid = aid
+        return child
 
 
-def _scheduler(child: BlockingChild) -> Scheduler:
+def _scheduler(child: BlockingChild | list[BlockingChild]) -> Scheduler:
     scheduler = Scheduler(
         session_factory=ChildFactory(child),
         worktree_pool=WorktreePool(".", use_worktrees=False),
@@ -69,27 +72,28 @@ def _scheduler(child: BlockingChild) -> Scheduler:
     return scheduler
 
 
-def test_inflight_spawn_tracks_then_clears():
+def test_inflight_spawn_keeps_parent_context_and_task_whitespace_distinct():
     async def scenario():
         gate = asyncio.Event()
         child = BlockingChild("coder", "RESULT", gate)
         scheduler = _scheduler(child)
+        task = "fix:\n  return 1"
+        context = "module=a"
 
-        aid = await scheduler.spawn(0, "coder", "build it", tool_call_id="call-1")
+        aid = await scheduler.spawn(0, "coder", task, context, tool_call_id="call-1")
 
-        # In flight: the same (role, task) is reported as already handled.
-        assert scheduler.inflight_spawn("coder", "build it") == aid
-        # Whitespace-insensitive — re-prompting with reflowed text still collides.
-        assert scheduler.inflight_spawn("coder", "build   it") == aid
-        # A different task (or role) is not deduped.
-        assert scheduler.inflight_spawn("coder", "build something else") is None
-        assert scheduler.inflight_spawn("reviewer", "build it") is None
+        # Only the same parent's exact delegated input is single-flight.
+        assert scheduler.inflight_spawn("coder", task, parent_aid=0, context=context) == aid
+        assert scheduler.inflight_spawn("coder", task, parent_aid=1, context=context) is None
+        assert scheduler.inflight_spawn("coder", task, parent_aid=0, context="module=b") is None
+        assert scheduler.inflight_spawn("coder", "fix: return 1", parent_aid=0, context=context) is None
+        assert scheduler.inflight_spawn("reviewer", task, parent_aid=0, context=context) is None
 
         gate.set()
         await scheduler._tasks[aid]
 
         # Terminal completion releases the reservation.
-        assert scheduler.inflight_spawn("coder", "build it") is None
+        assert scheduler.inflight_spawn("coder", task, parent_aid=0, context=context) is None
 
     run(scenario())
 
@@ -106,7 +110,7 @@ def test_duplicate_spawn_tool_call_is_refused_while_in_flight():
             aid=0, tool_call_id="call-1",
         )
         deferred = await tool.execute_with_runtime(
-            {"role": "coder", "task": "build it"}, first_rt
+            {"role": "coder", "task": "build it", "context": "module=a"}, first_rt
         )
         assert isinstance(deferred, DeferredCall)
         aid = deferred.ref
@@ -117,7 +121,7 @@ def test_duplicate_spawn_tool_call_is_refused_while_in_flight():
             aid=0, tool_call_id="call-2",
         )
         msg = await tool.execute_with_runtime(
-            {"role": "coder", "task": "build it"}, dup_rt
+            {"role": "coder", "task": "build it", "context": "module=a"}, dup_rt
         )
         assert isinstance(msg, str)
         assert f"aid={aid}" in msg
@@ -127,6 +131,48 @@ def test_duplicate_spawn_tool_call_is_refused_while_in_flight():
 
         gate.set()
         await scheduler._tasks[aid]
+
+    run(scenario())
+
+
+def test_same_role_task_from_different_parent_is_not_deduped():
+    async def scenario():
+        gate = asyncio.Event()
+        scheduler = _scheduler(
+            [
+                BlockingChild("coder", "first", gate),
+                BlockingChild("coder", "second", gate),
+            ]
+        )
+        second_parent = BlockingChild("reviewer", "", asyncio.Event())
+        second_parent.state.aid = 2
+        second_parent.state.set_phase(SessionPhase.DONE)
+        scheduler.table.add(
+            SessionControlBlock(
+                aid=2,
+                parent_aid=0,
+                agent=second_parent.agent,
+                state=second_parent.state,
+            )
+        )
+        scheduler._sessions[2] = second_parent
+        tool = SpawnAgentTool(scheduler)
+
+        first = await tool.execute_with_runtime(
+            {"role": "coder", "task": "inspect repository", "context": "module=a"},
+            ToolRuntime(None, None, None, aid=0, tool_call_id="call-1"),
+        )
+        second = await tool.execute_with_runtime(
+            {"role": "coder", "task": "inspect repository", "context": "module=a"},
+            ToolRuntime(None, None, None, aid=2, tool_call_id="call-2"),
+        )
+
+        assert isinstance(first, DeferredCall)
+        assert isinstance(second, DeferredCall)
+        assert first.ref != second.ref
+
+        gate.set()
+        await asyncio.gather(*scheduler._tasks.values())
 
     run(scenario())
 

--- a/tests/test_team_decomposition.py
+++ b/tests/test_team_decomposition.py
@@ -32,7 +32,7 @@ class FakeScheduler:
         self.spawn_calls.append((parent_aid, role, task, context, tool_call_id))
         return 42  # return a fake aid
 
-    def inflight_spawn(self, role, task):
+    def inflight_spawn(self, role, task, *, parent_aid=0, context=""):
         return None  # never deduped in this fake
 
     async def spawn_with_review(self, parent_aid, task, context="", max_iterations=3):

--- a/tests/test_team_event_emission.py
+++ b/tests/test_team_event_emission.py
@@ -22,7 +22,7 @@ from opencollab.application.session_run import GenerationTimeoutError
 from opencollab.bootstrap.session_factory import build_session
 from opencollab.domain.agent import Agent
 from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
-from opencollab.domain.scheduler import ReviewVerdict, SessionControlBlock
+from opencollab.domain.scheduler import ReviewVerdict
 from opencollab.domain.session import SessionPhase, SessionState
 
 
@@ -95,6 +95,7 @@ class _FakeSessionFactory:
         self._queues = {role: list(results) for role, results in role_results.items()}
         self.built: list[tuple[str, int]] = []
         self.built_tasks: list[tuple[str, str]] = []
+        self.built_contexts: list[tuple[str, str]] = []
 
     def build_lead_session(self, **kwargs):
         return _FakeLeadSession()
@@ -102,6 +103,7 @@ class _FakeSessionFactory:
     def build_spawn_session(self, *, role, env, budget, max_steps=50, aid=-1, scheduler=None, task=None, context=""):
         self.built.append((role, budget))
         self.built_tasks.append((role, task or ""))
+        self.built_contexts.append((role, context))
         queue = self._queues.get(role, [])
         result = queue.pop(0) if queue else ""
         return _FakeTeammateSession(result, role=role)
@@ -126,138 +128,6 @@ def _build_scheduler(monkeypatch, role_results: dict[str, list[str]]) -> tuple[S
 
 def _scheduler_events(events: list[Any]) -> list[SchedulerEvent]:
     return [e for e in events if isinstance(e, SchedulerEvent)]
-
-
-def test_spawn_emits_agent_spawned_then_completed(monkeypatch):
-    scheduler, events = _build_scheduler(monkeypatch, {"coder": ["coder did it"]})
-
-    run(_spawn_and_settle(scheduler, 0, "coder", "do the thing"))
-
-    seq = _scheduler_events(events)
-    types = [e.type for e in seq]
-    assert "agent_spawned" in types
-    assert "agent_completed" in types
-
-    spawned = [e for e in seq if e.type == "agent_spawned"][0]
-    assert spawned.data["role"] == "coder"
-    assert spawned.data["task"] == "do the thing"
-
-    completed = [e for e in seq if e.type == "agent_completed"][0]
-    assert completed.data["role"] == "coder"
-    assert "latency" in completed.data
-    assert isinstance(completed.data["latency"], float)
-
-
-def test_spawn_autosaves_parent_tool_call(monkeypatch, tmp_path):
-    scheduler, _ = _build_scheduler(monkeypatch, {"analyst": ["done"]})
-    lead = scheduler.lead_session
-    lead.auto_save_path = str(tmp_path / "agent_0_lead.json")
-    lead.state.append_message({"role": "user", "content": "fix it"})
-    lead.state.append_message(
-        {
-            "role": "assistant",
-            "tool_calls": [
-                {
-                    "id": "call-1",
-                    "type": "function",
-                    "function": {
-                        "name": "spawn_agent",
-                        "arguments": '{"role": "analyst", "task": "investigate"}',
-                    },
-                }
-            ],
-        }
-    )
-
-    run(_spawn_and_settle(scheduler, 0, "analyst", "investigate"))
-
-    with open(lead.auto_save_path) as f:
-        saved = json.load(f)
-    assert saved["messages"][-1]["tool_calls"][0]["function"]["name"] == "spawn_agent"
-
-
-def test_spawn_lifecycle_slow_autosave_keeps_event_loop_responsive(tmp_path):
-    started = threading.Event()
-    release = threading.Event()
-    scheduler, _ = _build_scheduler(None, {"analyst": ["done"]})
-    lead = scheduler.lead_session
-    lead.auto_save_path = str(tmp_path / "lead.json")
-
-    def slow_save(path: str) -> None:
-        started.set()
-        assert release.wait(timeout=2.0)
-        _FakeLeadSession.save(lead, path)
-
-    lead.save = slow_save
-
-    async def scenario():
-        aid = await scheduler.spawn(0, "analyst", "investigate")
-        assert await asyncio.to_thread(started.wait, 1.0)
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.Event().wait(), timeout=0.02)
-        owners = scheduler._fallback_autosavers[0].pending_tasks
-        assert owners
-        release.set()
-        await asyncio.gather(*owners, return_exceptions=True)
-        await scheduler._tasks[aid]
-        await scheduler.cleanup()
-
-    run(scenario())
-
-
-def test_message_queue_slow_autosave_keeps_event_loop_responsive(tmp_path):
-    started = threading.Event()
-    release = threading.Event()
-    scheduler, _ = _build_scheduler(None, {})
-    target = _FakeTeammateSession("unused", role="coder")
-    target.state.aid = 1
-    target.state.set_phase(SessionPhase.AWAITING_EVENTS)
-    target.auto_save_path = str(tmp_path / "target.json")
-
-    def slow_save(path: str) -> None:
-        started.set()
-        assert release.wait(timeout=2.0)
-        with open(path, "w", encoding="utf-8") as handle:
-            json.dump({"messages": target.state.enriched_messages()}, handle)
-
-    target.save = slow_save
-    scheduler.table.add(
-        SessionControlBlock(
-            aid=1,
-            parent_aid=0,
-            agent=target.agent,
-            state=target.state,
-        )
-    )
-    scheduler._sessions[1] = target
-
-    async def scenario():
-        result = await scheduler.send_message(0, 1, "question", "are you there?")
-        assert result == "Message queued to aid 1."
-        assert await asyncio.to_thread(started.wait, 1.0)
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.Event().wait(), timeout=0.02)
-        owners = scheduler._fallback_autosavers[1].pending_tasks
-        assert owners
-        release.set()
-        await asyncio.gather(*owners, return_exceptions=True)
-        target.auto_save_path = None
-        await scheduler.cleanup()
-
-    run(scenario())
-
-
-def test_cleanup_autosaves_live_sessions(monkeypatch, tmp_path):
-    scheduler, _ = _build_scheduler(monkeypatch, {})
-    lead = scheduler.lead_session
-    lead.auto_save_path = str(tmp_path / "agent_0_lead.json")
-    lead.state.append_message({"role": "assistant", "content": "latest state"})
-
-    run(scheduler.cleanup())
-
-    with open(lead.auto_save_path) as f:
-        saved = json.load(f)
-    assert saved["messages"][-1]["content"] == "latest state"
 
 
 def test_cleanup_drains_queued_autosaves_before_final_snapshot(tmp_path):
@@ -705,6 +575,31 @@ def test_spawn_with_review_iterates_when_reviewer_fails(monkeypatch):
     second_coder_task = [task for role, task in factory.built_tasks if role == "coder"][1]
     assert "v1 impl" in second_coder_task
     assert "Reapply the previous implementation" in second_coder_task
+
+
+def test_spawn_with_review_passes_context_and_constraints_to_reviewer(monkeypatch):
+    scheduler, _ = _build_scheduler(
+        monkeypatch,
+        {"coder": ["implemented parser"], "reviewer": ["VERDICT: PASS"]},
+    )
+    context = 'Preserve comments.\nSupport "Python 3.10" syntax.'
+
+    result = run(
+        scheduler.spawn_with_review(
+            0,
+            "implement parser",
+            context=context,
+            max_iterations=1,
+        )
+    )
+
+    assert "PASSED after 1 iteration" in result
+    factory = scheduler._session_factory
+    assert factory.built_contexts == [("coder", context), ("reviewer", context)]
+    reviewer_task = [task for role, task in factory.built_tasks if role == "reviewer"][0]
+    assert "Original task:\nimplement parser" in reviewer_task
+    assert f"Required context:\n{context}" in reviewer_task
+    assert "Artifact to review:\nimplemented parser" in reviewer_task
 
 
 def test_review_verdict_uses_only_the_final_nonempty_line():

--- a/tests/test_team_spawn_events.py
+++ b/tests/test_team_spawn_events.py
@@ -1,0 +1,156 @@
+"""Scheduler spawn and live-session autosave event tests.
+
+The broader cleanup/review characterization remains in
+``test_team_event_emission``; this file owns the spawn lifecycle slice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+from test_team_event_emission import (
+    _build_scheduler,
+    _FakeLeadSession,
+    _FakeTeammateSession,
+    _scheduler_events,
+    _spawn_and_settle,
+    run,
+)
+
+from opencollab.domain.scheduler import SessionControlBlock
+from opencollab.domain.session import SessionPhase
+
+
+def test_spawn_emits_agent_spawned_then_completed(monkeypatch):
+    scheduler, events = _build_scheduler(monkeypatch, {"coder": ["coder did it"]})
+
+    run(_spawn_and_settle(scheduler, 0, "coder", "do the thing"))
+
+    seq = _scheduler_events(events)
+    types = [e.type for e in seq]
+    assert "agent_spawned" in types
+    assert "agent_completed" in types
+
+    spawned = [e for e in seq if e.type == "agent_spawned"][0]
+    assert spawned.data["role"] == "coder"
+    assert spawned.data["task"] == "do the thing"
+
+    completed = [e for e in seq if e.type == "agent_completed"][0]
+    assert completed.data["role"] == "coder"
+    assert "latency" in completed.data
+    assert isinstance(completed.data["latency"], float)
+
+
+def test_spawn_autosaves_parent_tool_call(monkeypatch, tmp_path):
+    scheduler, _ = _build_scheduler(monkeypatch, {"analyst": ["done"]})
+    lead = scheduler.lead_session
+    lead.auto_save_path = str(tmp_path / "agent_0_lead.json")
+    lead.state.append_message({"role": "user", "content": "fix it"})
+    lead.state.append_message(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "spawn_agent",
+                        "arguments": '{"role": "analyst", "task": "investigate"}',
+                    },
+                }
+            ],
+        }
+    )
+
+    run(_spawn_and_settle(scheduler, 0, "analyst", "investigate"))
+
+    with open(lead.auto_save_path) as f:
+        saved = json.load(f)
+    assert saved["messages"][-1]["tool_calls"][0]["function"]["name"] == "spawn_agent"
+
+
+def test_spawn_lifecycle_slow_autosave_keeps_event_loop_responsive(tmp_path):
+    started = threading.Event()
+    release = threading.Event()
+    scheduler, _ = _build_scheduler(None, {"analyst": ["done"]})
+    lead = scheduler.lead_session
+    lead.auto_save_path = str(tmp_path / "lead.json")
+
+    def slow_save(path: str) -> None:
+        started.set()
+        assert release.wait(timeout=2.0)
+        _FakeLeadSession.save(lead, path)
+
+    lead.save = slow_save
+
+    async def scenario():
+        aid = await scheduler.spawn(0, "analyst", "investigate")
+        assert await asyncio.to_thread(started.wait, 1.0)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.Event().wait(), timeout=0.02)
+        owners = scheduler._fallback_autosavers[0].pending_tasks
+        assert owners
+        release.set()
+        await asyncio.gather(*owners, return_exceptions=True)
+        await scheduler._tasks[aid]
+        await scheduler.cleanup()
+
+    run(scenario())
+
+
+def test_message_queue_slow_autosave_keeps_event_loop_responsive(tmp_path):
+    started = threading.Event()
+    release = threading.Event()
+    scheduler, _ = _build_scheduler(None, {})
+    target = _FakeTeammateSession("unused", role="coder")
+    target.state.aid = 1
+    target.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    target.auto_save_path = str(tmp_path / "target.json")
+
+    def slow_save(path: str) -> None:
+        started.set()
+        assert release.wait(timeout=2.0)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump({"messages": target.state.enriched_messages()}, handle)
+
+    target.save = slow_save
+    scheduler.table.add(
+        SessionControlBlock(
+            aid=1,
+            parent_aid=0,
+            agent=target.agent,
+            state=target.state,
+        )
+    )
+    scheduler._sessions[1] = target
+
+    async def scenario():
+        result = await scheduler.send_message(0, 1, "question", "are you there?")
+        assert result == "Message queued to aid 1."
+        assert await asyncio.to_thread(started.wait, 1.0)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.Event().wait(), timeout=0.02)
+        owners = scheduler._fallback_autosavers[1].pending_tasks
+        assert owners
+        release.set()
+        await asyncio.gather(*owners, return_exceptions=True)
+        target.auto_save_path = None
+        await scheduler.cleanup()
+
+    run(scenario())
+
+
+def test_cleanup_autosaves_live_sessions(monkeypatch, tmp_path):
+    scheduler, _ = _build_scheduler(monkeypatch, {})
+    lead = scheduler.lead_session
+    lead.auto_save_path = str(tmp_path / "agent_0_lead.json")
+    lead.state.append_message({"role": "assistant", "content": "latest state"})
+
+    run(scheduler.cleanup())
+
+    with open(lead.auto_save_path) as f:
+        saved = json.load(f)
+    assert saved["messages"][-1]["content"] == "latest state"

--- a/tests/test_tool_execution_timeout_cleanup.py
+++ b/tests/test_tool_execution_timeout_cleanup.py
@@ -1,0 +1,330 @@
+"""Bounded tool cancellation and late-write cleanup tests.
+
+These lifecycle tests are kept separate from the core tool-use-case contract so
+the contract module remains small and focused.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from test_tool_execution_use_case import (
+    FakeAgent,
+    RuntimeNativeTool,
+    build_use_case,
+)
+
+import opencollab.application.tool_execution_runtime as tool_execution_runtime
+from opencollab.adapters.env import Environment
+
+
+class RevocableEnvironment(Environment):
+    def __init__(self):
+        self._aborted = False
+        self.writes = []
+
+    async def exec_cmd(self, cmd: str, timeout: float = 120.0):
+        self._ensure_active()
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    async def read_file(self, path: str) -> str:
+        self._ensure_active()
+        return ""
+
+    async def write_file(self, path: str, content: str) -> None:
+        self._ensure_active()
+        self.writes.append((path, content))
+
+
+class StubbornLateWriteTool:
+    name = "stubborn_late_writer"
+    default_timeout = 0.005
+    disable_outer_timeout = False
+
+    def __init__(self):
+        self.started = asyncio.Event()
+        self.cancel_seen = asyncio.Event()
+        self.release = asyncio.Event()
+        self.write_blocked = asyncio.Event()
+
+    async def execute_with_runtime(self, args, runtime):
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancel_seen.set()
+            while not self.release.is_set():
+                try:
+                    await self.release.wait()
+                except asyncio.CancelledError:
+                    continue
+            try:
+                await runtime.environment.write_file("late.py", "late")
+            except RuntimeError:
+                self.write_blocked.set()
+            return "late completion"
+
+
+def _bounded_tool_use_case(tool, environment):
+    return build_use_case(
+        agent=FakeAgent(tools=[tool]),
+        environment=environment,
+        cancellation_cleanup_timeout=0.01,
+        cancellation_force_timeout=0.01,
+        environment_abort_timeout=0.01,
+    )[0]
+
+
+@pytest.mark.asyncio
+async def test_stubborn_timed_out_tool_cannot_write_after_execute_returns(monkeypatch):
+    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
+    environment = RevocableEnvironment()
+    tool = StubbornLateWriteTool()
+    use_case = _bounded_tool_use_case(tool, environment)
+
+    started = time.monotonic()
+    output, _latency = await use_case.execute_tool(tool, {})
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.2
+    assert "Tool cancellation cleanup failed" in output
+    assert "environment was revoked" in output
+    assert environment._aborted is True
+    pending = use_case.pending_cleanup_tasks
+    assert len(pending) == 1
+
+    tool.release.set()
+    await asyncio.gather(*pending)
+    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
+
+    assert tool.write_blocked.is_set()
+    assert environment.writes == []
+    assert use_case.pending_cleanup_tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_stubborn_environment_abort_is_bounded_and_exposed(monkeypatch):
+    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
+
+    class StubbornAbortEnvironment(RevocableEnvironment):
+        def __init__(self):
+            super().__init__()
+            self.abort_started = asyncio.Event()
+            self.abort_release = asyncio.Event()
+
+        async def abort(self) -> None:
+            self.abort_started.set()
+            while not self.abort_release.is_set():
+                try:
+                    await self.abort_release.wait()
+                except asyncio.CancelledError:
+                    continue
+
+    environment = StubbornAbortEnvironment()
+    tool = StubbornLateWriteTool()
+    use_case = _bounded_tool_use_case(tool, environment)
+
+    started = time.monotonic()
+    output, _latency = await use_case.execute_tool(tool, {})
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.2
+    assert environment.abort_started.is_set()
+    assert "environment abort did not quiesce within its bounded timeout" in output
+    pending = use_case.pending_cleanup_tasks
+    assert len(pending) == 2
+
+    tool.release.set()
+    environment.abort_release.set()
+    await asyncio.gather(*pending)
+    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
+
+    assert tool.write_blocked.is_set()
+    assert environment.writes == []
+    assert use_case.pending_cleanup_tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_cooperative_tool_timeout_keeps_existing_result_shape(monkeypatch):
+    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
+
+    class CooperativeTimeoutTool:
+        name = "cooperative"
+        default_timeout = 0.005
+        disable_outer_timeout = False
+
+        async def execute_with_runtime(self, args, runtime):
+            await asyncio.Event().wait()
+
+    tool = CooperativeTimeoutTool()
+    environment = RevocableEnvironment()
+    use_case = _bounded_tool_use_case(tool, environment)
+
+    output, _latency = await use_case.execute_tool(tool, {})
+
+    assert output.startswith("Tool execution timed out after ")
+    assert "while running 'cooperative'." in output
+    assert "cleanup failed" not in output
+    assert environment._aborted is False
+    assert use_case.pending_cleanup_tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_success_path_is_unchanged():
+    tool = RuntimeNativeTool(output="success")
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
+
+    output, _latency = await use_case.execute_tool(tool, {"value": 1})
+
+    assert output == "success"
+    assert use_case.pending_cleanup_tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_preserves_caller_cancellation():
+    class CallerCancelledTool:
+        name = "caller_cancelled"
+        default_timeout = None
+        disable_outer_timeout = True
+
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+
+        async def execute_with_runtime(self, args, runtime):
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                self.cancelled.set()
+
+    tool = CallerCancelledTool()
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
+    execution = asyncio.create_task(use_case.execute_tool(tool, {}))
+    await tool.started.wait()
+
+    execution.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execution
+
+    await asyncio.wait_for(tool.cancelled.wait(), timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_repeated_caller_cancel_cannot_interrupt_late_write_cleanup():
+    class CallerStubbornLateWriteTool(StubbornLateWriteTool):
+        default_timeout = None
+        disable_outer_timeout = True
+
+    environment = RevocableEnvironment()
+    tool = CallerStubbornLateWriteTool()
+    use_case = _bounded_tool_use_case(tool, environment)
+    execution = asyncio.create_task(use_case.execute_tool(tool, {}))
+    await tool.started.wait()
+
+    execution.cancel()
+    await tool.cancel_seen.wait()
+    execution.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execution
+
+    assert environment._aborted is True
+    pending = use_case.pending_cleanup_tasks
+    assert len(pending) == 1
+    tool.release.set()
+    await asyncio.gather(*pending)
+    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
+
+    assert tool.write_blocked.is_set()
+    assert environment.writes == []
+    assert use_case.pending_cleanup_tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_caller_cancel_cannot_interrupt_tool_timeout_cleanup(monkeypatch):
+    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
+    environment = RevocableEnvironment()
+    tool = StubbornLateWriteTool()
+    use_case = _bounded_tool_use_case(tool, environment)
+    execution = asyncio.create_task(use_case.execute_tool(tool, {}))
+
+    await tool.cancel_seen.wait()
+    execution.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execution
+
+    assert environment._aborted is True
+    pending = use_case.pending_cleanup_tasks
+    assert len(pending) == 1
+    tool.release.set()
+    await asyncio.gather(*pending)
+    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
+
+    assert tool.write_blocked.is_set()
+    assert environment.writes == []
+    assert use_case.pending_cleanup_tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_simultaneous_outer_and_cleanup_cancel_cannot_spin():
+    use_case, _ = build_use_case()
+    cleanup_started = asyncio.Event()
+
+    async def cleanup():
+        cleanup_started.set()
+        await asyncio.Event().wait()
+
+    cleanup_task = asyncio.create_task(cleanup())
+    owner = asyncio.create_task(
+        use_case._await_owned_cleanup_despite_cancellation(cleanup_task)
+    )
+    await cleanup_started.wait()
+
+    owner.cancel()
+    cleanup_task.cancel()
+
+    await asyncio.wait_for(owner, timeout=0.2)
+    assert cleanup_task.cancelled() is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "cancellation_cleanup_timeout",
+        "cancellation_force_timeout",
+        "environment_abort_timeout",
+    ],
+)
+@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True, "invalid"])
+def test_tool_cleanup_timeouts_must_be_finite_and_positive(field, value):
+    kwargs = {field: value}
+
+    with pytest.raises(ValueError, match="must be a finite positive number"):
+        build_use_case(**kwargs)
+
+
+@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True, "invalid"])
+def test_invalid_requested_tool_timeout_falls_back_to_positive_bound(value):
+    tool = SimpleNamespace(default_timeout=None, disable_outer_timeout=False)
+    use_case, _ = build_use_case()
+
+    timeout = use_case.tool_execution_timeout(tool, {"timeout": value})
+
+    assert timeout is not None
+    assert math.isfinite(timeout)
+    assert timeout > 0
+
+
+def test_application_tool_execution_module_does_not_import_outer_layers():
+    package_root = Path(__file__).resolve().parents[1]
+    source = (package_root / "opencollab/application/tool_execution.py").read_text(encoding="utf-8")
+
+    assert "opencollab.core.session" not in source
+    assert "opencollab.tools" not in source
+    assert "opencollab.bootstrap" not in source
+    assert "opencollab.tui" not in source

--- a/tests/test_tool_execution_use_case.py
+++ b/tests/test_tool_execution_use_case.py
@@ -1,7 +1,4 @@
 import asyncio
-import math
-import time
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -15,9 +12,9 @@ from tool_execution_test_support import (
     RecordingEventPublisher as FakeEventPublisher,
 )
 
-import opencollab.application.tool_execution_runtime as tool_execution_runtime
-from opencollab.adapters.env import Environment
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
+from opencollab.application.structured_output import StructuredOutputTool
+from opencollab.application.submit_findings import SubmitFindingsTool
 from opencollab.application.tool_execution import (
     MAX_TOOL_CALLS_PER_BATCH,
     ToolExecutionUseCase,
@@ -74,6 +71,137 @@ class SideEffectTool(RuntimeNativeTool):
         "required": ["value"],
         "properties": {"value": {"type": "integer"}},
     }
+
+
+@pytest.mark.parametrize(
+    ("schema", "arguments", "expected_error"),
+    [
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+            '{"value": 1, "unexpected": true}',
+            "unexpected property",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "number", "minimum": 0}},
+                "required": ["value"],
+            },
+            '{"value": -1}',
+            "must be >= 0",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "number", "maximum": 10}},
+                "required": ["value"],
+            },
+            '{"value": 11}',
+            "must be <= 10",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "minLength": 3}},
+                "required": ["value"],
+            },
+            '{"value": "ab"}',
+            "must have length >= 3",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "maxLength": 3}},
+                "required": ["value"],
+            },
+            '{"value": "abcd"}',
+            "must have length <= 3",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "pattern": "^[A-Z]+$"}},
+                "required": ["value"],
+            },
+            '{"value": "lower"}',
+            "must match pattern",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "array", "minItems": 2}},
+                "required": ["value"],
+            },
+            '{"value": [1]}',
+            "must contain at least 2 items",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "array", "maxItems": 2}},
+                "required": ["value"],
+            },
+            '{"value": [1, 2, 3]}',
+            "must contain at most 2 items",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "oneOf": [
+                            {"type": "integer", "minimum": 0},
+                            {"type": "string", "minLength": 3},
+                        ]
+                    }
+                },
+                "required": ["value"],
+            },
+            '{"value": false}',
+            "must match exactly one schema in oneOf",
+        ),
+    ],
+    ids=[
+        "additional-properties",
+        "minimum",
+        "maximum",
+        "min-length",
+        "max-length",
+        "pattern",
+        "min-items",
+        "max-items",
+        "one-of",
+    ],
+)
+def test_declared_schema_constraints_block_side_effects(schema, arguments, expected_error):
+    tool = SideEffectTool()
+    tool.parameters = schema
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
+
+    result = run(use_case.process([tool_call(arguments=arguments)]))
+
+    assert tool.runtime_calls == []
+    assert result.messages_to_append[0]["content"].startswith(
+        "Error: schema validation failed:"
+    )
+    assert expected_error in result.messages_to_append[0]["content"]
+
+
+def test_structured_output_rejects_unsupported_assertion_schema_before_provider_use():
+    with pytest.raises(ValueError, match="anyOf: unsupported schema keyword"):
+        StructuredOutputTool(
+            {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                ]
+            }
+        )
 
 
 def event_factory() -> SessionEventFactory:
@@ -162,6 +290,86 @@ def test_tool_execution_use_case_handles_non_string_and_preparsed_arguments():
     assert "must be a JSON object" in invalid.messages_to_append[0]["content"]
     assert valid.messages_to_append[0]["content"] == "runtime result"
     assert tool.runtime_calls[0][0] == {"value": 1}
+
+
+def test_terminal_structured_output_skips_later_side_effect_and_answers_every_call():
+    terminal = StructuredOutputTool(
+        {
+            "type": "object",
+            "required": ["answer"],
+            "properties": {"answer": {"type": "string"}},
+        }
+    )
+    side_effect = SideEffectTool(output="side effect executed")
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[terminal, side_effect]))
+
+    result = run(
+        use_case.process(
+            [
+                tool_call(
+                    name="structured_output",
+                    arguments='{"answer": "done"}',
+                    call_id="terminal",
+                ),
+                tool_call(
+                    name="fake_tool",
+                    arguments='{"value": 1}',
+                    call_id="side-effect",
+                ),
+            ]
+        )
+    )
+
+    assert terminal.captured == {"answer": "done"}
+    assert side_effect.runtime_calls == []
+    assert result.messages_to_append == [
+        {
+            "role": "tool",
+            "tool_call_id": "terminal",
+            "content": "Recorded. Structured output accepted. Your task is complete.",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "side-effect",
+            "content": "Skipped: terminal structured output accepted earlier in this batch.",
+        },
+    ]
+
+
+def test_terminal_submit_findings_skips_later_side_effect():
+    terminal = SubmitFindingsTool()
+    side_effect = SideEffectTool(output="side effect executed")
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[terminal, side_effect]))
+
+    result = run(
+        use_case.process(
+            [
+                tool_call(
+                    name="submit_findings",
+                    arguments=(
+                        '{"findings": [], "summary": "done", '
+                        '"insufficient_evidence": true}'
+                    ),
+                    call_id="terminal",
+                ),
+                tool_call(
+                    name="fake_tool",
+                    arguments='{"value": 1}',
+                    call_id="side-effect",
+                ),
+            ]
+        )
+    )
+
+    assert terminal.captured is not None
+    assert side_effect.runtime_calls == []
+    assert [message["tool_call_id"] for message in result.messages_to_append] == [
+        "terminal",
+        "side-effect",
+    ]
+    assert result.messages_to_append[-1]["content"] == (
+        "Skipped: terminal structured output accepted earlier in this batch."
+    )
 
 
 def test_tool_execution_use_case_preserves_unknown_tool_error():
@@ -445,310 +653,3 @@ def test_loop_block_short_circuit_counts_toward_hard_brake():
 
     assert state.turn.loop_blocked_since_progress == 1
     assert result.loop_detections == [LoopDetection(tool="fake_tool", count=3)]
-
-
-class RevocableEnvironment(Environment):
-    def __init__(self):
-        self._aborted = False
-        self.writes = []
-
-    async def exec_cmd(self, cmd: str, timeout: float = 120.0):
-        self._ensure_active()
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    async def read_file(self, path: str) -> str:
-        self._ensure_active()
-        return ""
-
-    async def write_file(self, path: str, content: str) -> None:
-        self._ensure_active()
-        self.writes.append((path, content))
-
-
-class StubbornLateWriteTool:
-    name = "stubborn_late_writer"
-    default_timeout = 0.005
-    disable_outer_timeout = False
-
-    def __init__(self):
-        self.started = asyncio.Event()
-        self.cancel_seen = asyncio.Event()
-        self.release = asyncio.Event()
-        self.write_blocked = asyncio.Event()
-
-    async def execute_with_runtime(self, args, runtime):
-        self.started.set()
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            self.cancel_seen.set()
-            while not self.release.is_set():
-                try:
-                    await self.release.wait()
-                except asyncio.CancelledError:
-                    continue
-            try:
-                await runtime.environment.write_file("late.py", "late")
-            except RuntimeError:
-                self.write_blocked.set()
-            return "late completion"
-
-
-def _bounded_tool_use_case(tool, environment):
-    return build_use_case(
-        agent=FakeAgent(tools=[tool]),
-        environment=environment,
-        cancellation_cleanup_timeout=0.01,
-        cancellation_force_timeout=0.01,
-        environment_abort_timeout=0.01,
-    )[0]
-
-
-@pytest.mark.asyncio
-async def test_stubborn_timed_out_tool_cannot_write_after_execute_returns(monkeypatch):
-    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
-    environment = RevocableEnvironment()
-    tool = StubbornLateWriteTool()
-    use_case = _bounded_tool_use_case(tool, environment)
-
-    started = time.monotonic()
-    output, _latency = await use_case.execute_tool(tool, {})
-    elapsed = time.monotonic() - started
-
-    assert elapsed < 0.2
-    assert "Tool cancellation cleanup failed" in output
-    assert "environment was revoked" in output
-    assert environment._aborted is True
-    pending = use_case.pending_cleanup_tasks
-    assert len(pending) == 1
-
-    tool.release.set()
-    await asyncio.gather(*pending)
-    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
-
-    assert tool.write_blocked.is_set()
-    assert environment.writes == []
-    assert use_case.pending_cleanup_tasks == ()
-
-
-@pytest.mark.asyncio
-async def test_stubborn_environment_abort_is_bounded_and_exposed(monkeypatch):
-    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
-
-    class StubbornAbortEnvironment(RevocableEnvironment):
-        def __init__(self):
-            super().__init__()
-            self.abort_started = asyncio.Event()
-            self.abort_release = asyncio.Event()
-
-        async def abort(self) -> None:
-            self.abort_started.set()
-            while not self.abort_release.is_set():
-                try:
-                    await self.abort_release.wait()
-                except asyncio.CancelledError:
-                    continue
-
-    environment = StubbornAbortEnvironment()
-    tool = StubbornLateWriteTool()
-    use_case = _bounded_tool_use_case(tool, environment)
-
-    started = time.monotonic()
-    output, _latency = await use_case.execute_tool(tool, {})
-    elapsed = time.monotonic() - started
-
-    assert elapsed < 0.2
-    assert environment.abort_started.is_set()
-    assert "environment abort did not quiesce within its bounded timeout" in output
-    pending = use_case.pending_cleanup_tasks
-    assert len(pending) == 2
-
-    tool.release.set()
-    environment.abort_release.set()
-    await asyncio.gather(*pending)
-    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
-
-    assert tool.write_blocked.is_set()
-    assert environment.writes == []
-    assert use_case.pending_cleanup_tasks == ()
-
-
-@pytest.mark.asyncio
-async def test_cooperative_tool_timeout_keeps_existing_result_shape(monkeypatch):
-    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
-
-    class CooperativeTimeoutTool:
-        name = "cooperative"
-        default_timeout = 0.005
-        disable_outer_timeout = False
-
-        async def execute_with_runtime(self, args, runtime):
-            await asyncio.Event().wait()
-
-    tool = CooperativeTimeoutTool()
-    environment = RevocableEnvironment()
-    use_case = _bounded_tool_use_case(tool, environment)
-
-    output, _latency = await use_case.execute_tool(tool, {})
-
-    assert output.startswith("Tool execution timed out after ")
-    assert "while running 'cooperative'." in output
-    assert "cleanup failed" not in output
-    assert environment._aborted is False
-    assert use_case.pending_cleanup_tasks == ()
-
-
-@pytest.mark.asyncio
-async def test_execute_tool_success_path_is_unchanged():
-    tool = RuntimeNativeTool(output="success")
-    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
-
-    output, _latency = await use_case.execute_tool(tool, {"value": 1})
-
-    assert output == "success"
-    assert use_case.pending_cleanup_tasks == ()
-
-
-@pytest.mark.asyncio
-async def test_execute_tool_preserves_caller_cancellation():
-    class CallerCancelledTool:
-        name = "caller_cancelled"
-        default_timeout = None
-        disable_outer_timeout = True
-
-        def __init__(self):
-            self.started = asyncio.Event()
-            self.cancelled = asyncio.Event()
-
-        async def execute_with_runtime(self, args, runtime):
-            self.started.set()
-            try:
-                await asyncio.Event().wait()
-            finally:
-                self.cancelled.set()
-
-    tool = CallerCancelledTool()
-    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
-    execution = asyncio.create_task(use_case.execute_tool(tool, {}))
-    await tool.started.wait()
-
-    execution.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await execution
-
-    await asyncio.wait_for(tool.cancelled.wait(), timeout=0.2)
-
-
-@pytest.mark.asyncio
-async def test_repeated_caller_cancel_cannot_interrupt_late_write_cleanup():
-    class CallerStubbornLateWriteTool(StubbornLateWriteTool):
-        default_timeout = None
-        disable_outer_timeout = True
-
-    environment = RevocableEnvironment()
-    tool = CallerStubbornLateWriteTool()
-    use_case = _bounded_tool_use_case(tool, environment)
-    execution = asyncio.create_task(use_case.execute_tool(tool, {}))
-    await tool.started.wait()
-
-    execution.cancel()
-    await tool.cancel_seen.wait()
-    execution.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await execution
-
-    assert environment._aborted is True
-    pending = use_case.pending_cleanup_tasks
-    assert len(pending) == 1
-    tool.release.set()
-    await asyncio.gather(*pending)
-    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
-
-    assert tool.write_blocked.is_set()
-    assert environment.writes == []
-    assert use_case.pending_cleanup_tasks == ()
-
-
-@pytest.mark.asyncio
-async def test_caller_cancel_cannot_interrupt_tool_timeout_cleanup(monkeypatch):
-    monkeypatch.setattr(tool_execution_runtime, "TOOL_EXECUTION_TIMEOUT_GRACE", 0.001)
-    environment = RevocableEnvironment()
-    tool = StubbornLateWriteTool()
-    use_case = _bounded_tool_use_case(tool, environment)
-    execution = asyncio.create_task(use_case.execute_tool(tool, {}))
-
-    await tool.cancel_seen.wait()
-    execution.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await execution
-
-    assert environment._aborted is True
-    pending = use_case.pending_cleanup_tasks
-    assert len(pending) == 1
-    tool.release.set()
-    await asyncio.gather(*pending)
-    await asyncio.wait_for(tool.write_blocked.wait(), timeout=0.2)
-
-    assert tool.write_blocked.is_set()
-    assert environment.writes == []
-    assert use_case.pending_cleanup_tasks == ()
-
-
-@pytest.mark.asyncio
-async def test_simultaneous_outer_and_cleanup_cancel_cannot_spin():
-    use_case, _ = build_use_case()
-    cleanup_started = asyncio.Event()
-
-    async def cleanup():
-        cleanup_started.set()
-        await asyncio.Event().wait()
-
-    cleanup_task = asyncio.create_task(cleanup())
-    owner = asyncio.create_task(
-        use_case._await_owned_cleanup_despite_cancellation(cleanup_task)
-    )
-    await cleanup_started.wait()
-
-    owner.cancel()
-    cleanup_task.cancel()
-
-    await asyncio.wait_for(owner, timeout=0.2)
-    assert cleanup_task.cancelled() is True
-
-
-@pytest.mark.parametrize(
-    "field",
-    [
-        "cancellation_cleanup_timeout",
-        "cancellation_force_timeout",
-        "environment_abort_timeout",
-    ],
-)
-@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True, "invalid"])
-def test_tool_cleanup_timeouts_must_be_finite_and_positive(field, value):
-    kwargs = {field: value}
-
-    with pytest.raises(ValueError, match="must be a finite positive number"):
-        build_use_case(**kwargs)
-
-
-@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True, "invalid"])
-def test_invalid_requested_tool_timeout_falls_back_to_positive_bound(value):
-    tool = SimpleNamespace(default_timeout=None, disable_outer_timeout=False)
-    use_case, _ = build_use_case()
-
-    timeout = use_case.tool_execution_timeout(tool, {"timeout": value})
-
-    assert timeout is not None
-    assert math.isfinite(timeout)
-    assert timeout > 0
-
-
-def test_application_tool_execution_module_does_not_import_outer_layers():
-    package_root = Path(__file__).resolve().parents[1]
-    source = (package_root / "opencollab/application/tool_execution.py").read_text(encoding="utf-8")
-
-    assert "opencollab.core.session" not in source
-    assert "opencollab.tools" not in source
-    assert "opencollab.bootstrap" not in source
-    assert "opencollab.tui" not in source

--- a/tests/test_tool_runtime_contract.py
+++ b/tests/test_tool_runtime_contract.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from tool_execution_test_support import AlwaysAllowPermissionPolicy as FakePermissionPolicy
-from tool_runtime_test_support import FakeEnv, SpySafetyPolicy, run
+from tool_runtime_test_support import FakeEnv, FalseyFakeEnv, SpySafetyPolicy, run
 
 from opencollab.adapters.safety import SandboxInterceptor
 from opencollab.adapters.tools import human
@@ -79,6 +79,16 @@ def test_bash_tool_without_env_returns_existing_error():
     result = run(BashTool().execute_with_runtime({"command": "pwd"}, runtime))
 
     assert result == "Error: no execution environment available."
+
+
+def test_bash_tool_accepts_falsey_environment():
+    env = FalseyFakeEnv(stdout="ok\n")
+    runtime = ToolRuntime(environment=env, safety_policy=None, permission_policy=None)
+
+    result = run(BashTool().execute_with_runtime({"command": "echo ok"}, runtime))
+
+    assert env.exec_calls == [("echo ok", 120.0)]
+    assert "stdout:\nok" in result
 
 
 def test_bash_tool_passes_permission_confirm_fn_to_safety_check():

--- a/tests/test_workflow_context.py
+++ b/tests/test_workflow_context.py
@@ -218,15 +218,15 @@ async def test_structured_retry_build_error_records_safe_provider_fields():
     assert ctx.agent_failures[0]["provider_error_type"] == "access_terminated_error"
 
 @pytest.mark.asyncio
-async def test_agent_forwards_tools_and_isolation():
+async def test_agent_rejects_unsupported_isolation_before_building_session():
     session = FakeSession()
     factory = FakeFactory([session])
     ctx = WorkflowContext(factory)
 
-    await ctx.agent("p", tools=["t1"], isolation=True)
+    with pytest.raises(ValueError, match="isolation is not available"):
+        await ctx.agent("p", tools=["t1"], isolation=True)
 
-    assert factory.builds[0]["tools"] == ["t1"]
-    assert factory.builds[0]["isolation"] is True
+    assert factory.builds == []
 
 @pytest.mark.asyncio
 async def test_agent_threads_tool_choice_to_factory():

--- a/tests/test_workflow_context_budget.py
+++ b/tests/test_workflow_context_budget.py
@@ -92,25 +92,71 @@ async def test_parallel_agents_atomically_reserve_shared_budget():
     assert ctx.budget.spent() == 100
 
 @pytest.mark.asyncio
-async def test_uncapped_parallel_agents_split_the_available_budget_fairly():
+@pytest.mark.parametrize("max_concurrency", (1, 2, 3))
+async def test_uncapped_parallel_agents_split_budget_before_concurrency_admission(
+    max_concurrency,
+):
     release = asyncio.Event()
     sessions = [FakeSession(reply=str(i), gate=release) for i in range(3)]
     factory = FakeFactory(sessions)
-    ctx = WorkflowContext(factory, budget_total=90, max_concurrency=3)
+    ctx = WorkflowContext(factory, budget_total=90, max_concurrency=max_concurrency)
 
     task = asyncio.create_task(
         ctx.parallel([lambda i=i: ctx.agent(f"agent {i}") for i in range(3)])
     )
-    for _ in range(20):
-        await asyncio.sleep(0)
-        if len(factory.builds) == 3:
-            break
+    try:
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if factory.builds:
+                break
+
+        assert factory.builds[0]["budget"] == 30
+        release.set()
+        assert await task == ["0", "1", "2"]
+    finally:
+        release.set()
+        if not task.done():
+            await asyncio.gather(task, return_exceptions=True)
 
     grants = [build["budget"] for build in factory.builds]
     assert grants == [30, 30, 30]
     assert sum(grants) <= 90
-    release.set()
-    assert await task == ["0", "1", "2"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_cancellation_releases_presemaphore_budget_leases():
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def first_on_enter() -> None:
+        started.set()
+        await gate.wait()
+
+    sessions = [
+        FakeSession(gate=gate, on_enter=first_on_enter),
+        FakeSession(),
+        FakeSession(),
+    ]
+    ctx = WorkflowContext(FakeFactory(sessions), budget_total=90, max_concurrency=1)
+    task = asyncio.create_task(
+        ctx.parallel([lambda i=i: ctx.agent(f"agent {i}") for i in range(3)])
+    )
+
+    await started.wait()
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if len(ctx.budget._leases) == 3:
+            break
+    assert len(ctx.budget._leases) == 3
+    assert ctx.budget.remaining() == 0
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await ctx.wait_for_pending_cleanup()
+
+    assert ctx.budget.remaining() == 90
+
 
 @pytest.mark.asyncio
 async def test_timeout_keeps_budget_reserved_until_cancel_cleanup_finishes():
@@ -265,6 +311,87 @@ async def test_enforced_timeout_does_not_start_synth_while_scout_cleans_up():
     await asyncio.wait_for(timed_out.cancel_seen.wait(), timeout=0.5)
     timed_out.release_cancel.set()
     await asyncio.wait_for(ctx.wait_for_pending_cleanup(), timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_dead_scout_synth_respects_the_callers_deadline():
+    class DeadScout(FakeSession):
+        async def run_loop(self, cancel_event=None):
+            raise RuntimeError("scout failed after collecting evidence")
+
+    class BlockingSynth(FakeSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.cancelled = asyncio.Event()
+
+        async def run_loop(self, cancel_event=None):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+
+    scout = DeadScout()
+    scout.state.turn.scout_ledger = [
+        {
+            "tool": "file_read",
+            "target": "module.py",
+            "outcome": "hit",
+            "snippet": "observed evidence",
+        }
+    ]
+    synth = BlockingSynth()
+    ctx = WorkflowContext(FakeFactory([scout, synth]))
+    started_at = asyncio.get_running_loop().time()
+    try:
+        result = await asyncio.wait_for(
+            ctx.agent(
+                "scout",
+                timeout=0.01,
+                enforcement_strength=ENFORCEMENT_ON,
+            ),
+            timeout=0.2,
+        )
+    finally:
+        await ctx.wait_for_pending_cleanup()
+
+    assert result is not None and "evidence cards" in result
+    assert synth.cancelled.is_set()
+    assert asyncio.get_running_loop().time() - started_at < 0.1
+
+
+@pytest.mark.asyncio
+async def test_dead_scout_synth_uses_internal_cap_without_caller_deadline(monkeypatch):
+    dead = FakeSession()
+    dead.state.turn.scout_ledger = [
+        {
+            "tool": "file_read",
+            "target": "module.py",
+            "outcome": "hit",
+            "snippet": "observed evidence",
+        }
+    ]
+    ctx = WorkflowContext(FakeFactory([FakeSession()]))
+    internal_deadline = asyncio.get_running_loop().time() + 120.0
+    seen_deadlines: list[float | None] = []
+
+    monkeypatch.setattr(ctx, "_internal_commit_deadline", lambda: internal_deadline)
+
+    async def record_deadline(_session, _prompt, *, deadline, cancel_event=None):
+        seen_deadlines.append(deadline)
+        return ""
+
+    monkeypatch.setattr(ctx, "_run_session_turn", record_deadline)
+
+    await ctx._synthesize_dead_scout(
+        dead,
+        "scout",
+        commit_reserve=1,
+        caller_deadline=None,
+    )
+
+    assert seen_deadlines == [internal_deadline]
+
 
 @pytest.mark.asyncio
 async def test_caller_cancellation_keeps_budget_reserved_until_cleanup_finishes():

--- a/tests/test_workflow_context_parallel.py
+++ b/tests/test_workflow_context_parallel.py
@@ -243,13 +243,8 @@ async def test_budget_none_never_raises():
     assert ctx.budget.remaining() == float("inf")
 
 @pytest.mark.asyncio
-async def test_parallel_swallows_budget_exceeded_to_none():
-    """A budget-exhausted ctx.agent() inside a parallel thunk resolves to None.
-
-    WorkflowBudgetExceeded escapes ctx.agent() at the WorkflowContext level, but
-    parallel()'s per-slot guard localizes ANY exception (including the budget
-    one) to that slot — it must not abort the gather.
-    """
+async def test_parallel_propagates_budget_exceeded():
+    """A parallel fan-out must preserve the workflow terminal budget signal."""
     s1 = FakeSession(reply="a", tokens=500)
     s2 = FakeSession(reply="b", tokens=0)
     ctx = WorkflowContext(FakeFactory([s1, s2]), budget_total=500)
@@ -257,18 +252,63 @@ async def test_parallel_swallows_budget_exceeded_to_none():
     # First call spends the whole budget; the second starts already exhausted.
     assert await ctx.agent("warm up") == "a"
 
-    results = await ctx.parallel([lambda: ctx.agent("exhausted")])
+    with pytest.raises(WorkflowBudgetExceeded):
+        await ctx.parallel([lambda: ctx.agent("exhausted")])
 
-    assert results == [None]
 
 @pytest.mark.asyncio
-async def test_pipeline_swallows_budget_exceeded_to_none_and_skips_rest():
-    """A budget-exhausted ctx.agent() in a pipeline stage drops the item to None.
+@pytest.mark.parametrize("composition", ("parallel", "pipeline"))
+async def test_collections_settle_gated_siblings_before_propagating_budget_stop(
+    composition,
+):
+    sibling_started = asyncio.Event()
+    budget_ready = asyncio.Event()
+    release_sibling = asyncio.Event()
+    sibling_finished = asyncio.Event()
 
-    The exhausted stage raises WorkflowBudgetExceeded; pipeline()'s flow guard
-    drops that item to None and skips its remaining stages, leaving other items
-    untouched.
-    """
+    async def gated_sibling():
+        sibling_started.set()
+        try:
+            await release_sibling.wait()
+            return "finished"
+        finally:
+            sibling_finished.set()
+
+    async def exhausted():
+        await sibling_started.wait()
+        budget_ready.set()
+        raise WorkflowBudgetExceeded("budget exhausted")
+
+    ctx = WorkflowContext(FakeFactory([]))
+    if composition == "parallel":
+        task = asyncio.create_task(ctx.parallel([exhausted, gated_sibling]))
+    else:
+
+        async def stage(_previous, _item, index):
+            if index == 0:
+                return await exhausted()
+            return await gated_sibling()
+
+        task = asyncio.create_task(ctx.pipeline(["exhausted", "gated"], stage))
+
+    try:
+        await budget_ready.wait()
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if task.done():
+                break
+        assert task.done() is False
+        release_sibling.set()
+        with pytest.raises(WorkflowBudgetExceeded):
+            await task
+        assert sibling_finished.is_set()
+    finally:
+        release_sibling.set()
+        await asyncio.gather(task, return_exceptions=True)
+
+@pytest.mark.asyncio
+async def test_pipeline_propagates_budget_exceeded_and_skips_later_stages():
+    """A pipeline must preserve the workflow terminal budget signal."""
     s1 = FakeSession(reply="a", tokens=500)
     s2 = FakeSession(reply="b", tokens=0)
     ctx = WorkflowContext(FakeFactory([s1, s2]), budget_total=500)
@@ -285,8 +325,7 @@ async def test_pipeline_swallows_budget_exceeded_to_none_and_skips_rest():
         later_ran.append(item)
         return prev
 
-    results = await ctx.pipeline([7], agent_stage, later_stage)
-
-    assert results == [None]
+    with pytest.raises(WorkflowBudgetExceeded):
+        await ctx.pipeline([7], agent_stage, later_stage)
     # The exhausted item never reaches the later stage.
     assert later_ran == []

--- a/tests/test_workflow_registry.py
+++ b/tests/test_workflow_registry.py
@@ -8,8 +8,12 @@ import arbitrary files), so it is exercised here against a tmp_path directory.
 
 from __future__ import annotations
 
+import asyncio
 import os
+import sys
 import textwrap
+import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -235,6 +239,275 @@ def test_discover_workflows_dedupes_aliased_workflow(tmp_path):
 
     reg = discover_workflows(str(wf_dir))
     assert [s.name for s in reg.list_specs()] == ["alpha"]
+
+
+def test_load_workflow_specs_supports_dataclasses_and_relative_imports(tmp_path):
+    """Discovery modules get a package context while they are executing."""
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    _write_workflow_module(
+        wf_dir,
+        "helpers.py",
+        '''
+        DESCRIPTION = "loaded through a relative import"
+        ''',
+    )
+    _write_workflow_module(
+        wf_dir,
+        "with_context.py",
+        '''
+        from __future__ import annotations
+
+        from dataclasses import dataclass
+
+        from .helpers import DESCRIPTION
+        from opencollab.application.workflow_registry import workflow
+
+        @dataclass
+        class Arguments:
+            message: str = DESCRIPTION
+
+        @workflow(name="with_context", description=Arguments().message)
+        async def run(ctx, args):
+            return None
+        ''',
+    )
+
+    specs = workflow_discovery.load_workflow_specs(str(wf_dir / "with_context.py"))
+
+    assert [spec.name for spec in specs] == ["with_context"]
+    assert specs[0].description == "loaded through a relative import"
+
+
+@pytest.mark.asyncio
+async def test_loaded_workflow_keeps_runtime_relative_imports_available(tmp_path):
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    _write_workflow_module(wf_dir, "_runtime_helper.py", 'VALUE = "runtime helper"')
+    _write_workflow_module(
+        wf_dir,
+        "runtime_import.py",
+        '''
+        from opencollab.application.workflow_registry import workflow
+
+        @workflow(name="runtime-import", description="d")
+        async def run(ctx, args):
+            from ._runtime_helper import VALUE
+
+            return VALUE
+        ''',
+    )
+
+    specs = workflow_discovery.load_workflow_specs(str(wf_dir / "runtime_import.py"))
+    module_name = specs[0].fn.__module__
+    package_name = module_name.partition(".")[0]
+
+    assert module_name not in sys.modules
+    assert package_name not in sys.modules
+    assert package_name not in workflow_discovery._WORKFLOW_IMPORT_FINDER._package_roots
+
+    assert await specs[0].fn(None, {}) == "runtime helper"
+    assert module_name not in sys.modules
+    assert package_name not in sys.modules
+    assert package_name not in workflow_discovery._WORKFLOW_IMPORT_FINDER._package_roots
+
+
+@pytest.mark.asyncio
+async def test_overlapping_workflow_calls_share_runtime_package_until_last_release(tmp_path):
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    _write_workflow_module(wf_dir, "_runtime_helper.py", 'VALUE = "runtime helper"')
+    _write_workflow_module(
+        wf_dir,
+        "overlap.py",
+        '''
+        from opencollab.application.workflow_registry import workflow
+
+        @workflow(name="overlap", description="d")
+        async def run(ctx, args):
+            await args["started"].put(args["name"])
+            await args["release"].wait()
+            from ._runtime_helper import VALUE
+
+            return f"{args['name']} {VALUE}"
+        ''',
+    )
+    spec = workflow_discovery.load_workflow_specs(str(wf_dir / "overlap.py"))[0]
+    package_name = spec.fn.__module__.partition(".")[0]
+    started = asyncio.Queue()
+    first_release = asyncio.Event()
+    second_release = asyncio.Event()
+    first = asyncio.create_task(
+        spec.fn(None, {"name": "first", "started": started, "release": first_release})
+    )
+    second = asyncio.create_task(
+        spec.fn(None, {"name": "second", "started": started, "release": second_release})
+    )
+    assert {await started.get(), await started.get()} == {"first", "second"}
+
+    first_release.set()
+    assert await first == "first runtime helper"
+    assert package_name in sys.modules
+    assert package_name in workflow_discovery._WORKFLOW_IMPORT_FINDER._package_roots
+
+    second_release.set()
+    assert await second == "second runtime helper"
+    assert package_name not in sys.modules
+    assert package_name not in workflow_discovery._WORKFLOW_IMPORT_FINDER._package_roots
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("namespace_package", [False, True])
+async def test_loaded_workflow_supports_nested_local_packages(tmp_path, namespace_package):
+    wf_dir = tmp_path / "workflows"
+    helpers = wf_dir / "_helpers"
+    helpers.mkdir(parents=True)
+    if not namespace_package:
+        _write_workflow_module(helpers, "__init__.py", "")
+    _write_workflow_module(helpers, "value.py", 'VALUE = "nested helper"')
+    _write_workflow_module(
+        wf_dir,
+        "nested_import.py",
+        '''
+        from opencollab.application.workflow_registry import workflow
+
+        @workflow(name="nested-import", description="d")
+        async def run(ctx, args):
+            from ._helpers.value import VALUE
+
+            return VALUE
+        ''',
+    )
+
+    specs = workflow_discovery.load_workflow_specs(str(wf_dir / "nested_import.py"))
+
+    assert await specs[0].fn(None, {}) == "nested helper"
+
+
+def test_repeated_loads_leave_no_global_workflow_modules_or_finder_roots(tmp_path):
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    _write_workflow_module(
+        wf_dir,
+        "repeat.py",
+        '''
+        from opencollab.application.workflow_registry import workflow
+
+        @workflow(name="repeat", description="d")
+        async def run(ctx, args):
+            return "ok"
+        ''',
+    )
+    before = {name for name in sys.modules if name.startswith("_opencollab_workflow_")}
+
+    loaded = [
+        workflow_discovery.load_workflow_specs(str(wf_dir / "repeat.py"))
+        for _ in range(20)
+    ]
+
+    assert all(specs[0].name == "repeat" for specs in loaded)
+    assert {name for name in sys.modules if name.startswith("_opencollab_workflow_")} == before
+    assert workflow_discovery._WORKFLOW_IMPORT_FINDER._package_roots == {}
+
+
+@pytest.mark.asyncio
+async def test_loaded_workflow_supports_function_local_dataclass(tmp_path):
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    _write_workflow_module(
+        wf_dir,
+        "local_dataclass.py",
+        '''
+        from opencollab.application.workflow_registry import workflow
+
+        @workflow(name="local-dataclass", description="d")
+        async def run(ctx, args):
+            from dataclasses import dataclass
+
+            @dataclass
+            class Result:
+                value: str
+
+            return Result(value="created after discovery")
+        ''',
+    )
+
+    specs = workflow_discovery.load_workflow_specs(str(wf_dir / "local_dataclass.py"))
+
+    result = await specs[0].fn(None, {})
+    assert result.value == "created after discovery"
+
+
+@pytest.mark.parametrize("kind", ["symlink", "fifo", "oversized"])
+def test_relative_import_helpers_use_bounded_regular_loader(tmp_path, monkeypatch, kind):
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    helper = wf_dir / "_helper.py"
+    if kind == "symlink":
+        outside = tmp_path / "outside.py"
+        outside.write_text("VALUE = 1\n", encoding="utf-8")
+        helper.symlink_to(outside)
+    elif kind == "fifo":
+        os.mkfifo(helper)
+
+        def feed_fifo() -> None:
+            try:
+                helper.write_text("VALUE = 1\n", encoding="utf-8")
+            except BrokenPipeError:
+                pass
+
+        writer = threading.Thread(target=feed_fifo, daemon=True)
+        writer.start()
+    else:
+        helper.write_text("VALUE = 1\n" + "x" * 512, encoding="utf-8")
+        monkeypatch.setattr(workflow_discovery, "MAX_WORKFLOW_SOURCE_BYTES", 256)
+    _write_workflow_module(
+        wf_dir,
+        "imports_helper.py",
+        '''
+        from ._helper import VALUE
+        from opencollab.application.workflow_registry import workflow
+
+        @workflow(name="imports-helper", description=str(VALUE))
+        async def run(ctx, args):
+            return VALUE
+        ''',
+    )
+
+    try:
+        with pytest.raises((OSError, ValueError), match="_helper.py"):
+            workflow_discovery.load_workflow_specs(str(wf_dir / "imports_helper.py"))
+    finally:
+        if kind == "fifo":
+            fd = os.open(helper, os.O_RDONLY | os.O_NONBLOCK)
+            os.close(fd)
+            writer.join(timeout=1)
+
+
+def test_load_workflow_specs_rolls_back_registered_modules_after_failure(tmp_path, monkeypatch):
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    _write_workflow_module(wf_dir, "helpers.py", "VALUE = 1")
+    _write_workflow_module(
+        wf_dir,
+        "broken.py",
+        '''
+        from .helpers import VALUE
+
+        raise RuntimeError(f"broken workflow: {VALUE}")
+        ''',
+    )
+    module_prefix = "_opencollab_workflow_failure"
+    monkeypatch.setattr(
+        workflow_discovery.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="broken workflow: 1"):
+        workflow_discovery.load_workflow_specs(str(wf_dir / "broken.py"))
+
+    assert not any(name.startswith(module_prefix) for name in sys.modules)
 
 
 @pytest.mark.parametrize("kind", ["fifo", "symlink", "oversized"])

--- a/tests/test_workflow_runtime.py
+++ b/tests/test_workflow_runtime.py
@@ -53,6 +53,40 @@ async def test_built_context_agent_runs_session_with_resolved_llm(monkeypatch):
     # The per-session budget is the remaining workflow budget.
     assert calls[0]["max_budget_tokens"] == 100_000
 
+
+class _FalseyEnvironment:
+    def __bool__(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_built_context_preserves_falsey_injected_environment(monkeypatch):
+    calls = _patch_build_session(monkeypatch)
+    environment = _FalseyEnvironment()
+    ctx = workflow_runtime.build_workflow_context(cfg=_cfg(), env=environment)
+
+    await ctx.agent("solve this")
+
+    assert calls[0]["env"] is environment
+    assert ctx._tree_probe._env is environment
+
+
+def test_concrete_factory_rejects_unsupported_isolation_before_building_session(monkeypatch):
+    calls = _patch_build_session(monkeypatch)
+    cfg = _cfg()
+    factory = workflow_runtime.WorkflowSessionFactory(
+        model=cfg["model"],
+        provider=cfg["provider"],
+        api_key=cfg["api_key"],
+        base_url=cfg["base_url"],
+    )
+
+    with pytest.raises(ValueError, match="isolation is not available"):
+        factory.build_workflow_session(prompt="solve", budget=1, isolation=True)
+
+    assert calls == []
+
+
 @pytest.mark.asyncio
 async def test_built_context_injects_sampling_and_output_limits(monkeypatch):
     calls = _patch_build_session(monkeypatch)
@@ -232,6 +266,34 @@ async def test_run_workflow_reports_live_spend_on_budget_exceeded(monkeypatch):
     assert result["budget_total"] == 1000
     assert result["tokens_spent"] == 0  # _FakeSession.used_tokens == 0
     assert len(calls) == 1  # the agent did build+run before the raise
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("composition", ("parallel", "pipeline"))
+async def test_run_workflow_marks_collection_budget_exhaustion_stopped(
+    monkeypatch,
+    composition,
+):
+    _patch_build_session(monkeypatch)
+
+    async def fn(ctx, args):
+        if composition == "parallel":
+            return await ctx.parallel([lambda: ctx.agent("exhausted")])
+
+        async def agent_stage(_previous, _item, _index):
+            return await ctx.agent("exhausted")
+
+        return await ctx.pipeline(["item"], agent_stage)
+
+    details = await workflow_runtime.run_workflow(
+        fn,
+        {},
+        cfg=_cfg(budget=0),
+        return_details=True,
+    )
+
+    assert details.stop_reason == "budget_exceeded"
+    assert details.output["status"] == "budget_exceeded"
 
 @pytest.mark.asyncio
 async def test_run_workflow_other_exceptions_propagate(monkeypatch):

--- a/tests/test_workflow_structured_output.py
+++ b/tests/test_workflow_structured_output.py
@@ -132,6 +132,36 @@ def test_validate_union_type_list():
     assert validate({"x": 7}, schema)
 
 
+def test_validate_nullable_object_enforces_object_constraints():
+    schema = {
+        "type": ["object", "null"],
+        "required": ["x"],
+        "properties": {"x": {"type": "integer"}},
+        "additionalProperties": False,
+    }
+
+    assert validate(None, schema) == []
+    assert validate({"x": 1}, schema) == []
+    assert validate({}, schema)
+    assert validate({"x": "wrong"}, schema)
+    assert validate({"x": 1, "extra": True}, schema)
+
+
+def test_validate_nullable_array_enforces_array_constraints():
+    schema = {
+        "type": ["array", "null"],
+        "items": {"type": "integer"},
+        "minItems": 2,
+        "maxItems": 2,
+    }
+
+    assert validate(None, schema) == []
+    assert validate([1, 2], schema) == []
+    assert validate([1, "wrong"], schema)
+    assert validate([1], schema)
+    assert validate([1, 2, 3], schema)
+
+
 # --------------------------------------------------------------------------- #
 # StructuredOutputTool
 # --------------------------------------------------------------------------- #

--- a/tests/tool_runtime_test_support.py
+++ b/tests/tool_runtime_test_support.py
@@ -31,6 +31,14 @@ class FakeEnv:
         raise AssertionError("write_file was not expected")
 
 
+class FalseyFakeEnv(FakeEnv):
+    def __bool__(self) -> bool:
+        return False
+
+    async def read_file(self, path: str) -> str:
+        return "contents\n"
+
+
 class SpySafetyPolicy:
     def __init__(self):
         self.cmd_calls = []


### PR DESCRIPTION
## Summary

Integrate the reviewed workflow orchestration changes currently carried by `codex/layer-runtime-foundation` into the latest `main` through a clean, single-commit branch.

This preserves the runtime foundation already merged through PR #50 and adds the workflow, scheduler, messaging, token-accounting, and regression-test changes from PR #51.

## Validation

- `uv run ruff check .`
- `uv run pytest -q` with 1836 passing tests
- clean merge against `480da2841336d5fbe81a751c1f5c45559ea30266`
- latest `main` README and CI title-check changes preserved
