### PR TITLE
chore(release): finalize budget and stack validation

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   secrets:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 - Configuration and team schemas reject unknown keys, API-key fallback is
   provider/endpoint specific, watchdog/low-yield wind-down latches reset per
   user turn while the hard budget and its protected reserve remain
-  session-lifetime, and useful partial compaction is retained.
+  session-lifetime (with an allocation-time autosave), and useful partial
+  compaction is retained.
 
 ### Fixed
 - Capped structured-output corrective retries at 60 seconds while preserving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-08
+
 ### Added
 - Added Mini Edict, a bilingual, tested Three Departments and Six Ministries
   example with both a team configuration and a hard-gated workflow.
 - Added a public maintainer release procedure covering exact-SHA validation,
   artifact construction, signed tagging, publication, and failure handling.
 - Added explicit lifecycle exceptions for rejected concurrent turns,
-  scheduler turn failures/stalls, and unavailable isolated snapshots. See the
-  0.5.0 migration guide for import paths and recovery actions.
+  duplicate live spawns, scheduler turn failures/stalls, and unavailable
+  isolated snapshots. See the 0.5.0 migration guide for import paths and
+  recovery actions.
+- Added `task_concurrency` to workflow runs and `cleanup_timeout` to team runs
+  so callers can bound non-agent workflow units and scheduler shutdown
+  independently.
 
 ### Changed
 - Replaced changelog links that depended on the absent remote `v0.1.0` tag with
@@ -22,6 +28,9 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 - Scheduler and session boundaries now preserve terminal failures, ownership,
   budgets, deadlines, and snapshot isolation instead of silently treating
   partial work as success.
+- Configuration and team schemas reject unknown keys, API-key fallback is
+  provider/endpoint specific, wind-down latches reset per user turn while hard
+  budgets remain session-lifetime, and useful partial compaction is retained.
 
 ### Fixed
 - Capped structured-output corrective retries at 60 seconds while preserving
@@ -105,6 +114,7 @@ clean architecture where everything but the model sits behind swappable ports.
 - Trimmed the GLM SWE-bench experiment archive to the final report and prediction files.
 - Moved Chinese working notes into `docs/archive/`.
 
