### PR TITLE
perf(ci): cache scanned secret file versions

### DIFF
--- a/scripts/check_secret_history.py
+++ b/scripts/check_secret_history.py
@@ -51,14 +51,22 @@ def _tree_blobs(repository: Path, commit: str) -> list[tuple[str, str]]:
     return entries
 
 
-def _materialize_tree(repository: Path, commit: str, destination: Path) -> list[str]:
+def _materialize_blobs(
+    repository: Path,
+    blobs: list[tuple[str, str]],
+    destination: Path,
+) -> list[str]:
     paths: list[str] = []
-    for relative, object_id in _tree_blobs(repository, commit):
+    for relative, object_id in blobs:
         target = destination.joinpath(*PurePosixPath(relative).parts)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(_git(repository, "cat-file", "blob", object_id))
         paths.append(relative)
     return paths
+
+
+def _scannable_blobs(repository: Path, commit: str) -> list[tuple[str, str]]:
+    return [blob for blob in _tree_blobs(repository, commit) if blob[0] != BASELINE_PATH]
 
 
 def _secret_fingerprints(payload: bytes) -> set[tuple[str, str, str]]:
@@ -83,20 +91,17 @@ def _introduced_secrets(trusted_baseline: bytes, scanned_baseline: Path) -> set[
     return _secret_fingerprints(scanned_baseline.read_bytes()) - _secret_fingerprints(trusted_baseline)
 
 
-def _scan_materialized_tree(
+def _scan_materialized_blobs(
     repository: Path,
     commit: str,
+    blobs: list[tuple[str, str]],
     scanner: list[str],
     trusted_baseline: bytes,
     root: Path,
 ) -> int:
     tree = root / commit
     tree.mkdir()
-    paths = [
-        path
-        for path in _materialize_tree(repository, commit, tree)
-        if path != BASELINE_PATH
-    ]
+    paths = _materialize_blobs(repository, blobs, tree)
     if not paths:
         print(f"::error::Proposed commit {commit} has no files to scan.")
         return 1
@@ -169,16 +174,37 @@ def check_secret_history(
     trusted_baseline = _git(repository, "show", f"{base}:{BASELINE_PATH}")
     with tempfile.TemporaryDirectory(prefix="opencollab-secret-history-") as temporary:
         root = Path(temporary)
+        scanned = set(_scannable_blobs(repository, base))
+        cache_hits = 0
+        scanned_versions = 0
+        scanner_runs = 0
         for commit in _commits(repository, base, head):
-            result = _scan_materialized_tree(
+            current = _scannable_blobs(repository, commit)
+            if not current:
+                print(f"::error::Proposed commit {commit} has no files to scan.")
+                return 1
+            pending = [blob for blob in current if blob not in scanned]
+            cache_hits += len(current) - len(pending)
+            if not pending:
+                continue
+            result = _scan_materialized_blobs(
                 repository,
                 commit,
+                pending,
                 scanner,
                 trusted_baseline,
                 root,
             )
             if result:
                 return result
+            scanned.update(pending)
+            scanned_versions += len(pending)
+            scanner_runs += 1
+    print(
+        "Secret scan cache summary: "
+        f"scanned_versions={scanned_versions}, cache_hits={cache_hits}, "
+        f"scanner_runs={scanner_runs}."
+    )
     print("Secret history checks passed.")
     return 0
 
@@ -188,9 +214,10 @@ def check_trusted_tree(repository: Path, commit: str, scanner: list[str]) -> int
     commit = _git(repository, "rev-parse", "--verify", f"{commit}^{{commit}}").decode("ascii").strip()
     trusted_baseline = _git(repository, "show", f"{commit}:{BASELINE_PATH}")
     with tempfile.TemporaryDirectory(prefix="opencollab-secret-tree-") as temporary:
-        result = _scan_materialized_tree(
+        result = _scan_materialized_blobs(
             repository,
             commit,
+            _scannable_blobs(repository, commit),
             scanner,
             trusted_baseline,
             Path(temporary),

--- a/tests/test_secret_history_check.py
+++ b/tests/test_secret_history_check.py
@@ -255,12 +255,76 @@ def test_secret_history_accepts_clean_commits_and_special_names(tmp_path):
 def test_secret_history_rejects_zero_file_scan(tmp_path, monkeypatch, capsys):
     repository, base, scanner = _repository(tmp_path)
     module = _script_module()
-    monkeypatch.setattr(module, "_materialize_tree", lambda *_args: [])
+    monkeypatch.setattr(module, "_scannable_blobs", lambda *_args: [])
 
     result = module.check_secret_history(repository, base, base, [str(scanner)])
 
     assert result == 1
     assert "has no files to scan" in capsys.readouterr().out
+
+
+def test_secret_history_scans_each_path_and_blob_pair_once(tmp_path, monkeypatch):
+    repository, base, scanner = _repository(tmp_path)
+    (repository / "first.txt").write_text("first version\n", encoding="utf-8")
+    _git(repository, "add", "first.txt")
+    _git(repository, "commit", "-m", "add first file")
+    (repository / "second.txt").write_text("second version\n", encoding="utf-8")
+    _git(repository, "add", "second.txt")
+    _git(repository, "commit", "-m", "add second file")
+
+    module = _script_module()
+    scanned_batches: list[list[tuple[str, str]]] = []
+
+    def record_scan(
+        _repository: Path,
+        _commit: str,
+        blobs: list[tuple[str, str]],
+        _scanner: list[str],
+        _trusted_baseline: bytes,
+        _root: Path,
+    ) -> int:
+        scanned_batches.append(blobs)
+        return 0
+
+    monkeypatch.setattr(module, "_scan_materialized_blobs", record_scan)
+
+    result = module.check_secret_history(repository, base, "HEAD", [str(scanner)])
+
+    assert result == 0
+    scanned_paths = [path for batch in scanned_batches for path, _object_id in batch]
+    assert scanned_paths == ["first.txt", "second.txt"]
+
+
+def test_secret_history_rescans_same_blob_at_a_new_path(tmp_path, monkeypatch):
+    repository, base, scanner = _repository(tmp_path)
+    (repository / "first.txt").write_text("shared contents\n", encoding="utf-8")
+    _git(repository, "add", "first.txt")
+    _git(repository, "commit", "-m", "add first path")
+    _git(repository, "mv", "first.txt", "second.txt")
+    _git(repository, "commit", "-m", "rename path")
+
+    module = _script_module()
+    scanned_batches: list[list[tuple[str, str]]] = []
+
+    def record_scan(
+        _repository: Path,
+        _commit: str,
+        blobs: list[tuple[str, str]],
+        _scanner: list[str],
+        _trusted_baseline: bytes,
+        _root: Path,
+    ) -> int:
+        scanned_batches.append(blobs)
+        return 0
+
+    monkeypatch.setattr(module, "_scan_materialized_blobs", record_scan)
+
+    result = module.check_secret_history(repository, base, "HEAD", [str(scanner)])
+
+    assert result == 0
+    scanned = [(path, object_id) for batch in scanned_batches for path, object_id in batch]
+    assert [path for path, _object_id in scanned] == ["first.txt", "second.txt"]
+    assert scanned[0][1] == scanned[1][1]
 
 
 def test_trusted_tree_uses_the_baseline_from_the_same_tree(tmp_path):


### PR DESCRIPTION
## Summary

The secret-history checker now caches successful scans by repository-relative path and Git blob OID. Every proposed commit is still traversed. New paths and new content versions continue to run through `detect-secrets-hook`. The log reports unique file versions, cache hits, and scanner invocations.

## Security properties

The cache key includes both the original path and blob OID, so moving identical content to another path triggers another scan and preserves the trusted baseline path rules. Failed scans are never cached. The cache exists only for the lifetime of one check process.

## Performance

A run over the 26 commits from PR #56 with detect-secrets 1.5.0 scanned 81 unique file versions, reused 9,603 cached results, and completed in 14.79 seconds. The previous full-tree-per-commit scan took about 398 seconds.

## Verification

All 14 focused tests pass. Repository-wide Ruff passes. The complete pytest run reports 2,202 passing tests after rebasing onto the main branch that includes PR #65.
