### PR TITLE
fix(llm): preserve DeepSeek max reasoning effort

### DIFF
--- a/opencollab/adapters/llm/types.py
+++ b/opencollab/adapters/llm/types.py
@@ -160,6 +160,7 @@ _EXACT_MODEL_CAPABILITIES: dict[str, ModelCapabilities] = {
         context_window=1_048_576,
         supports_forced_tool_choice=False,
         supports_responses_json_schema=True,
+        honors_workflow_thinking_override=False,
     ),
     "k3": ModelCapabilities(
         context_window=1_048_576,

--- a/tests/test_llm_provider_requests.py
+++ b/tests/test_llm_provider_requests.py
@@ -196,6 +196,7 @@ def test_deepseek_flash_declares_verified_responses_json_schema_support():
     assert capabilities.context_window == 1_048_576
     assert capabilities.supports_forced_tool_choice is False
     assert capabilities.supports_responses_json_schema is True
+    assert capabilities.honors_workflow_thinking_override is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflow_runtime.py
+++ b/tests/test_workflow_runtime.py
@@ -92,7 +92,7 @@ def test_concrete_factory_rejects_unsupported_isolation_before_building_session(
 def test_explicit_thinking_false_disables_responses_reasoning_effort(monkeypatch):
     _patch_build_session(monkeypatch)
     factory = workflow_runtime.WorkflowSessionFactory(
-        model="deepseek-v4-flash",
+        model="gpt-5",
         provider="openai",
         wire_protocol="responses",
         api_key="fake",  # pragma: allowlist secret
@@ -111,6 +111,29 @@ def test_explicit_thinking_false_disables_responses_reasoning_effort(monkeypatch
     assert default_session.agent.reasoning_effort_policy == "configured"
     assert corrective_session.agent.reasoning_effort is None
     assert corrective_session.agent.reasoning_effort_policy == "suppressed"
+
+
+def test_deepseek_max_reasoning_survives_workflow_thinking_override(monkeypatch):
+    _patch_build_session(monkeypatch)
+    factory = workflow_runtime.WorkflowSessionFactory(
+        model="deepseek-v4-flash-0731",
+        provider="openai",
+        wire_protocol="responses",
+        api_key="fake",  # pragma: allowlist secret
+        base_url="https://example.test",
+        thinking=True,
+        reasoning_effort="max",
+    )
+
+    session = factory.build_workflow_session(
+        prompt="return structured evidence",
+        budget=100_000,
+        thinking=False,
+    )
+
+    assert session.agent.thinking is True
+    assert session.agent.reasoning_effort == "max"
+    assert session.agent.reasoning_effort_policy == "configured"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Preserve the globally configured Responses reasoning effort for DeepSeek V4 Flash when a workflow requests a non-reasoning structured call.

DeepSeek V4 Flash uses one shared reasoning policy across the workflow. The previous capability declaration allowed per-call workflow overrides, so G1.1 structured calls could silently remove `reasoning.effort=max` from real Responses requests. The model capability now rejects that override while providers that support per-call suppression keep their existing behavior.

The regression tests cover the exact `deepseek-v4-flash-0731` model name and verify that global thinking and `max` reasoning survive `thinking=False` at workflow level.

## Verification

`ruff check .` passed. The complete test suite passed with 2283 tests. The added-file hygiene check passed. A live four-worker SWE-bench Pro-Lite run has also produced 141 observed Responses requests with `reasoning_effort=max` and no request using another effort value.