-[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/RISE-X-Lab/OpenCollab/compare/563027175e2cc2540d19324def73010a7e436dcc...v0.4.1
 [0.1.0]: https://github.com/RISE-X-Lab/OpenCollab/tree/563027175e2cc2540d19324def73010a7e436dcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
   budgets, deadlines, and snapshot isolation instead of silently treating
   partial work as success.
 - Configuration and team schemas reject unknown keys, API-key fallback is
-  provider/endpoint specific, wind-down latches reset per user turn while hard
-  budgets remain session-lifetime, and useful partial compaction is retained.
+  provider/endpoint specific, watchdog/low-yield wind-down latches reset per
+  user turn while the hard budget and its protected reserve remain
+  session-lifetime, and useful partial compaction is retained.
 
 ### Fixed
 - Capped structured-output corrective retries at 60 seconds while preserving

--- a/configs/README.md
+++ b/configs/README.md
@@ -43,8 +43,16 @@ OPENCOLLAB_API_KEY=<your-api-key>
 OPENCOLLAB_LLM_TIMEOUT=600
 ```
 
-For DashScope-compatible mode, `DASHSCOPE_API_KEY` is also accepted and is
-preferred over generic API-key variables for DashScope base URLs.
+API-key fallback is provider and endpoint specific:
+
+| Route | Resolution order |
+| --- | --- |
+| OpenAI-compatible, non-DashScope | `OPENCOLLAB_API_KEY`, then `OPENAI_API_KEY` |
+| Native Anthropic | `ANTHROPIC_API_KEY`, then `OPENCOLLAB_API_KEY` |
+| DashScope-compatible base URL | `DASHSCOPE_API_KEY`, then `OPENCOLLAB_API_KEY` |
+
+Keys from another provider are not used as fallbacks. Process-environment
+values beat the same variable in an env file, and blank values are ignored.
 
 ## Model capability metadata
 
@@ -155,6 +163,7 @@ selected team file, the built-in `lead` may spawn any ad-hoc role. See
 The final resolved configuration is validated by a Pydantic model. `budget`
 must be a positive integer. `llm_timeout` must be a positive number of seconds.
 `temperature` must be within `0.0`–`2.0`. Blank `api_key` and `base_url` values
-are treated as unset.
+are treated as unset. Unknown configuration and team-schema keys are rejected
+instead of being silently ignored.
 
 Do not commit `configs/.env` or any file containing real API keys.

--- a/docs/migrations/0.5.0.md
+++ b/docs/migrations/0.5.0.md
@@ -56,10 +56,12 @@ Teammate inbox delivery is bounded by count and bytes, drains appended messages
 before shutdown, and deduplicates restored messages. Deferred tool batches are
 validated and capped just like the original batch.
 
-Wind-down tool/latch state is current-turn state and resets for a new user
-message. `used_tokens` and `step_count` remain session-lifetime counters. Local
-and aggregate hard budgets are checked before the wind-down gate, so a fresh
-turn cannot grant another model call after either hard cap is exhausted.
+Wind-down tool/latch state for watchdog and low-yield brakes is current-turn
+state and resets for a new user message. `used_tokens`, `step_count`, and the
+budget-reserve grant remain session-lifetime state: the protected call carved
+from `commit_reserve` is allocated at most once, including after save/restore.
+Local and aggregate hard budgets are checked before the wind-down gate, so a
+fresh turn cannot grant another model call after either hard cap is exhausted.
 
 Auto-compaction retains any candidate that is strictly smaller than the
 original view, even when the summary does not reach `target_tokens`. It rejects

--- a/docs/migrations/0.5.0.md
+++ b/docs/migrations/0.5.0.md
@@ -60,6 +60,7 @@ Wind-down tool/latch state for watchdog and low-yield brakes is current-turn
 state and resets for a new user message. `used_tokens`, `step_count`, and the
 budget-reserve grant remain session-lifetime state: the protected call carved
 from `commit_reserve` is allocated at most once, including after save/restore.
+The allocation emits a dedicated autosave trigger before the provider call.
 Local and aggregate hard budgets are checked before the wind-down gate, so a
 fresh turn cannot grant another model call after either hard cap is exhausted.
 

--- a/docs/migrations/0.5.0.md
+++ b/docs/migrations/0.5.0.md
@@ -1,9 +1,8 @@
 # OpenCollab 0.5.0 migration guide
 
-This guide records the compatibility changes required by the audited lifecycle
-and scheduler fixes. The package metadata remains `0.4.1` while the high- and
-medium-risk batches are reviewed; the final integration must bump the package
-and test metadata to `0.5.0` together.
+This guide records the compatibility changes required by the audited lifecycle,
+scheduler, configuration, and compaction fixes. The integration branch updates
+the package, lockfile, public version, and release tests to `0.5.0` together.
 
 ## Runtime failures are explicit
 
@@ -25,6 +24,7 @@ The exception classes are intentionally exposed at their owning boundaries:
 
 ```python
 from opencollab.application.scheduler import (
+    DuplicateSpawnError,
     SchedulerStalledError,
     SchedulerTurnError,
 )
@@ -40,6 +40,10 @@ instead of silently running in a shared environment. Timeouts and cancellation
 also leave caller-owned environments under caller control; OpenCollab only
 cleans up resources it owns.
 
+An identical delegated spawn that already has a live single-flight owner raises
+`DuplicateSpawnError`. Callers should await the existing work or submit a
+distinct task instead of relying on duplicate requests being silently merged.
+
 ## Budget, turn, and delivery semantics
 
 Provider truncation (`finish_reason="length"`) is a controlled stop, not a
@@ -52,6 +56,36 @@ Teammate inbox delivery is bounded by count and bytes, drains appended messages
 before shutdown, and deduplicates restored messages. Deferred tool batches are
 validated and capped just like the original batch.
 
+Wind-down tool/latch state is current-turn state and resets for a new user
+message. `used_tokens` and `step_count` remain session-lifetime counters. Local
+and aggregate hard budgets are checked before the wind-down gate, so a fresh
+turn cannot grant another model call after either hard cap is exhausted.
+
+Auto-compaction retains any candidate that is strictly smaller than the
+original view, even when the summary does not reach `target_tokens`. It rejects
+only candidates that fail to reduce the view. Shaping configuration now
+requires positive `trigger_tokens`, `target_tokens`, and `keep_recent`, requires
+`target_tokens < trigger_tokens`, and requires non-negative
+`keep_recent_groups`.
+
+## Configuration and API-key routing
+
+Configuration and team models now reject unknown keys. Correct misspellings or
+remove obsolete fields; they are no longer ignored.
+
+API-key fallback is restricted to the selected provider/endpoint:
+
+| Route | Resolution order |
+| --- | --- |
+| OpenAI-compatible, non-DashScope | `OPENCOLLAB_API_KEY`, then `OPENAI_API_KEY` |
+| Native Anthropic | `ANTHROPIC_API_KEY`, then `OPENCOLLAB_API_KEY` |
+| DashScope-compatible base URL | `DASHSCOPE_API_KEY`, then `OPENCOLLAB_API_KEY` |
+
+An Anthropic or DashScope key is not sent to a plain OpenAI-compatible endpoint,
+and `OPENAI_API_KEY` is not used for Anthropic or DashScope. A non-empty explicit
+`api_key` override still wins. For the same variable name, the process
+environment wins over env-file values; blank values are skipped.
+
 ## Self-collaboration and workflow contracts
 
 The coder must finish in `DONE` before a reviewer `VERDICT: PASS` can mark a
@@ -59,6 +93,18 @@ self-collaboration loop successful. Reviewer `STOPPED` and `ERROR` outcomes are
 failures. Workflow tool schemas now enforce declared constraints locally, and
 discovery loads modules with normal import semantics so relative imports and
 dataclasses remain valid.
+
+Duplicate tool names now fail before dispatch. Rename the conflicting tool or
+remove one registration rather than relying on last-write-wins behavior.
+
+## SDK parameters
+
+- `OpenCollab.team(..., cleanup_timeout=...)` bounds scheduler cleanup and must
+  be a finite positive number.
+- `OpenCollab.workflow(..., task_concurrency=...)` independently bounds active
+  parallel/pipeline units and defaults to `concurrency`.
+- Workflow `cleanup_timeout` continues to bound workflow shutdown separately
+  from the execution timeout.
 
 ## Upgrade checklist
 
@@ -68,8 +114,7 @@ dataclasses remain valid.
    `isolation=True` or `snapshot_session()`.
 3. Treat `STOPPED` and `ERROR` child rows as failed work and decide whether to
    retry or surface the failure.
-4. Update integrations that depend on permissive tool/schema inputs to pass
-   validated, declared values.
-5. When the medium-risk batch lands, follow the additional provider-key,
-   configuration strictness, turn wind-down, compaction, and SDK-parameter
-   notes added to this file before releasing `0.5.0`.
+4. Update integrations that depend on permissive tool/schema/config inputs to
+   pass validated, declared values and provider-specific credentials.
+5. Audit custom shaper settings and duplicate tool/spawn behavior against the
+   stricter validation and explicit exceptions above.

--- a/opencollab/README.md
+++ b/opencollab/README.md
@@ -91,7 +91,8 @@ three return `RunResult`. Import optional authoring contracts from
 Treat other package paths as internal. An `artifacts` directory, when supplied,
 must be new or empty because each run claims it for executable evidence.
 `team(...)` uses the built-in lead-only configuration unless its `config=`
-argument names a team YAML file.
+argument names a team YAML file. Its `cleanup_timeout` bounds scheduler
+shutdown and must be a finite positive number.
 
 `OpenCollab.configuration` is a read-only snapshot of effective model,
 provider, budget, timeout, sampling, output-token, and thinking settings.

--- a/opencollab/__init__.py
+++ b/opencollab/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from opencollab.sdk import OpenCollab, RunError, RunResult, workflow
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 __all__ = ["OpenCollab", "RunError", "RunResult", "workflow"]
 _PUBLIC_MODULES = {

--- a/opencollab/application/_session_run_completion.py
+++ b/opencollab/application/_session_run_completion.py
@@ -544,12 +544,16 @@ class _SessionRunCompletionMixin:
         if self._per_call_timeout is None:
             return await self.llm.complete(**kwargs)
         try:
+            protected_call = self.state.wind_down_done
             return await abandon_on_timeout(
                 self.llm.complete(**kwargs),
                 self._per_call_timeout,
                 task_tracker=self._track_provider_task,
                 late_task_tracker=self._mark_provider_task_draining,
-                late_result_handler=self._record_late_provider_result,
+                late_result_handler=lambda task: self._record_late_provider_result(
+                    task,
+                    protected_call=protected_call,
+                ),
             )
         except CallerTimeoutError as exc:
             raise GenerationTimeoutError(

--- a/opencollab/application/_session_run_usage.py
+++ b/opencollab/application/_session_run_usage.py
@@ -1,0 +1,30 @@
+"""Provider usage validation shared by session completion paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _nonnegative_usage_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"provider usage {field} must be a non-negative integer")
+    return value
+
+
+def _normalize_completion_usage(usage: Any) -> tuple[int, int]:
+    """Validate provider counters atomically and prevent total undercharging."""
+    input_tokens = _nonnegative_usage_int(
+        getattr(usage, "input_tokens", None),
+        "input_tokens",
+    )
+    reported_total = _nonnegative_usage_int(
+        getattr(usage, "total_tokens", None),
+        "total_tokens",
+    )
+    raw_output = getattr(usage, "output_tokens", None)
+    output_tokens = (
+        max(0, reported_total - input_tokens)
+        if raw_output is None
+        else _nonnegative_usage_int(raw_output, "output_tokens")
+    )
+    return input_tokens, max(reported_total, input_tokens + output_tokens)

--- a/opencollab/application/autosave.py
+++ b/opencollab/application/autosave.py
@@ -12,7 +12,9 @@ from opencollab.domain.events import SessionRuntimeEvent as SessionEvent
 SaveOperation = Callable[[], None]
 PrepareSave = Callable[[], SaveOperation | None]
 
-SAVE_TRIGGERS = frozenset({"user_message_appended", "step_end"})
+SAVE_TRIGGERS = frozenset(
+    {"user_message_appended", "step_end", "budget_reserve_allocated"}
+)
 
 logger = logging.getLogger(__name__)
 

--- a/opencollab/application/session.py
+++ b/opencollab/application/session.py
@@ -485,6 +485,9 @@ class Session:
         restored.wind_down_token_mark = _snapshot_nonnegative_int(
             raw_state.get("wind_down_token_mark")
         )
+        restored.budget_reserve_consumed = bool(
+            raw_state.get("budget_reserve_consumed", restored.wind_down_done)
+        )
         restored.turn.loop_blocked_since_progress = _snapshot_nonnegative_int(
             raw_state.get("loop_blocked_since_progress")
         )
@@ -671,6 +674,7 @@ class Session:
                 "wind_down_done": self.state.wind_down_done,
                 "wind_down_attempts": self.state.wind_down_attempts,
                 "wind_down_token_mark": self.state.wind_down_token_mark,
+                "budget_reserve_consumed": self.state.budget_reserve_consumed,
                 "loop_blocked_since_progress": self.state.turn.loop_blocked_since_progress,
                 "phase": self.state.phase.value,
                 "terminal_reason": self.state.terminal_reason,

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -34,6 +34,7 @@ from opencollab.application.ports import (
     TracePort,
 )
 from opencollab.application.tool_execution import ToolExecutionUseCase
+from opencollab.domain.events import SessionRuntimeEvent
 from opencollab.domain.session import SessionPhase, SessionState
 
 __all__ = [
@@ -521,6 +522,16 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         self._trace_brake_trip(budget_spent, watchdog_tripped, low_yield_tripped)
         if budget_spent:
             self.state.budget_reserve_consumed = True
+            await self.event_publisher.emit(
+                SessionRuntimeEvent(
+                    type="budget_reserve_allocated",
+                    data={
+                        "aid": self.state.aid,
+                        "used_tokens": self.state.used_tokens,
+                        "reserve": self._commit_reserve,
+                    },
+                )
+            )
         self._enter_wind_down()
         self.state.transition_to(SessionPhase.CALLING_LLM)
         return True

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -26,6 +26,7 @@ from opencollab.application._session_run_shared import (
     _submit_tool_choice,
     _TokenBudgetStop,
 )
+from opencollab.application._session_run_usage import _normalize_completion_usage
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
 from opencollab.application.ports import (
     EventPublisherPort,
@@ -54,31 +55,6 @@ __all__ = [
     "_WIND_DOWN_NUDGE",
     "_WIND_DOWN_RETRY",
 ]
-
-
-def _nonnegative_usage_int(value: Any, field: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise ValueError(f"provider usage {field} must be a non-negative integer")
-    return value
-
-
-def _normalize_completion_usage(usage: Any) -> tuple[int, int]:
-    """Validate provider counters atomically and prevent total undercharging."""
-    input_tokens = _nonnegative_usage_int(
-        getattr(usage, "input_tokens", None),
-        "input_tokens",
-    )
-    reported_total = _nonnegative_usage_int(
-        getattr(usage, "total_tokens", None),
-        "total_tokens",
-    )
-    raw_output = getattr(usage, "output_tokens", None)
-    output_tokens = (
-        max(0, reported_total - input_tokens)
-        if raw_output is None
-        else _nonnegative_usage_int(raw_output, "output_tokens")
-    )
-    return input_tokens, max(reported_total, input_tokens + output_tokens)
 
 
 class SessionRunUseCase(_SessionRunCompletionMixin):

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -227,13 +227,29 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         except BaseException:
             pass
 
-    def _record_late_provider_result(self, task: asyncio.Future[Any]) -> None:
+    def _mark_budget_reserve_consumed(self, *, protected_call: bool | None = None) -> None:
+        """Keep late and ordinary protected-call accounting on one invariant."""
+        if protected_call is None:
+            protected_call = self.state.wind_down_done
+        if (
+            protected_call
+            and self.state.used_tokens >= self.max_budget_tokens - self._commit_reserve
+        ):
+            self.state.budget_reserve_consumed = True
+
+    def _record_late_provider_result(
+        self,
+        task: asyncio.Future[Any],
+        *,
+        protected_call: bool = False,
+    ) -> None:
         """Charge a provider response that survived cancellation after timeout."""
         try:
             response = task.result()
             _input_tokens, total_tokens = _normalize_completion_usage(response.usage)
             self._late_provider_usage += (total_tokens,)
             self.state.add_used_tokens(total_tokens)
+            self._mark_budget_reserve_consumed(protected_call=protected_call)
         except BaseException:
             pass
         finally:
@@ -582,11 +598,7 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         latency = time.monotonic() - start
         input_tokens, total_tokens = _normalize_completion_usage(response.usage)
         self.state.add_used_tokens(total_tokens)
-        if (
-            self.state.wind_down_done
-            and self.state.used_tokens >= self.max_budget_tokens - self._commit_reserve
-        ):
-            self.state.budget_reserve_consumed = True
+        self._mark_budget_reserve_consumed()
         self.state.add_markup_recovered(getattr(response.usage, "markup_recovered", 0))
         self.state.set_context_tokens(input_tokens)
 

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -496,8 +496,15 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         brake = budget_spent or watchdog_tripped or low_yield_tripped
         if not brake or not self.state.pending_events.is_empty():
             return False
+        if budget_spent and self.state.budget_reserve_consumed:
+            await self._stop_precheck(
+                "budget reserve exhausted: protected commit turn already used"
+            )
+            return True
 
         self._trace_brake_trip(budget_spent, watchdog_tripped, low_yield_tripped)
+        if budget_spent:
+            self.state.budget_reserve_consumed = True
         self._enter_wind_down()
         self.state.transition_to(SessionPhase.CALLING_LLM)
         return True
@@ -575,6 +582,11 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         latency = time.monotonic() - start
         input_tokens, total_tokens = _normalize_completion_usage(response.usage)
         self.state.add_used_tokens(total_tokens)
+        if (
+            self.state.wind_down_done
+            and self.state.used_tokens >= self.max_budget_tokens - self._commit_reserve
+        ):
+            self.state.budget_reserve_consumed = True
         self.state.add_markup_recovered(getattr(response.usage, "markup_recovered", 0))
         self.state.set_context_tokens(input_tokens)
 

--- a/opencollab/domain/events.py
+++ b/opencollab/domain/events.py
@@ -36,6 +36,7 @@ SessionEventType = Literal[
     "step_end",
     "loop_detected",
     "budget_warning",
+    "budget_reserve_allocated",
     "error",
     "user_message_appended",
 ]

--- a/opencollab/domain/session.py
+++ b/opencollab/domain/session.py
@@ -210,6 +210,10 @@ class SessionState:
     # durable so a restore cannot re-grant the one compatibility retry.
     wind_down_attempts: int = 0
     wind_down_token_mark: int = 0
+    # Session-lifetime latch for the protected call carved from the hard token
+    # budget. Per-turn watchdog/low-yield wind-down state resets between user
+    # turns, but the same lifetime reserve must never be allocated twice.
+    budget_reserve_consumed: bool = field(default=False, kw_only=True)
     phase: SessionPhase = SessionPhase.IDLE
     # Human-readable detail for the current terminal phase (e.g. the exception
     # for ERROR, the token/step counts for the resource caps). ``None`` while
@@ -448,7 +452,8 @@ class SessionState:
         intentionally preserved — both ``max_steps`` and ``max_budget_tokens``
         are session-lifetime caps, so a long-lived interactive/messaged session
         keeps accumulating across turns rather than getting a fresh allowance.
-        Durable wind-down latches are current-turn state and reset here.
+        Durable wind-down latches are current-turn state and reset here. The
+        session-lifetime budget-reserve latch is intentionally preserved.
         """
         self.resume_to_idle()
         self.turn = TurnEnforcementState()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencollab"
-version = "0.4.1"
+version = "0.5.0"
 description = "Minimal multi-agent software development framework for explicit team and workflow orchestration."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -24,7 +24,7 @@ from opencollab.workflows import WorkflowContext
 
 def test_root_and_sdk_export_one_small_surface() -> None:
     expected = ["OpenCollab", "RunError", "RunResult", "workflow"]
-    assert opencollab.__version__ == "0.4.1"
+    assert opencollab.__version__ == "0.5.0"
     assert opencollab.__all__ == expected
     assert sdk.__all__ == expected
     assert all(getattr(opencollab, name) is getattr(sdk, name) for name in expected)

--- a/tests/test_session_characterization_runtime.py
+++ b/tests/test_session_characterization_runtime.py
@@ -173,8 +173,9 @@ def test_save_and_load_round_trip_restores_control_flow_latches(tmp_path):
     state.turn.seen_result_hashes = {"content-hash", "call-hash"}
     state.turn.scout_ledger = [{"tool": "grep", "outcome": "hit"}]
     state.turn.steps_since_progress = 2
-    state.wind_down_done = True
+    state.wind_down_done = False
     state.wind_down_token_mark = 123
+    state.budget_reserve_consumed = True
     state.turn.loop_blocked_since_progress = 2
     path = tmp_path / "control-state.json"
 
@@ -189,8 +190,9 @@ def test_save_and_load_round_trip_restores_control_flow_latches(tmp_path):
     assert restored.turn.seen_result_hashes == {"content-hash", "call-hash"}
     assert restored.turn.scout_ledger == [{"tool": "grep", "outcome": "hit"}]
     assert restored.turn.steps_since_progress == 2
-    assert restored.wind_down_done is True
+    assert restored.wind_down_done is False
     assert restored.wind_down_token_mark == 123
+    assert restored.budget_reserve_consumed is True
     assert restored.turn.loop_blocked_since_progress == 2
 
 def test_checkpoint_and_restore_user_turn_roll_back_per_turn_enforcement():
@@ -215,8 +217,10 @@ def test_checkpoint_and_restore_user_turn_roll_back_per_turn_enforcement():
         "content": "retry after restore",
         "message_index": 1,
     }
-    # The durable current-turn latch is part of the user-turn transaction.
+    # The wind-down latch is part of the current-turn transaction; the budget
+    # reserve is session-lifetime state and must survive a rollback.
     state.wind_down_done = True
+    state.budget_reserve_consumed = False
 
     checkpoint = state.checkpoint_user_turn()
 
@@ -230,6 +234,7 @@ def test_checkpoint_and_restore_user_turn_roll_back_per_turn_enforcement():
     state.turn.loop_blocked_since_progress = 99
     state.pending_external_user_turn = None
     state.wind_down_done = False
+    state.budget_reserve_consumed = True
 
     state.restore_user_turn(checkpoint)
 
@@ -247,8 +252,10 @@ def test_checkpoint_and_restore_user_turn_roll_back_per_turn_enforcement():
         "content": "retry after restore",
         "message_index": 1,
     }
-    # Rollback restores the prior turn's latch along with its counters.
+    # Rollback restores the prior turn's latch while retaining the lifetime
+    # budget reserve consumption.
     assert state.wind_down_done is True
+    assert state.budget_reserve_consumed is True
 
     # The checkpoint is an independent snapshot: mutating restored state and
     # restoring a second time still yields the checkpoint values.

--- a/tests/test_session_run_loop_limits.py
+++ b/tests/test_session_run_loop_limits.py
@@ -21,6 +21,7 @@ from session_run_loop_test_support import (
 )
 
 from opencollab.application.session_run import (
+    ENFORCEMENT_ON,
     GenerationTimeoutError,
 )
 from opencollab.application.steering import READS_NUDGE_HARD
@@ -268,6 +269,33 @@ def test_timeout_quarantines_late_success_and_records_its_usage():
                 await asyncio.sleep(0)
 
     run(scenario())
+
+
+def test_late_protected_provider_usage_consumes_budget_reserve():
+    async def scenario():
+        state = SessionState(
+            messages=[],
+            used_tokens=79,
+            wind_down_done=True,
+        )
+        runner = build_runner(
+            state=state,
+            llm=SlowLLM(llm_response(content="unused"), 0),
+            max_budget_tokens=100,
+            commit_reserve=20,
+            enforcement_strength=ENFORCEMENT_ON,
+        )
+        late = asyncio.get_running_loop().create_future()
+        late.set_result(llm_response(content="late", total_tokens=5))
+
+        # The provider call was protected before the caller reset the turn.
+        runner._record_late_provider_result(late, protected_call=True)
+
+        assert state.used_tokens == 84
+        assert state.budget_reserve_consumed is True
+
+    run(scenario())
+
 
 def test_provider_timeout_is_not_relabelled_as_generation_ceiling():
 

--- a/tests/test_session_wind_down.py
+++ b/tests/test_session_wind_down.py
@@ -167,6 +167,36 @@ def test_hard_budget_preempts_new_turn_wind_down(
     assert state.wind_down_done is False
 
 
+def test_budget_wind_down_is_not_regranted_on_a_new_user_turn():
+    state = SessionState(
+        messages=[{"role": "user", "content": "first"}],
+        used_tokens=80,
+    )
+    llm = FakeLLM([llm_response(content="first protected answer", total_tokens=5)])
+    runner = build_runner(
+        state=state,
+        agent=_agent_with_submit(),
+        llm=llm,
+        max_budget_tokens=100,
+        enforcement_strength=ENFORCEMENT_ON,
+        commit_reserve=20,
+    )
+
+    run(runner.run_loop())
+    assert len(llm.calls) == 1
+    assert state.used_tokens == 85
+
+    state.reset_for_user_turn()
+    runner.reset_runtime_for_user_turn()
+    state.append_message({"role": "user", "content": "again"})
+
+    run(runner.run_loop())
+
+    assert len(llm.calls) == 1
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason == "budget reserve exhausted: protected commit turn already used"
+
+
 # --------------------------------------------------------------------------- #
 # T2 — WIND-DOWN BEHAVIOR.
 # --------------------------------------------------------------------------- #
@@ -327,6 +357,7 @@ def test_legacy_wind_down_snapshot_without_attempts_stops_conservatively(tmp_pat
     session.save(str(path))
     snapshot = json.loads(path.read_text())
     del snapshot["session_state"]["wind_down_attempts"]
+    del snapshot["session_state"]["budget_reserve_consumed"]
     path.write_text(json.dumps(snapshot))
 
     restored_llm = FakeLLM()
@@ -339,6 +370,7 @@ def test_legacy_wind_down_snapshot_without_attempts_stops_conservatively(tmp_pat
     run(restored.run_loop())
 
     assert restored.state.wind_down_attempts == 2
+    assert restored.state.budget_reserve_consumed is True
     assert restored_llm.calls == []
 
 
@@ -349,6 +381,7 @@ def test_t2_winddown_not_entered_while_a_tool_result_is_pending():
     from opencollab.domain.pending import PendingRow, RowKind, RowStatus
 
     state = SessionState(messages=[{"role": "user", "content": "x"}], used_tokens=80_000)
+    state.budget_reserve_consumed = True
     state.pending_events.add(
         PendingRow(tool_call_id="t1", kind=RowKind.CHILD_AGENT, order=0, status=RowStatus.PENDING)
     )

--- a/tests/test_session_wind_down.py
+++ b/tests/test_session_wind_down.py
@@ -242,6 +242,28 @@ def test_t2_winddown_forces_tool_choice_and_commits_in_one_turn():
     assert state.phase.is_terminal()
 
 
+def test_budget_wind_down_persists_allocation_before_provider_call():
+    events, bus = collect_events()
+    state = SessionState(
+        messages=[{"role": "user", "content": "investigate"}],
+        used_tokens=80_000,
+    )
+    runner = build_runner(
+        state=state,
+        agent=_agent_with_submit(),
+        llm=FakeLLM([llm_response(content="done")]),
+        event_bus=bus,
+        max_budget_tokens=100_000,
+        commit_reserve=20_000,
+        enforcement_strength=ENFORCEMENT_ON,
+    )
+
+    run(runner.run_loop())
+
+    assert state.budget_reserve_consumed is True
+    assert any(event_type == "budget_reserve_allocated" for event_type, _ in events)
+
+
 def test_t2_winddown_retries_once_on_wrong_tool_then_commits_forced():
     # Provider IGNORES the forced tool_choice (DashScope 400->auto): turn 1 calls a
     # now-unknown tool. FIX #2: one retry is issued (not terminated), and on the

--- a/tests/test_session_wind_down.py
+++ b/tests/test_session_wind_down.py
@@ -170,21 +170,21 @@ def test_hard_budget_preempts_new_turn_wind_down(
 def test_budget_wind_down_is_not_regranted_on_a_new_user_turn():
     state = SessionState(
         messages=[{"role": "user", "content": "first"}],
-        used_tokens=80,
+        used_tokens=80_000,
     )
     llm = FakeLLM([llm_response(content="first protected answer", total_tokens=5)])
     runner = build_runner(
         state=state,
         agent=_agent_with_submit(),
         llm=llm,
-        max_budget_tokens=100,
+        max_budget_tokens=100_000,
         enforcement_strength=ENFORCEMENT_ON,
-        commit_reserve=20,
+        commit_reserve=25_000,
     )
 
     run(runner.run_loop())
     assert len(llm.calls) == 1
-    assert state.used_tokens == 85
+    assert state.used_tokens == 80_005
 
     state.reset_for_user_turn()
     runner.reset_runtime_for_user_turn()

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "opencollab"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
This replacement preserves the release and budget-lifecycle layer from PR #58 while targeting main directly.\n\nThe layer finalizes the 0.5.0 migration contract, makes protected budget reserve allocation durable across a session lifetime, accounts for late provider usage, and keeps the bounded security history scan viable.\n\nThe current branch is a cumulative direct-to-main prefix and should be merged after PR #57. After each preceding layer is merged, this branch will be rebased onto the latest main so GitHub presents only the remaining layer changes.\n\nValidation completed on commit 48946e4550ba3901e5d148de41f6e663b81c12cc. Ruff, diff hygiene, added-file checks, focused pending-tool behavior tests, and the complete test suite passed. The complete suite result was 2181 passed.
