### PR TITLE
fix(runtime): preserve reviewed failure and restore contracts

### DIFF
--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -297,7 +297,7 @@ async def _repl_loop(tui: Any, handle_turn, lead: Any, bottom_toolbar: Any = Non
             result = await handle_turn(line, target_aid)
         except SchedulerTurnError as exc:
             if exc.partial_answer:
-                console.print(exc.partial_answer)
+                console.print(Text(exc.partial_answer))
             reason = exc.terminal_reason or exc.phase.value
             style = "yellow" if exc.phase.value == "stopped" else "red"
             console.print(

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -44,6 +44,7 @@ from opencollab.adapters.safe_files import read_regular_text
 from opencollab.adapters.tui.theme import BRAND_VIOLET
 from opencollab.application.async_timeout import run_with_bounded_shutdown
 from opencollab.application.exception_notes import add_exception_note
+from opencollab.application.scheduler_types import SchedulerTurnError
 
 app = typer.Typer(
     name="opencollab",
@@ -292,7 +293,21 @@ async def _repl_loop(tui: Any, handle_turn, lead: Any, bottom_toolbar: Any = Non
         except KeyError:
             pass
         target_aid = tui.selected_aid
-        result = await handle_turn(line, target_aid)
+        try:
+            result = await handle_turn(line, target_aid)
+        except SchedulerTurnError as exc:
+            if exc.partial_answer:
+                console.print(exc.partial_answer)
+            reason = exc.terminal_reason or exc.phase.value
+            style = "yellow" if exc.phase.value == "stopped" else "red"
+            console.print(
+                Text(
+                    f"Agent {exc.aid} {exc.phase.value}: {reason}",
+                    style=style,
+                )
+            )
+            tui.print_turn_divider()
+            continue
         if result is False:
             break
         tui.print_turn_divider()

--- a/opencollab/application/schema_validate.py
+++ b/opencollab/application/schema_validate.py
@@ -41,11 +41,9 @@ _TYPE_CHECKS = {
     "null": lambda v: v is None,
 }
 
-_SUPPORTED_KEYWORDS = frozenset({
+_VALIDATION_KEYWORDS = frozenset({
     "additionalProperties",
-    "description",
     "enum",
-    "examples",
     "items",
     "maxItems",
     "maxLength",
@@ -57,9 +55,21 @@ _SUPPORTED_KEYWORDS = frozenset({
     "pattern",
     "properties",
     "required",
-    "title",
     "type",
 })
+
+_ANNOTATION_KEYWORDS = frozenset({
+    "default",
+    "deprecated",
+    "description",
+    "examples",
+    "format",
+    "readOnly",
+    "title",
+    "writeOnly",
+})
+
+_SUPPORTED_KEYWORDS = _VALIDATION_KEYWORDS | _ANNOTATION_KEYWORDS | {"$schema"}
 
 
 def validate_schema(schema: Any) -> list[str]:
@@ -86,9 +96,14 @@ def _validate_schema(schema: Any, path: str, errors: list[str]) -> None:
     if not isinstance(schema, dict):
         errors.append(f"{path}: schema node must be an object")
         return
-    for keyword in schema:
+    for keyword, keyword_value in schema.items():
         if keyword not in _SUPPORTED_KEYWORDS:
             errors.append(f"{path}.{keyword}: unsupported schema keyword")
+        elif keyword == "$schema":
+            if path != "$schema":
+                errors.append(f"{path}.$schema: dialect declaration is only allowed at the root")
+            elif not isinstance(keyword_value, str) or not keyword_value.strip():
+                errors.append(f"{path}.$schema: dialect declaration must be a non-empty string")
     expected_type = schema.get("type")
     if expected_type is not None:
         members = (

--- a/opencollab/application/session.py
+++ b/opencollab/application/session.py
@@ -393,6 +393,8 @@ class Session:
 
     def restore(self, path: str) -> None:
         """Restore a complete snapshot while accepting legacy message-only stores."""
+        if self._turn_lock.locked() or self.pending_cleanup_tasks:
+            raise SessionBusyError("session cannot be restored while runtime work is active")
         if isinstance(self.store, SnapshotStorePort):
             snapshot = self.store.load_snapshot(path, self.agent.system_prompt)
         else:
@@ -559,6 +561,7 @@ class Session:
 
     def _publish_restored_state(self, restored: SessionState) -> None:
         """Publish one fully validated restore while retaining shared identity."""
+        self.runner.reset_for_restore()
         self.state.__dict__.clear()
         self.state.__dict__.update(restored.__dict__)
 

--- a/opencollab/application/session.py
+++ b/opencollab/application/session.py
@@ -503,6 +503,11 @@ class Session:
         phase = _restore_phase(raw_state.get("phase", SessionPhase.IDLE.value))
         if phase is SessionPhase.AWAITING_EVENTS:
             self._complete_missing_pending_rows(restored)
+            if restored_turn_start is None:
+                # Legacy and malformed snapshots may not carry a valid answer
+                # cursor. Future messages begin at the restored transcript end,
+                # which excludes prior answers while retaining the resumed one.
+                restored_turn_start = len(restored.messages)
         # In-flight provider/tool phases depend on process-local coroutines that
         # cannot survive restart. AWAITING_EVENTS is recoverable because pending
         # child rows above are converted to explicit FAILED tool results.

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -178,6 +178,16 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         self._pending_tool_allowlist = None
         self._pending_tool_gate_label = None
 
+    def reset_for_restore(self) -> None:
+        """Discard process-local turn state before publishing a snapshot."""
+        self.reset_runtime_for_user_turn()
+        self._pending = None
+        self._empty_stop_retried = False
+        self._last_steering_level = None
+        self._turn_start_message_index = None
+        self._llm_step_started = False
+        self._late_provider_usage = ()
+
     @property
     def pending_cleanup_tasks(self) -> tuple[asyncio.Task[Any], ...]:
         return tuple(
@@ -265,8 +275,7 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         if entry_phase is SessionPhase.IDLE:
             self.state.consume_queued_external_user_turn()
         if entry_phase is SessionPhase.AWAITING_EVENTS:
-            if self._turn_start_message_index is None:
-                self._turn_start_message_index = self.state.active_turn_start_message_index
+            self._turn_start_message_index = self.state.active_turn_start_message_index
         elif entry_phase is SessionPhase.DONE:
             # Re-entering an already-completed session is a compatibility
             # read-only query for its final answer, not a restored active turn.

--- a/opencollab/bootstrap/programmatic_team.py
+++ b/opencollab/bootstrap/programmatic_team.py
@@ -14,6 +14,7 @@ from typing import Any, Literal
 
 from opencollab.adapters.trace import Tracer
 from opencollab.application.exception_notes import add_exception_note
+from opencollab.application.scheduler_types import SchedulerTurnError
 from opencollab.bootstrap import programmatic as _programmatic
 from opencollab.bootstrap.programmatic import (
     DEFAULT_TEAM_CLEANUP_TIMEOUT_SECONDS,
@@ -22,6 +23,7 @@ from opencollab.bootstrap.programmatic import (
 )
 from opencollab.bootstrap.runtime_context import build_runtime_context
 from opencollab.bootstrap.team_config import load_team_config
+from opencollab.domain.session import SessionPhase
 
 
 async def run_team(
@@ -82,6 +84,15 @@ async def run_team(
         except TimeoutError as exc:
             status = "stopped"
             reason = "timeout"
+            failure = exc
+        except SchedulerTurnError as exc:
+            output = exc.partial_answer
+            status = (
+                "stopped"
+                if exc.phase is SessionPhase.STOPPED
+                else "failed"
+            )
+            reason = exc.terminal_reason or exc.phase.value
             failure = exc
         except asyncio.CancelledError as exc:
             cancellation = exc

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import fcntl
+import io
 import os
 import struct
 import termios
@@ -15,6 +16,7 @@ from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.output.vt100 import Vt100_Output
+from rich.console import Console
 
 from opencollab.adapters.cli import main as cli_main
 from opencollab.adapters.cli.prompt_view import (
@@ -362,3 +364,39 @@ async def test_repl_reports_stopped_turn_and_accepts_next_input(monkeypatch):
         "Agent 2 stopped: token budget exhausted",
     ]
     assert len(dividers) == 2
+
+
+@pytest.mark.asyncio
+async def test_repl_prints_partial_answer_as_literal_rich_text(monkeypatch):
+    tui = _FakeTUI()
+    lines = iter(["first", "second", None])
+    monkeypatch.setattr(
+        cli_main,
+        "_read_command",
+        lambda *_args, **_kwargs: asyncio.sleep(0, result=next(lines)),
+    )
+    output = io.StringIO()
+    monkeypatch.setattr(
+        cli_main,
+        "console",
+        Console(file=output, force_terminal=False, color_system=None),
+    )
+    calls: list[str] = []
+
+    async def handle_turn(line: str, _aid: int) -> None:
+        calls.append(line)
+        if line == "first":
+            raise SchedulerTurnError(
+                0,
+                SessionPhase.STOPPED,
+                "token budget exhausted",
+                "Here is malformed rich: [bold]x[/red]",
+            )
+
+    tui.print_turn_divider = lambda: None
+
+    await cli_main._repl_loop(tui, handle_turn, object())
+
+    assert calls == ["first", "second"]
+    assert "Here is malformed rich: [bold]x[/red]" in output.getvalue()
+    assert "Agent 0 stopped: token budget exhausted" in output.getvalue()

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -21,6 +21,8 @@ from opencollab.adapters.cli.prompt_view import (
     build_agent_navigation_bindings,
     build_agent_prompt,
 )
+from opencollab.application.scheduler_types import SchedulerTurnError
+from opencollab.domain.session import SessionPhase
 
 
 class _FakeTUI:
@@ -319,3 +321,44 @@ async def test_repl_routes_input_to_selected_agent(monkeypatch):
     await cli_main._repl_loop(tui, handle_turn, object())
 
     assert calls == [(2, "message selected agent")]
+
+
+@pytest.mark.asyncio
+async def test_repl_reports_stopped_turn_and_accepts_next_input(monkeypatch):
+    tui = _FakeTUI()
+    tui.selected_aid = 2
+    lines = iter(["first", "second", None])
+    monkeypatch.setattr(
+        cli_main,
+        "_read_command",
+        lambda *_args, **_kwargs: asyncio.sleep(0, result=next(lines)),
+    )
+    printed: list[str] = []
+    monkeypatch.setattr(
+        cli_main,
+        "console",
+        SimpleNamespace(print=lambda value: printed.append(str(value))),
+    )
+    calls: list[tuple[int, str]] = []
+
+    async def handle_turn(line: str, aid: int) -> None:
+        calls.append((aid, line))
+        if line == "first":
+            raise SchedulerTurnError(
+                aid,
+                SessionPhase.STOPPED,
+                "token budget exhausted",
+                "partial answer",
+            )
+
+    dividers: list[None] = []
+    tui.print_turn_divider = lambda: dividers.append(None)
+
+    await cli_main._repl_loop(tui, handle_turn, object())
+
+    assert calls == [(2, "first"), (2, "second")]
+    assert printed == [
+        "partial answer",
+        "Agent 2 stopped: token budget exhausted",
+    ]
+    assert len(dividers) == 2

--- a/tests/test_schema_annotation_execution.py
+++ b/tests/test_schema_annotation_execution.py
@@ -1,0 +1,109 @@
+"""Execution coverage for accepted JSON Schema annotations."""
+
+import asyncio
+
+import pytest
+from tool_execution_test_support import FakeAgent, RecordingEventPublisher
+
+from opencollab.application.events import default_session_event_factory
+from opencollab.application.tool_execution import ToolExecutionUseCase
+from opencollab.domain.session import SessionState
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def tool_call(
+    *,
+    arguments: str = "{}",
+    call_id: str = "call-1",
+) -> dict:
+    return {
+        "id": call_id,
+        "function": {
+            "name": "fake_tool",
+            "arguments": arguments,
+        },
+    }
+
+
+class RuntimeNativeTool:
+    name = "fake_tool"
+
+    def __init__(self) -> None:
+        self.runtime_calls = []
+
+    async def execute_with_runtime(self, args, runtime):
+        self.runtime_calls.append((args, runtime))
+        return "runtime result"
+
+
+def build_use_case(tool: RuntimeNativeTool) -> ToolExecutionUseCase:
+    return ToolExecutionUseCase(
+        agent=FakeAgent(tools=[tool]),
+        environment=None,
+        state=SessionState(messages=[]),
+        event_publisher=RecordingEventPublisher(),
+        event_factory=default_session_event_factory(aid=-1),
+    )
+
+
+def test_declared_schema_annotations_allow_single_and_batch_execution():
+    tool = RuntimeNativeTool()
+    tool.parameters = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "Third-party tool",
+        "description": "Schema annotations should remain compatible",
+        "required": ["value"],
+        "properties": {
+            "value": {
+                "type": "string",
+                "default": "fallback",
+                "examples": ["first", "second"],
+                "format": "hostname",
+                "deprecated": False,
+                "readOnly": False,
+                "writeOnly": False,
+            }
+        },
+    }
+    use_case = build_use_case(tool)
+
+    result = run(use_case.process([
+        tool_call(arguments='{"value": "one"}', call_id="call-1"),
+        tool_call(arguments='{"value": "two"}', call_id="call-2"),
+    ]))
+
+    assert [call[0] for call in tool.runtime_calls] == [
+        {"value": "one"},
+        {"value": "two"},
+    ]
+    assert [message["content"] for message in result.messages_to_append] == [
+        "runtime result",
+        "runtime result",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("anyOf", [{"type": "string"}]),
+        ("allOf", [{"type": "string"}]),
+        ("const", "fixed"),
+        ("$ref", "#/$defs/value"),
+        ("nullable", True),
+    ],
+)
+def test_unimplemented_schema_semantics_still_block_execution(keyword, value):
+    tool = RuntimeNativeTool()
+    tool.parameters = {"type": "object", keyword: value}
+    use_case = build_use_case(tool)
+
+    result = run(use_case.process([tool_call()]))
+
+    assert tool.runtime_calls == []
+    assert f"{keyword}: unsupported schema keyword" in (
+        result.messages_to_append[0]["content"]
+    )

--- a/tests/test_sdk_team_runtime.py
+++ b/tests/test_sdk_team_runtime.py
@@ -14,6 +14,9 @@ from test_sdk_runtime import (
     sdk_client,
 )
 
+from opencollab.application.scheduler_types import SchedulerTurnError
+from opencollab.domain.session import SessionPhase
+
 
 async def test_team_config_preflight_does_not_claim_artifact_directory(
     tmp_path: Path,
@@ -131,6 +134,85 @@ async def test_shared_team_runtime_always_cleans_scheduler(
     assert result.status == "completed"
     assert result.tokens == 8
     assert result.metrics == {"steps": 2, "sessions": 1}
+
+
+@pytest.mark.parametrize(
+    ("phase", "terminal_reason", "partial_answer", "expected_status", "expected_reason"),
+    [
+        (
+            SessionPhase.STOPPED,
+            "token budget exhausted",
+            "partial answer",
+            "stopped",
+            "token budget exhausted",
+        ),
+        (
+            SessionPhase.ERROR,
+            "provider failed",
+            "partial answer",
+            "failed",
+            "provider failed",
+        ),
+        (SessionPhase.STOPPED, None, None, "stopped", "stopped"),
+    ],
+)
+async def test_team_result_preserves_scheduler_turn_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    phase: SessionPhase,
+    terminal_reason: str | None,
+    partial_answer: str | None,
+    expected_status: str,
+    expected_reason: str,
+) -> None:
+    turn_error = SchedulerTurnError(
+        0,
+        phase,
+        terminal_reason,
+        partial_answer,
+    )
+
+    class FakeScheduler:
+        cleaned = False
+        used_tokens = 8
+        table = SimpleNamespace(entries={0: object()})
+        lead_session = SimpleNamespace(
+            phase=phase,
+            state=SimpleNamespace(terminal_reason=terminal_reason),
+            step_count=2,
+        )
+
+        async def run(self, _prompt: str) -> str:
+            raise turn_error
+
+        async def cleanup(self, *, cleanup_timeout: float) -> None:
+            assert cleanup_timeout > 0
+            self.cleaned = True
+
+    scheduler = FakeScheduler()
+    monkeypatch.setattr(
+        programmatic,
+        "build_scheduler",
+        lambda *_args, **_kwargs: scheduler,
+    )
+
+    result = await programmatic.run_team(
+        prompt="solve",
+        config={"model": "model", "provider": "openai", "budget": 50},
+        workspace=str(tmp_path),
+        team_config_path=None,
+        max_tokens=50,
+        timeout=None,
+        artifacts=None,
+        trace=False,
+        use_worktrees=False,
+    )
+
+    assert scheduler.cleaned is True
+    assert result.status == expected_status
+    assert result.output == partial_answer
+    assert result.reason == expected_reason
+    assert result.error is turn_error
 
 
 async def test_team_result_exposes_sanitized_child_failures(

--- a/tests/test_session_characterization_restore.py
+++ b/tests/test_session_characterization_restore.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
+from types import SimpleNamespace
 
 import pytest
 from session_characterization_test_support import (
@@ -18,6 +19,7 @@ from session_characterization_test_support import (
 from opencollab.adapters.storage import SessionStore
 from opencollab.application.event_bus import EventBus
 from opencollab.application.scheduler_types import LaunchSpec
+from opencollab.application.session import SessionBusyError
 from opencollab.bootstrap import build_session as Session
 from opencollab.bootstrap import load_session
 from opencollab.domain.pending import PendingRow, PendingRowError, RowKind, RowStatus
@@ -344,6 +346,147 @@ def test_restore_awaiting_turn_never_returns_previous_turn_answer(tmp_path):
     assert restored.state.phase is SessionPhase.AWAITING_EVENTS
     assert restored.state.active_turn_start_message_index == 4
     assert run(restored.run_loop()) == ""
+
+
+def test_restore_reused_session_resets_live_turn_cursor(tmp_path):
+    baseline_tool = SimpleNamespace(
+        to_openai_schema=lambda: {
+            "type": "function",
+            "function": {"name": "baseline", "parameters": {}},
+        }
+    )
+    agent = FakeAgent(tools=[baseline_tool])
+    snapshot_source = Session(agent=agent, llm=FakeLLMClient(), max_steps=1)
+    snapshot_source.state.replace_messages([
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "OLD SNAPSHOT ANSWER"},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "child-current",
+                "type": "function",
+                "function": {"name": "spawn_agent", "arguments": "{}"},
+            }],
+        },
+    ])
+    snapshot_source.state.set_step_count(1)
+    snapshot_source.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    snapshot_source.state.active_turn_start_message_index = 4
+    snapshot_source.state.pending_events.add(PendingRow(
+        tool_call_id="child-current",
+        kind=RowKind.CHILD_AGENT,
+        order=0,
+        ref=1,
+        status=RowStatus.PENDING,
+    ))
+    path = tmp_path / "reused-awaiting-cursor.json"
+    snapshot_source.save(str(path))
+
+    llm = FakeLLMClient([llm_response(content="prior live answer")])
+    reused = Session(agent=agent, llm=llm, max_steps=1)
+    run(reused.add_user_message("prior live question"))
+    assert run(reused.run_loop()) == "prior live answer"
+    assert reused.runner._turn_start_message_index is not None
+    reused.agent.tools = []
+    reused.agent.tool_choice = {
+        "type": "function",
+        "function": {"name": "stale"},
+    }
+
+    reused.restore(str(path))
+
+    assert reused.state.active_turn_start_message_index == 4
+    assert reused.runner._turn_start_message_index is None
+    assert reused.agent.tools == [baseline_tool]
+    assert reused.agent.tool_choice is None
+    assert run(reused.run_loop()) == ""
+    assert reused.state.phase is SessionPhase.STOPPED
+    assert len(llm.calls) == 1
+
+
+def test_restore_reused_session_rearms_empty_response_retry(tmp_path):
+    agent = FakeAgent()
+    snapshot_source = Session(agent=agent, llm=FakeLLMClient())
+    snapshot_source.state.replace_messages([
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "child-current",
+                "type": "function",
+                "function": {"name": "spawn_agent", "arguments": "{}"},
+            }],
+        },
+    ])
+    snapshot_source.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    snapshot_source.state.active_turn_start_message_index = 1
+    snapshot_source.state.pending_events.add(PendingRow(
+        tool_call_id="child-current",
+        kind=RowKind.CHILD_AGENT,
+        order=0,
+        ref=1,
+        status=RowStatus.DONE,
+        result="child result",
+    ))
+    path = tmp_path / "reused-empty-retry.json"
+    snapshot_source.save(str(path))
+
+    llm = FakeLLMClient([
+        llm_response(content=None),
+        llm_response(content="prior recovered"),
+        llm_response(content=None),
+        llm_response(content="restored recovered"),
+    ])
+    reused = Session(agent=agent, llm=llm)
+    run(reused.add_user_message("prior question"))
+    assert run(reused.run_loop()) == "prior recovered"
+    assert reused.runner._empty_stop_retried is True
+
+    reused.restore(str(path))
+
+    assert reused.runner._empty_stop_retried is False
+    assert run(reused.run_loop()) == "restored recovered"
+    assert len(llm.calls) == 4
+
+
+def test_restore_rejects_a_session_with_an_active_turn(tmp_path):
+    agent = FakeAgent()
+    source = Session(agent=agent, llm=FakeLLMClient())
+    path = tmp_path / "busy-restore.json"
+    source.save(str(path))
+
+    session = Session(agent=agent, llm=FakeLLMClient())
+    run(session._turn_lock.acquire())
+    try:
+        with pytest.raises(SessionBusyError, match="runtime work is active"):
+            session.restore(str(path))
+    finally:
+        session._turn_lock.release()
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_pending_runtime_cleanup(tmp_path):
+    agent = FakeAgent()
+    source = Session(agent=agent, llm=FakeLLMClient())
+    path = tmp_path / "cleanup-restore.json"
+    source.save(str(path))
+
+    session = Session(agent=agent, llm=FakeLLMClient())
+    blocker = asyncio.Event()
+    cleanup_task = asyncio.create_task(blocker.wait())
+    session.tool_execution._pending_cleanup_tasks.add(cleanup_task)
+    try:
+        with pytest.raises(SessionBusyError, match="runtime work is active"):
+            session.restore(str(path))
+    finally:
+        cleanup_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cleanup_task
 
 def test_scheduler_init_preserves_and_drains_restored_awaiting_phase(tmp_path):
     from opencollab.application.scheduler import LaunchSpec, Scheduler

--- a/tests/test_session_characterization_restore.py
+++ b/tests/test_session_characterization_restore.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
-from types import SimpleNamespace
 
 import pytest
 from session_characterization_test_support import (
@@ -19,7 +18,6 @@ from session_characterization_test_support import (
 from opencollab.adapters.storage import SessionStore
 from opencollab.application.event_bus import EventBus
 from opencollab.application.scheduler_types import LaunchSpec
-from opencollab.application.session import SessionBusyError
 from opencollab.bootstrap import build_session as Session
 from opencollab.bootstrap import load_session
 from opencollab.domain.pending import PendingRow, PendingRowError, RowKind, RowStatus
@@ -347,146 +345,6 @@ def test_restore_awaiting_turn_never_returns_previous_turn_answer(tmp_path):
     assert restored.state.active_turn_start_message_index == 4
     assert run(restored.run_loop()) == ""
 
-
-def test_restore_reused_session_resets_live_turn_cursor(tmp_path):
-    baseline_tool = SimpleNamespace(
-        to_openai_schema=lambda: {
-            "type": "function",
-            "function": {"name": "baseline", "parameters": {}},
-        }
-    )
-    agent = FakeAgent(tools=[baseline_tool])
-    snapshot_source = Session(agent=agent, llm=FakeLLMClient(), max_steps=1)
-    snapshot_source.state.replace_messages([
-        {"role": "system", "content": "sys"},
-        {"role": "user", "content": "old question"},
-        {"role": "assistant", "content": "OLD SNAPSHOT ANSWER"},
-        {"role": "user", "content": "current question"},
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [{
-                "id": "child-current",
-                "type": "function",
-                "function": {"name": "spawn_agent", "arguments": "{}"},
-            }],
-        },
-    ])
-    snapshot_source.state.set_step_count(1)
-    snapshot_source.state.set_phase(SessionPhase.AWAITING_EVENTS)
-    snapshot_source.state.active_turn_start_message_index = 4
-    snapshot_source.state.pending_events.add(PendingRow(
-        tool_call_id="child-current",
-        kind=RowKind.CHILD_AGENT,
-        order=0,
-        ref=1,
-        status=RowStatus.PENDING,
-    ))
-    path = tmp_path / "reused-awaiting-cursor.json"
-    snapshot_source.save(str(path))
-
-    llm = FakeLLMClient([llm_response(content="prior live answer")])
-    reused = Session(agent=agent, llm=llm, max_steps=1)
-    run(reused.add_user_message("prior live question"))
-    assert run(reused.run_loop()) == "prior live answer"
-    assert reused.runner._turn_start_message_index is not None
-    reused.agent.tools = []
-    reused.agent.tool_choice = {
-        "type": "function",
-        "function": {"name": "stale"},
-    }
-
-    reused.restore(str(path))
-
-    assert reused.state.active_turn_start_message_index == 4
-    assert reused.runner._turn_start_message_index is None
-    assert reused.agent.tools == [baseline_tool]
-    assert reused.agent.tool_choice is None
-    assert run(reused.run_loop()) == ""
-    assert reused.state.phase is SessionPhase.STOPPED
-    assert len(llm.calls) == 1
-
-
-def test_restore_reused_session_rearms_empty_response_retry(tmp_path):
-    agent = FakeAgent()
-    snapshot_source = Session(agent=agent, llm=FakeLLMClient())
-    snapshot_source.state.replace_messages([
-        {"role": "system", "content": "sys"},
-        {"role": "user", "content": "current question"},
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [{
-                "id": "child-current",
-                "type": "function",
-                "function": {"name": "spawn_agent", "arguments": "{}"},
-            }],
-        },
-    ])
-    snapshot_source.state.set_phase(SessionPhase.AWAITING_EVENTS)
-    snapshot_source.state.active_turn_start_message_index = 1
-    snapshot_source.state.pending_events.add(PendingRow(
-        tool_call_id="child-current",
-        kind=RowKind.CHILD_AGENT,
-        order=0,
-        ref=1,
-        status=RowStatus.DONE,
-        result="child result",
-    ))
-    path = tmp_path / "reused-empty-retry.json"
-    snapshot_source.save(str(path))
-
-    llm = FakeLLMClient([
-        llm_response(content=None),
-        llm_response(content="prior recovered"),
-        llm_response(content=None),
-        llm_response(content="restored recovered"),
-    ])
-    reused = Session(agent=agent, llm=llm)
-    run(reused.add_user_message("prior question"))
-    assert run(reused.run_loop()) == "prior recovered"
-    assert reused.runner._empty_stop_retried is True
-
-    reused.restore(str(path))
-
-    assert reused.runner._empty_stop_retried is False
-    assert run(reused.run_loop()) == "restored recovered"
-    assert len(llm.calls) == 4
-
-
-def test_restore_rejects_a_session_with_an_active_turn(tmp_path):
-    agent = FakeAgent()
-    source = Session(agent=agent, llm=FakeLLMClient())
-    path = tmp_path / "busy-restore.json"
-    source.save(str(path))
-
-    session = Session(agent=agent, llm=FakeLLMClient())
-    run(session._turn_lock.acquire())
-    try:
-        with pytest.raises(SessionBusyError, match="runtime work is active"):
-            session.restore(str(path))
-    finally:
-        session._turn_lock.release()
-
-
-@pytest.mark.asyncio
-async def test_restore_rejects_pending_runtime_cleanup(tmp_path):
-    agent = FakeAgent()
-    source = Session(agent=agent, llm=FakeLLMClient())
-    path = tmp_path / "cleanup-restore.json"
-    source.save(str(path))
-
-    session = Session(agent=agent, llm=FakeLLMClient())
-    blocker = asyncio.Event()
-    cleanup_task = asyncio.create_task(blocker.wait())
-    session.tool_execution._pending_cleanup_tasks.add(cleanup_task)
-    try:
-        with pytest.raises(SessionBusyError, match="runtime work is active"):
-            session.restore(str(path))
-    finally:
-        cleanup_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await cleanup_task
 
 def test_scheduler_init_preserves_and_drains_restored_awaiting_phase(tmp_path):
     from opencollab.application.scheduler import LaunchSpec, Scheduler

--- a/tests/test_session_restore_runtime_reset.py
+++ b/tests/test_session_restore_runtime_reset.py
@@ -1,0 +1,158 @@
+"""Regression coverage for restoring a reused session runtime."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from session_characterization_test_support import (
+    FakeAgent,
+    FakeLLMClient,
+    llm_response,
+    run,
+)
+
+from opencollab.application.session import SessionBusyError
+from opencollab.bootstrap import build_session as Session
+from opencollab.domain.pending import PendingRow, RowKind, RowStatus
+from opencollab.domain.session import SessionPhase
+
+
+def test_restore_reused_session_resets_live_turn_cursor(tmp_path):
+    baseline_tool = SimpleNamespace(
+        to_openai_schema=lambda: {
+            "type": "function",
+            "function": {"name": "baseline", "parameters": {}},
+        }
+    )
+    agent = FakeAgent(tools=[baseline_tool])
+    snapshot_source = Session(agent=agent, llm=FakeLLMClient(), max_steps=1)
+    snapshot_source.state.replace_messages([
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "OLD SNAPSHOT ANSWER"},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "child-current",
+                "type": "function",
+                "function": {"name": "spawn_agent", "arguments": "{}"},
+            }],
+        },
+    ])
+    snapshot_source.state.set_step_count(1)
+    snapshot_source.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    snapshot_source.state.active_turn_start_message_index = 4
+    snapshot_source.state.pending_events.add(PendingRow(
+        tool_call_id="child-current",
+        kind=RowKind.CHILD_AGENT,
+        order=0,
+        ref=1,
+        status=RowStatus.PENDING,
+    ))
+    path = tmp_path / "reused-awaiting-cursor.json"
+    snapshot_source.save(str(path))
+
+    llm = FakeLLMClient([llm_response(content="prior live answer")])
+    reused = Session(agent=agent, llm=llm, max_steps=1)
+    run(reused.add_user_message("prior live question"))
+    assert run(reused.run_loop()) == "prior live answer"
+    assert reused.runner._turn_start_message_index is not None
+    reused.agent.tools = []
+    reused.agent.tool_choice = {
+        "type": "function",
+        "function": {"name": "stale"},
+    }
+
+    reused.restore(str(path))
+
+    assert reused.state.active_turn_start_message_index == 4
+    assert reused.runner._turn_start_message_index is None
+    assert reused.agent.tools == [baseline_tool]
+    assert reused.agent.tool_choice is None
+    assert run(reused.run_loop()) == ""
+    assert reused.state.phase is SessionPhase.STOPPED
+    assert len(llm.calls) == 1
+
+
+def test_restore_reused_session_rearms_empty_response_retry(tmp_path):
+    agent = FakeAgent()
+    snapshot_source = Session(agent=agent, llm=FakeLLMClient())
+    snapshot_source.state.replace_messages([
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "child-current",
+                "type": "function",
+                "function": {"name": "spawn_agent", "arguments": "{}"},
+            }],
+        },
+    ])
+    snapshot_source.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    snapshot_source.state.active_turn_start_message_index = 1
+    snapshot_source.state.pending_events.add(PendingRow(
+        tool_call_id="child-current",
+        kind=RowKind.CHILD_AGENT,
+        order=0,
+        ref=1,
+        status=RowStatus.DONE,
+        result="child result",
+    ))
+    path = tmp_path / "reused-empty-retry.json"
+    snapshot_source.save(str(path))
+
+    llm = FakeLLMClient([
+        llm_response(content=None),
+        llm_response(content="prior recovered"),
+        llm_response(content=None),
+        llm_response(content="restored recovered"),
+    ])
+    reused = Session(agent=agent, llm=llm)
+    run(reused.add_user_message("prior question"))
+    assert run(reused.run_loop()) == "prior recovered"
+    assert reused.runner._empty_stop_retried is True
+
+    reused.restore(str(path))
+
+    assert reused.runner._empty_stop_retried is False
+    assert run(reused.run_loop()) == "restored recovered"
+    assert len(llm.calls) == 4
+
+
+def test_restore_rejects_a_session_with_an_active_turn(tmp_path):
+    agent = FakeAgent()
+    source = Session(agent=agent, llm=FakeLLMClient())
+    path = tmp_path / "busy-restore.json"
+    source.save(str(path))
+
+    session = Session(agent=agent, llm=FakeLLMClient())
+    run(session._turn_lock.acquire())
+    try:
+        with pytest.raises(SessionBusyError, match="runtime work is active"):
+            session.restore(str(path))
+    finally:
+        session._turn_lock.release()
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_pending_runtime_cleanup(tmp_path):
+    agent = FakeAgent()
+    source = Session(agent=agent, llm=FakeLLMClient())
+    path = tmp_path / "cleanup-restore.json"
+    source.save(str(path))
+
+    session = Session(agent=agent, llm=FakeLLMClient())
+    blocker = asyncio.Event()
+    cleanup_task = asyncio.create_task(blocker.wait())
+    session.tool_execution._pending_cleanup_tasks.add(cleanup_task)
+    try:
+        with pytest.raises(SessionBusyError, match="runtime work is active"):
+            session.restore(str(path))
+    finally:
+        cleanup_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cleanup_task

--- a/tests/test_session_restore_runtime_reset.py
+++ b/tests/test_session_restore_runtime_reset.py
@@ -1,6 +1,7 @@
 """Regression coverage for restoring a reused session runtime."""
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -121,6 +122,54 @@ def test_restore_reused_session_rearms_empty_response_retry(tmp_path):
     assert reused.runner._empty_stop_retried is False
     assert run(reused.run_loop()) == "restored recovered"
     assert len(llm.calls) == 4
+
+
+@pytest.mark.parametrize("cursor", [None, 10_000])
+def test_restore_awaiting_legacy_cursor_returns_resumed_answer(tmp_path, cursor):
+    agent = FakeAgent()
+    source = Session(agent=agent, llm=FakeLLMClient())
+    source.state.replace_messages([
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "child-current",
+                "type": "function",
+                "function": {"name": "spawn_agent", "arguments": "{}"},
+            }],
+        },
+    ])
+    source.state.set_phase(SessionPhase.AWAITING_EVENTS)
+    source.state.active_turn_start_message_index = 4
+    source.state.pending_events.add(PendingRow(
+        tool_call_id="child-current",
+        kind=RowKind.CHILD_AGENT,
+        order=0,
+        ref=1,
+        status=RowStatus.DONE,
+        result="child result",
+    ))
+    path = tmp_path / "awaiting-legacy-cursor.json"
+    source.save(str(path))
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    if cursor is None:
+        snapshot["session_state"].pop("active_turn_start_message_index")
+    else:
+        snapshot["session_state"]["active_turn_start_message_index"] = cursor
+    path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    restored = Session(
+        agent=agent,
+        llm=FakeLLMClient([llm_response(content="answer after legacy restore")]),
+    )
+    restored.restore(str(path))
+
+    assert restored.state.active_turn_start_message_index == 5
+    assert run(restored.run_loop()) == "answer after legacy restore"
 
 
 def test_restore_rejects_a_session_with_an_active_turn(tmp_path):

--- a/tests/test_structured_output_schema.py
+++ b/tests/test_structured_output_schema.py
@@ -55,6 +55,47 @@ def test_validate_schema_accepts_nonempty_json_enum():
     assert validate_schema(schema) == []
 
 
+def test_validate_schema_accepts_annotations_without_weakening_constraints():
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "Third-party tool arguments",
+        "description": "A representative provider schema",
+        "required": ["email"],
+        "properties": {
+            "email": {
+                "type": "string",
+                "default": "user@example.com",
+                "examples": ["admin@example.com"],
+                "format": "email",
+                "deprecated": False,
+                "readOnly": False,
+                "writeOnly": False,
+            }
+        },
+    }
+
+    assert validate_schema(schema) == []
+    assert validate({"email": "not-checked-as-a-format"}, schema) == []
+    assert validate({}, schema) == ["$.email: required property is missing"]
+
+
+def test_validate_schema_rejects_nested_dialect_declaration():
+    errors = validate_schema({
+        "type": "object",
+        "properties": {
+            "value": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "string",
+            }
+        },
+    })
+
+    assert errors == [
+        "$schema.properties.value.$schema: dialect declaration is only allowed at the root"
+    ]
+
+
 def test_validate_nested_object_and_array():
     schema = {
         "type": "object",

--- a/tests/test_tool_execution_use_case.py
+++ b/tests/test_tool_execution_use_case.py
@@ -193,66 +193,6 @@ def test_declared_schema_constraints_block_side_effects(schema, arguments, expec
     assert expected_error in result.messages_to_append[0]["content"]
 
 
-def test_declared_schema_annotations_allow_single_and_batch_execution():
-    tool = RuntimeNativeTool()
-    tool.parameters = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "title": "Third-party tool",
-        "description": "Schema annotations should remain compatible",
-        "required": ["value"],
-        "properties": {
-            "value": {
-                "type": "string",
-                "default": "fallback",
-                "examples": ["first", "second"],
-                "format": "hostname",
-                "deprecated": False,
-                "readOnly": False,
-                "writeOnly": False,
-            }
-        },
-    }
-    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
-
-    result = run(use_case.process([
-        tool_call(arguments='{"value": "one"}', call_id="call-1"),
-        tool_call(arguments='{"value": "two"}', call_id="call-2"),
-    ]))
-
-    assert [call[0] for call in tool.runtime_calls] == [
-        {"value": "one"},
-        {"value": "two"},
-    ]
-    assert [message["content"] for message in result.messages_to_append] == [
-        "runtime result",
-        "runtime result",
-    ]
-
-
-@pytest.mark.parametrize(
-    ("keyword", "value"),
-    [
-        ("anyOf", [{"type": "string"}]),
-        ("allOf", [{"type": "string"}]),
-        ("const", "fixed"),
-        ("$ref", "#/$defs/value"),
-        ("nullable", True),
-    ],
-)
-def test_unimplemented_schema_semantics_still_block_execution(keyword, value):
-    tool = RuntimeNativeTool()
-    tool.parameters = {"type": "object", keyword: value}
-    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
-
-    result = run(use_case.process([tool_call()]))
-
-    assert tool.runtime_calls == []
-    assert f"{keyword}: unsupported schema keyword" in (
-        result.messages_to_append[0]["content"]
-    )
-
-
 def test_structured_output_rejects_unsupported_assertion_schema_before_provider_use():
     with pytest.raises(ValueError, match="anyOf: unsupported schema keyword"):
         StructuredOutputTool(

--- a/tests/test_tool_execution_use_case.py
+++ b/tests/test_tool_execution_use_case.py
@@ -193,6 +193,66 @@ def test_declared_schema_constraints_block_side_effects(schema, arguments, expec
     assert expected_error in result.messages_to_append[0]["content"]
 
 
+def test_declared_schema_annotations_allow_single_and_batch_execution():
+    tool = RuntimeNativeTool()
+    tool.parameters = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "Third-party tool",
+        "description": "Schema annotations should remain compatible",
+        "required": ["value"],
+        "properties": {
+            "value": {
+                "type": "string",
+                "default": "fallback",
+                "examples": ["first", "second"],
+                "format": "hostname",
+                "deprecated": False,
+                "readOnly": False,
+                "writeOnly": False,
+            }
+        },
+    }
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
+
+    result = run(use_case.process([
+        tool_call(arguments='{"value": "one"}', call_id="call-1"),
+        tool_call(arguments='{"value": "two"}', call_id="call-2"),
+    ]))
+
+    assert [call[0] for call in tool.runtime_calls] == [
+        {"value": "one"},
+        {"value": "two"},
+    ]
+    assert [message["content"] for message in result.messages_to_append] == [
+        "runtime result",
+        "runtime result",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("anyOf", [{"type": "string"}]),
+        ("allOf", [{"type": "string"}]),
+        ("const", "fixed"),
+        ("$ref", "#/$defs/value"),
+        ("nullable", True),
+    ],
+)
+def test_unimplemented_schema_semantics_still_block_execution(keyword, value):
+    tool = RuntimeNativeTool()
+    tool.parameters = {"type": "object", keyword: value}
+    use_case, _ = build_use_case(agent=FakeAgent(tools=[tool]))
+
+    result = run(use_case.process([tool_call()]))
+
+    assert tool.runtime_calls == []
+    assert f"{keyword}: unsupported schema keyword" in (
+        result.messages_to_append[0]["content"]
+    )
+
+
 def test_structured_output_rejects_unsupported_assertion_schema_before_provider_use():
     with pytest.raises(ValueError, match="anyOf: unsupported schema keyword"):
         StructuredOutputTool(


### PR DESCRIPTION
## Summary

This follow-up addresses the three review findings from #51 and #52 after the runtime stack ending at #64.

Interactive CLI turns now preserve partial output and report stopped or failed state before accepting the next prompt. One-shot CLI calls still fail explicitly. The programmatic team API returns the same terminal details.

Third-party JSON Schema annotations are accepted without enabling unsupported validation semantics. Unsupported assertion and applicator keywords still block tool execution.

Session restore now rejects active runtime work, resets process-local turn state, and reloads the durable answer cursor.

## Verification

`uv run ruff check .`

`uv run pytest -q --tb=short` with 2197 passed

Independent review APPROVE