### PR TITLE
test(worktree): stabilize async filesystem checks

### DIFF
--- a/tests/test_worktree_pool.py
+++ b/tests/test_worktree_pool.py
@@ -183,8 +183,7 @@ async def test_non_git_copy_does_not_block_event_loop(tmp_path, monkeypatch) -> 
     timer = threading.Timer(0.15, release.set)
     timer.start()
     try:
-        await asyncio.sleep(0.02)
-        assert started.is_set()
+        assert await asyncio.to_thread(started.wait, 1.0)
         assert not owner.done()
     finally:
         release.set()
@@ -212,8 +211,7 @@ async def test_non_git_cleanup_does_not_block_event_loop(tmp_path, monkeypatch) 
     timer = threading.Timer(0.15, release.set)
     timer.start()
     try:
-        await asyncio.sleep(0.02)
-        assert started.is_set()
+        assert await asyncio.to_thread(started.wait, 1.0)
         assert not owner.done()
     finally:
         release.set()


### PR DESCRIPTION
## Summary

Replace two fixed 20 ms scheduling assumptions in the plain-directory worktree tests with event-driven synchronization. The checks still prove that filesystem copying and cleanup run outside the event loop and remain incomplete while the injected blocking operation is active.

## Reason

The fixed delay passed in isolation but intermittently expired under full-suite load before the worker thread started. This blocked repeatable local release verification even though the asynchronous implementation behaved correctly.

## Validation

- Ruff passed for the full repository
- Both affected tests passed in 20 consecutive runs
- Full pytest passed with 2,282 tests
- `git diff --check` passed
