### PR TITLE
fix(llm): align contracts across providers

### DIFF
--- a/opencollab/adapters/llm/anthropic_provider.py
+++ b/opencollab/adapters/llm/anthropic_provider.py
@@ -8,9 +8,16 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 from typing import Any
 
 from opencollab.adapters.llm.retry import RetryTimeBudget, with_retry
+from opencollab.adapters.llm.tool_contracts import (
+    NormalizedToolChoice,
+    normalize_function_tools,
+    normalize_tool_choice,
+    validate_tool_choice_target,
+)
 from opencollab.adapters.llm.types import (
     DEFAULT_MAX_OUTPUT_TOKENS,
     LLMResponse,
@@ -18,8 +25,75 @@ from opencollab.adapters.llm.types import (
     rescue_empty_turn,
 )
 
+_ANTHROPIC_REASONING_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
+_ANTHROPIC_VERSION_RE = re.compile(
+    r"^claude-(?P<family>opus|sonnet|haiku|fable|mythos)-"
+    r"(?P<major>\d+)(?:-(?P<minor>\d+))?(?:-|$)"
+)
 
-def _anthropic_tool_choice(tool_choice: Any) -> dict[str, Any] | None:
+
+def _anthropic_model_version(model: str) -> tuple[str, int, int] | None:
+    leaf = model.strip().lower().rsplit("/", 1)[-1]
+    match = _ANTHROPIC_VERSION_RE.match(leaf)
+    if match is None:
+        return None
+    return (
+        match.group("family"),
+        int(match.group("major")),
+        int(match.group("minor") or 0),
+    )
+
+
+def _anthropic_requires_default_sampling(model: str) -> bool:
+    """Whether a known native Claude model rejects non-default sampling."""
+    leaf = model.strip().lower().rsplit("/", 1)[-1]
+    if leaf.startswith("claude-mythos-preview"):
+        return True
+    version = _anthropic_model_version(model)
+    if version is None:
+        return False
+    _, major, minor = version
+    return major >= 5 or (major == 4 and minor >= 7)
+
+
+def _anthropic_defaults_to_thinking(model: str) -> bool:
+    leaf = model.strip().lower().rsplit("/", 1)[-1]
+    if leaf.startswith("claude-mythos-preview"):
+        return True
+    version = _anthropic_model_version(model)
+    return version is not None and version[1] >= 5
+
+
+def _anthropic_thinking_is_always_on(model: str) -> bool:
+    leaf = model.strip().lower().rsplit("/", 1)[-1]
+    if leaf.startswith("claude-mythos-preview"):
+        return True
+    version = _anthropic_model_version(model)
+    return (
+        version is not None
+        and version[0] in {"fable", "mythos"}
+        and version[1] >= 5
+    )
+
+
+def _validate_anthropic_thinking_mode(model: str, thinking_type: str) -> None:
+    """Reject mode and native-model combinations known to return HTTP 400."""
+    version = _anthropic_model_version(model)
+    if (
+        thinking_type == "enabled"
+        and version is not None
+        and _anthropic_requires_default_sampling(model)
+    ):
+        raise ValueError(f"Anthropic model {model!r} requires adaptive thinking")
+    if thinking_type == "adaptive" and version is not None:
+        _, major, minor = version
+        if major < 4 or (major == 4 and minor < 6):
+            raise ValueError(f"Anthropic model {model!r} does not support adaptive thinking")
+
+
+def _anthropic_tool_choice(
+    tool_choice: NormalizedToolChoice | None,
+) -> dict[str, Any] | None:
     """Map OpenAI-style ``tool_choice`` values to Anthropic's dict form.
 
     Anthropic expects ``{"type": "auto"|"any"|"tool"}``; OpenAI's ``"required"``
@@ -28,26 +102,19 @@ def _anthropic_tool_choice(tool_choice: Any) -> dict[str, Any] | None:
     """
     if tool_choice is None:
         return None
-    if tool_choice == "none":
+    if tool_choice.mode == "none":
         return {"type": "none"}
-    if tool_choice == "required":
+    if tool_choice.mode == "required":
         return {"type": "any"}
-    if tool_choice == "auto":
+    if tool_choice.mode == "auto":
         return {"type": "auto"}
-    if isinstance(tool_choice, dict):
-        if tool_choice.get("type") == "function":
-            function = tool_choice.get("function") or {}
-            name = function.get("name")
-            if name:
-                return {"type": "tool", "name": name}
-        if tool_choice.get("type") == "tool" and tool_choice.get("name"):
-            return {"type": "tool", "name": tool_choice["name"]}
-    return None
+    return {"type": "tool", "name": tool_choice.name}
 
 
 def _anthropic_thinking_kwargs(
     thinking_params: dict | None,
     *,
+    model: str,
     max_tokens: int,
 ) -> dict[str, Any]:
     """Validate provider-native thinking settings for one Anthropic request."""
@@ -72,6 +139,7 @@ def _anthropic_thinking_kwargs(
         raise ValueError(
             "Anthropic thinking_params.thinking.type must be enabled or adaptive"
         )
+    _validate_anthropic_thinking_mode(model, thinking_type)
     allowed_thinking = (
         {"type", "budget_tokens", "display"}
         if thinking_type == "enabled"
@@ -132,6 +200,25 @@ def _validate_anthropic_output_format(value: Any) -> None:
         raise ValueError("Anthropic output_config.format must contain a JSON schema")
 
 
+def _merge_anthropic_reasoning_effort(
+    request: dict[str, Any],
+    reasoning_effort: str | None,
+) -> None:
+    """Merge the provider-agnostic effort into Anthropic output_config."""
+    if reasoning_effort is None:
+        return
+    if reasoning_effort not in _ANTHROPIC_REASONING_EFFORTS:
+        raise ValueError("unsupported Anthropic reasoning_effort")
+    output_config = copy.deepcopy(request.get("output_config") or {})
+    native_effort = output_config.get("effort")
+    if native_effort is not None and native_effort != reasoning_effort:
+        raise ValueError(
+            "reasoning_effort conflicts with thinking_params.output_config.effort"
+        )
+    output_config["effort"] = reasoning_effort
+    request["output_config"] = output_config
+
+
 def _build_request_kwargs(
     model: str,
     messages: list[dict],
@@ -142,14 +229,31 @@ def _build_request_kwargs(
     tool_choice: Any = None,
     top_p: float | None = None,
     max_output_tokens: int | None = None,
+    reasoning_effort: str | None = None,
 ) -> dict[str, Any]:
     system_parts, anthropic_messages = convert_to_anthropic_messages(messages)
     max_tokens = int(max_output_tokens or DEFAULT_MAX_OUTPUT_TOKENS)
     thinking_kwargs = (
-        _anthropic_thinking_kwargs(thinking_params, max_tokens=max_tokens)
+        _anthropic_thinking_kwargs(
+            thinking_params,
+            model=model,
+            max_tokens=max_tokens,
+        )
         if thinking
         else {}
     )
+    _merge_anthropic_reasoning_effort(thinking_kwargs, reasoning_effort)
+
+    if (
+        not thinking
+        and reasoning_effort is None
+        and _anthropic_defaults_to_thinking(model)
+    ):
+        if _anthropic_thinking_is_always_on(model):
+            raise ValueError(
+                f"Anthropic model {model!r} cannot disable adaptive thinking"
+            )
+        thinking_kwargs["thinking"] = {"type": "disabled"}
 
     kwargs: dict[str, Any] = {
         "model": model,
@@ -159,19 +263,27 @@ def _build_request_kwargs(
     # Anthropic requires the default temperature while thinking is enabled.
     # Omitting it also works for compatible gateways and avoids turning the
     # ordinary OpenCollab temperature default into a provider-side 400.
-    if not thinking:
+    default_sampling_only = _anthropic_requires_default_sampling(model)
+    if not thinking and not default_sampling_only:
         kwargs["temperature"] = temperature
     # Nucleus sampling rides along ONLY when explicitly set; when None the key is
     # omitted so the request is byte-for-byte identical to today's behavior.
     if thinking and top_p is not None:
         raise ValueError("Anthropic thinking requires the provider-default top_p")
-    if top_p is not None:
+    if default_sampling_only and top_p is not None and top_p != 1.0:
+        raise ValueError(
+            f"Anthropic model {model!r} requires the provider-default top_p"
+        )
+    if top_p is not None and not default_sampling_only:
         kwargs["top_p"] = top_p
     if system_parts:
         kwargs["system"] = "\n\n".join(system_parts)
-    if tools:
-        kwargs["tools"] = [_convert_tool(tool) for tool in tools]
-        choice = _anthropic_tool_choice(tool_choice)
+    converted_tools = normalize_function_tools(tools)
+    normalized_choice = normalize_tool_choice(tool_choice)
+    validate_tool_choice_target(normalized_choice, converted_tools)
+    if converted_tools:
+        kwargs["tools"] = [_convert_tool(tool) for tool in converted_tools]
+        choice = _anthropic_tool_choice(normalized_choice)
         if choice is not None:
             if (
                 thinking_kwargs.get("thinking", {}).get("type") == "enabled"
@@ -186,11 +298,14 @@ def _build_request_kwargs(
 def _convert_tool(tool: dict) -> dict:
     """Convert an OpenAI function-tool definition to Anthropic's schema."""
     func = tool["function"]
-    return {
+    converted = {
         "name": func["name"],
         "description": func.get("description", ""),
         "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
     }
+    if "strict" in func:
+        converted["strict"] = func["strict"]
+    return converted
 
 
 async def complete_anthropic(
@@ -205,6 +320,7 @@ async def complete_anthropic(
     tool_choice: Any = None,
     top_p: float | None = None,
     max_output_tokens: int | None = None,
+    reasoning_effort: str | None = None,
     provider_error_time_budget: RetryTimeBudget | None = None,
 ) -> LLMResponse:
     """Single-shot completion against the Anthropic API."""
@@ -218,6 +334,7 @@ async def complete_anthropic(
         tool_choice,
         top_p,
         max_output_tokens,
+        reasoning_effort,
     )
     resp = await with_retry(
         lambda: client.messages.create(**kwargs),
@@ -260,9 +377,14 @@ def _parse_response(resp: Any) -> LLMResponse:
         usage=_parse_usage(resp.usage),
         finish_reason=resp.stop_reason,
         reasoning=reasoning,
+        provider_model=(
+            value
+            if isinstance((value := getattr(resp, "model", None)), str) and value
+            else None
+        ),
         provider_state=(
             {"anthropic_content": provider_content}
-            if has_thinking
+            if has_thinking or tool_calls
             else None
         ),
     )
@@ -321,16 +443,20 @@ def _parse_usage(usage: Any) -> Usage:
     cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
     cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
     uncached_input = getattr(usage, "input_tokens", 0) or 0
+    output_details = getattr(usage, "output_tokens_details", None)
+    thinking_tokens = getattr(output_details, "thinking_tokens", 0) or 0
     return Usage(
         input_tokens=uncached_input + cache_read + cache_creation,
         output_tokens=getattr(usage, "output_tokens", 0) or 0,
         cache_read_tokens=cache_read,
         cache_creation_tokens=cache_creation,
+        reasoning_tokens=max(0, int(thinking_tokens)) or None,
         raw_usage={
             "input_tokens": uncached_input,
             "output_tokens": getattr(usage, "output_tokens", 0) or 0,
             "cache_read_input_tokens": cache_read,
             "cache_creation_input_tokens": cache_creation,
+            "output_tokens_details": {"thinking_tokens": thinking_tokens},
         },
     )
 
@@ -393,6 +519,8 @@ def convert_to_anthropic_messages(messages: list[dict]) -> tuple[list[str], list
                 anthropic_messages.append({"role": "assistant", "content": content_blocks})
         elif role == "tool":
             _append_tool_result(anthropic_messages, message)
+        else:
+            raise ValueError(f"message {message_index} has unsupported role {role!r}")
 
     return system_parts, anthropic_messages
 

--- a/opencollab/adapters/llm/client.py
+++ b/opencollab/adapters/llm/client.py
@@ -205,6 +205,7 @@ class LLMClient:
                     tool_choice=tool_choice,
                     top_p=top_p,
                     max_output_tokens=max_output_tokens,
+                    reasoning_effort=reasoning_effort,
                     provider_error_time_budget=self.provider_retry_budget,
                 )
             elif self.wire_protocol == RESPONSES:
@@ -239,6 +240,7 @@ class LLMClient:
                     tool_choice=tool_choice,
                     top_p=top_p,
                     max_output_tokens=max_output_tokens,
+                    reasoning_effort=reasoning_effort,
                     provider_error_time_budget=self.provider_retry_budget,
                 )
             await _record_api_usage_async(

--- a/opencollab/adapters/llm/openai_provider.py
+++ b/opencollab/adapters/llm/openai_provider.py
@@ -11,6 +11,12 @@ import re
 from typing import Any
 
 from opencollab.adapters.llm.retry import RetryTimeBudget, with_retry
+from opencollab.adapters.llm.tool_contracts import (
+    NormalizedToolChoice,
+    normalize_function_tools,
+    normalize_tool_choice,
+    validate_tool_choice_target,
+)
 from opencollab.adapters.llm.types import (
     LLMResponse,
     Usage,
@@ -29,6 +35,7 @@ _FRAMEWORK_CONTROLLED_THINKING_FIELDS = frozenset({
     "max_tokens",
     "messages",
     "model",
+    "reasoning_effort",
     "stream",
     "stream_options",
     "temperature",
@@ -36,7 +43,7 @@ _FRAMEWORK_CONTROLLED_THINKING_FIELDS = frozenset({
     "tools",
     "top_p",
 })
-_OPENAI_REASONING_MODEL_RE = re.compile(r"^o(?:1|3)(?:$|[-.])")
+_OPENAI_REASONING_MODEL_RE = re.compile(r"^(?:o(?:1|3|4)|gpt-5)(?:$|[-.])")
 
 
 def _validated_thinking_params(thinking_params: dict | None) -> dict:
@@ -57,6 +64,14 @@ def _uses_reasoning_request_fields(model: str) -> bool:
     return _OPENAI_REASONING_MODEL_RE.match(leaf) is not None
 
 
+def _openai_tool_choice(choice: NormalizedToolChoice | None) -> Any:
+    if choice is None:
+        return "auto"
+    if choice.mode == "named":
+        return {"type": "function", "function": {"name": choice.name}}
+    return choice.mode
+
+
 def _build_request_kwargs(
     model: str,
     messages: list[dict],
@@ -67,6 +82,7 @@ def _build_request_kwargs(
     tool_choice: Any = None,
     top_p: float | None = None,
     max_output_tokens: int | None = None,
+    reasoning_effort: str | None = None,
 ) -> dict[str, Any]:
     reasoning_model = _uses_reasoning_request_fields(model)
     kwargs: dict[str, Any] = {
@@ -82,15 +98,23 @@ def _build_request_kwargs(
     if max_output_tokens is not None:
         token_field = "max_completion_tokens" if reasoning_model else "max_tokens"
         kwargs[token_field] = int(max_output_tokens)
-    if tools:
-        kwargs["tools"] = tools
-        choice = tool_choice or "auto"
-        capabilities = model_capabilities(model)
+    if reasoning_effort is not None:
+        kwargs["reasoning_effort"] = reasoning_effort
+    converted_tools = normalize_function_tools(tools)
+    choice = normalize_tool_choice(tool_choice)
+    capabilities = model_capabilities(model)
+    if converted_tools:
+        kwargs["tools"] = converted_tools
+        provider_choice = _openai_tool_choice(choice)
         if not capabilities.supports_forced_tool_choice and (
-            choice == "required" or isinstance(choice, dict)
+            provider_choice == "required" or isinstance(provider_choice, dict)
         ):
-            choice = "auto"
-        kwargs["tool_choice"] = choice
+            provider_choice = "auto"
+        else:
+            validate_tool_choice_target(choice, converted_tools)
+        kwargs["tool_choice"] = provider_choice
+    elif capabilities.supports_forced_tool_choice:
+        validate_tool_choice_target(choice, converted_tools)
     # Thinking passthrough: when on, the provider-specific reasoning params ride
     # along as ``extra_body`` (a valid OpenAI SDK create() kwarg) — for DashScope
     # compatible mode this is ``{"enable_thinking": True}``. When off, nothing is
@@ -273,6 +297,11 @@ def _parse_response(
         usage=usage,
         finish_reason=choice.finish_reason,
         reasoning=reasoning,
+        provider_model=(
+            value
+            if isinstance((value := getattr(resp, "model", None)), str) and value
+            else None
+        ),
     )
 
 
@@ -302,6 +331,8 @@ def _parse_usage(
     output_tokens = _usage_int(raw_usage, "completion_tokens")
     prompt_details = raw_usage.get("prompt_tokens_details") or {}
     cached_tokens = _usage_int(prompt_details, "cached_tokens")
+    completion_details = raw_usage.get("completion_tokens_details") or {}
+    reasoning_tokens = _usage_int(completion_details, "reasoning_tokens")
 
     estimated = False
     if input_tokens <= 0:
@@ -315,6 +346,7 @@ def _parse_usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cache_read_tokens=cached_tokens,
+        reasoning_tokens=reasoning_tokens or None,
         estimated=estimated,
         raw_usage=raw_usage,
     )
@@ -353,6 +385,7 @@ async def complete_openai(
     tool_choice: Any = None,
     top_p: float | None = None,
     max_output_tokens: int | None = None,
+    reasoning_effort: str | None = None,
     provider_error_time_budget: RetryTimeBudget | None = None,
 ) -> LLMResponse:
     """Single-shot completion against an OpenAI-compatible endpoint."""
@@ -366,6 +399,7 @@ async def complete_openai(
         tool_choice,
         top_p,
         max_output_tokens,
+        reasoning_effort,
     )
     resp = await with_retry(
         lambda: client.chat.completions.create(**kwargs),

--- a/opencollab/adapters/llm/responses_errors.py
+++ b/opencollab/adapters/llm/responses_errors.py
@@ -1,0 +1,37 @@
+"""Typed errors emitted while parsing OpenAI Responses streams."""
+
+from __future__ import annotations
+
+from opencollab.adapters.llm.errors import TransientEmptyOutputError, TransientProviderError
+
+
+class ResponsesProtocolError(RuntimeError):
+    """The Responses endpoint returned an incomplete or invalid event sequence."""
+
+
+class ResponsesTerminalEventError(ResponsesProtocolError):
+    """A typed terminal event preserved its provider error identity."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.body = {"error": {"code": code, "message": message}}
+
+
+class ResponsesEmptyOutputError(ResponsesProtocolError, TransientEmptyOutputError):
+    """A completed Responses request contained no usable assistant output."""
+
+
+class ResponsesStreamInterruptedError(ResponsesProtocolError, TransientProviderError):
+    """A Responses stream ended without its required terminal event."""
+
+
+class ResponsesTransientEventError(ResponsesTerminalEventError, TransientProviderError):
+    """A typed Responses error identified a temporary provider failure."""

--- a/opencollab/adapters/llm/responses_provider.py
+++ b/opencollab/adapters/llm/responses_provider.py
@@ -8,7 +8,14 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-from opencollab.adapters.llm.errors import TransientEmptyOutputError, TransientProviderError
+from opencollab.adapters.llm.errors import TransientProviderError
+from opencollab.adapters.llm.responses_errors import (
+    ResponsesEmptyOutputError,
+    ResponsesProtocolError,
+    ResponsesStreamInterruptedError,
+    ResponsesTerminalEventError,
+    ResponsesTransientEventError,
+)
 from opencollab.adapters.llm.responses_structured import (
     ForcedTextTool,
     forced_text_format,
@@ -17,6 +24,12 @@ from opencollab.adapters.llm.responses_structured import (
 )
 from opencollab.adapters.llm.responses_usage import parse_responses_usage
 from opencollab.adapters.llm.retry import RetryTimeBudget, with_retry
+from opencollab.adapters.llm.tool_contracts import (
+    normalize_function_tools,
+    normalize_text_content,
+    normalize_tool_choice,
+    validate_tool_choice_target,
+)
 from opencollab.adapters.llm.types import (
     LLMResponse,
     model_capabilities,
@@ -48,22 +61,6 @@ _PASSIVE_EVENT_TYPES = frozenset(
 )
 
 
-class ResponsesProtocolError(RuntimeError):
-    """The Responses endpoint returned an incomplete or invalid event sequence."""
-
-
-class ResponsesEmptyOutputError(ResponsesProtocolError, TransientEmptyOutputError):
-    """A completed Responses request contained no usable assistant output."""
-
-
-class ResponsesStreamInterruptedError(ResponsesProtocolError, TransientProviderError):
-    """A Responses stream ended without its required terminal event."""
-
-
-class ResponsesTransientEventError(ResponsesProtocolError, TransientProviderError):
-    """A typed Responses error identified a temporary provider failure."""
-
-
 @dataclass
 class _StreamState:
     output_items: list[dict[str, Any]] = field(default_factory=list)
@@ -72,21 +69,10 @@ class _StreamState:
 
 
 def _message_text(content: Any) -> str:
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return str(content)
-    parts: list[str] = []
-    for part in content:
-        if isinstance(part, str):
-            parts.append(part)
-        elif isinstance(part, dict):
-            text = part.get("text")
-            if isinstance(text, str):
-                parts.append(text)
-    return "\n".join(parts)
+    try:
+        return normalize_text_content(content)
+    except ValueError as exc:
+        raise ResponsesProtocolError(str(exc)) from exc
 
 
 def _validated_response_items(value: Any) -> list[dict[str, Any]]:
@@ -151,7 +137,10 @@ def _messages_to_input(messages: list[dict[str, Any]]) -> tuple[str | None, list
         if role == "system":
             text = _message_text(message.get("content"))
             if text:
-                instructions.append(text)
+                if message.get("compacted"):
+                    items.append({"role": "user", "content": text})
+                else:
+                    instructions.append(text)
             continue
         if role == "tool":
             call_id = message.get("tool_call_id")
@@ -210,36 +199,50 @@ def _messages_to_input(messages: list[dict[str, Any]]) -> tuple[str | None, list
 
 
 def _responses_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    try:
+        normalized_tools = normalize_function_tools(tools)
+    except ValueError as exc:
+        raise ResponsesProtocolError(str(exc)) from exc
     converted: list[dict[str, Any]] = []
-    for tool in tools or ():
-        function = tool.get("function") if isinstance(tool, dict) else None
-        if tool.get("type") != "function" or not isinstance(function, dict):
-            raise ResponsesProtocolError("Responses supports only OpenAI function tools")
+    for tool in normalized_tools:
+        function = tool["function"]
         item = {
             "type": "function",
-            "name": function.get("name"),
-            "parameters": function.get("parameters") or {"type": "object", "properties": {}},
+            "name": function["name"],
+            "parameters": function["parameters"],
         }
         if function.get("description") is not None:
             item["description"] = function["description"]
         if function.get("strict") is not None:
-            item["strict"] = bool(function["strict"])
+            item["strict"] = function["strict"]
         converted.append(item)
     return converted
 
 
-def _responses_tool_choice(value: Any) -> Any:
-    if value is None:
+def _responses_tool_choice(
+    value: Any,
+    converted_tools: list[dict[str, Any]],
+) -> Any:
+    try:
+        choice = normalize_tool_choice(value)
+        openai_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "parameters": tool["parameters"],
+                },
+            }
+            for tool in converted_tools
+        ]
+        validate_tool_choice_target(choice, openai_tools)
+    except ValueError as exc:
+        raise ResponsesProtocolError(str(exc)) from exc
+    if choice is None:
         return "auto"
-    if not isinstance(value, dict):
-        return value
-    function = value.get("function")
-    if value.get("type") == "function" and isinstance(function, dict):
-        name = function.get("name")
-        if not isinstance(name, str) or not name:
-            raise ResponsesProtocolError("function tool_choice is missing a name")
-        return {"type": "function", "name": name}
-    return value
+    if choice.mode == "named":
+        return {"type": "function", "name": choice.name}
+    return choice.mode
 
 
 def _forced_text_tool(
@@ -248,7 +251,7 @@ def _forced_text_tool(
     tool_choice: Any,
 ) -> ForcedTextTool | None:
     """Bind one named tool through ``text.format`` when forcing is unsupported."""
-    choice = _responses_tool_choice(tool_choice)
+    choice = _responses_tool_choice(tool_choice, converted_tools)
     try:
         return forced_text_tool(
             converted_tools,
@@ -287,13 +290,13 @@ def _build_request_kwargs(
     if instructions:
         kwargs["instructions"] = instructions
     converted_tools = _responses_tools(tools)
+    choice = _responses_tool_choice(tool_choice, converted_tools)
     if converted_tools:
         text_tool = _forced_text_tool(model, converted_tools, tool_choice)
         if text_tool is not None:
             kwargs["text"] = forced_text_format(text_tool)
         else:
             kwargs["tools"] = converted_tools
-            choice = _responses_tool_choice(tool_choice)
             if not model_capabilities(model).supports_forced_tool_choice and choice is not None and choice != "auto":
                 choice = "auto"
             kwargs["tool_choice"] = choice
@@ -376,31 +379,59 @@ def _accept_output_item(event: Any, state: _StreamState) -> None:
     state.output_items.append(item)
 
 
-def _validate_completed_response(response: Any, expected_model: str | None) -> str:
+def _validate_terminal_response(
+    response: Any,
+    expected_model: str | None,
+) -> tuple[str, str]:
     status = getattr(response, "status", None)
-    if status != "completed":
+    if status not in {"completed", "incomplete"}:
         raise ResponsesProtocolError(f"Responses request ended with status {status!r}")
     error = to_plain_data(getattr(response, "error", None))
     if error is not None:
-        raise ResponsesProtocolError(f"completed Responses object contains error {error!r}")
+        raise ResponsesProtocolError(f"terminal Responses object contains error {error!r}")
     incomplete = to_plain_data(getattr(response, "incomplete_details", None))
-    if incomplete is not None:
+    if status == "completed" and incomplete is not None:
         raise ResponsesProtocolError(f"completed Responses object contains incomplete details {incomplete!r}")
+    finish_reason = "stop"
+    if status == "incomplete":
+        reason = incomplete.get("reason") if isinstance(incomplete, dict) else None
+        if reason not in {"max_tokens", "max_output_tokens"}:
+            raise ResponsesProtocolError(
+                f"incomplete Responses object has unsupported reason {reason!r}"
+            )
+        finish_reason = "max_tokens"
     actual_model = getattr(response, "model", None)
     if not isinstance(actual_model, str) or not actual_model:
-        raise ResponsesProtocolError("completed Responses object is missing model identity")
-    return actual_model
+        raise ResponsesProtocolError("terminal Responses object is missing model identity")
+    return actual_model, finish_reason
 
 
 def _handle_event(event: Any, state: _StreamState, expected_model: str | None = None) -> bool:
     event_type = _event_type(event)
-    if event_type in {"error", "response.failed", "response.incomplete"}:
+    if event_type in {"error", "response.failed"}:
         error = _event_error_data(event)
         message = _event_error(event)
         code = error.get("code") if isinstance(error, dict) else None
         if code in {"rate_limit_exceeded", "server_error", "vector_store_timeout"}:
-            raise ResponsesTransientEventError(message)
-        raise ResponsesProtocolError(message)
+            status_code = 429 if code == "rate_limit_exceeded" else 503
+            raise ResponsesTransientEventError(
+                message,
+                code=code,
+                status_code=status_code,
+            )
+        status_code = 400 if code == "context_length_exceeded" else None
+        raise ResponsesTerminalEventError(
+            message,
+            code=code,
+            status_code=status_code,
+        )
+    if event_type == "response.incomplete":
+        response = getattr(event, "response", None)
+        if getattr(response, "status", None) != "incomplete":
+            raise ResponsesTerminalEventError(_event_error(event))
+        state.completed_response = response
+        _validate_terminal_response(response, expected_model)
+        return True
     if event_type == "response.function_call_arguments.delta":
         index = getattr(event, "output_index", None)
         delta = getattr(event, "delta", None)
@@ -424,7 +455,7 @@ def _handle_event(event: Any, state: _StreamState, expected_model: str | None = 
         state.completed_response = getattr(event, "response", None)
         if state.completed_response is None:
             raise ResponsesProtocolError("response.completed is missing the response object")
-        _validate_completed_response(state.completed_response, expected_model)
+        _validate_terminal_response(state.completed_response, expected_model)
         return True
     if event_type not in _PASSIVE_EVENT_TYPES:
         raise ResponsesProtocolError(f"unsupported Responses event {event_type!r}")
@@ -588,14 +619,26 @@ def _parse_stream(
     expected_model: str | None = None,
     forced_text_tool: ForcedTextTool | None = None,
 ) -> LLMResponse:
-    actual_model = _validate_completed_response(state.completed_response, expected_model)
+    actual_model, finish_reason = _validate_terminal_response(
+        state.completed_response,
+        expected_model,
+    )
+    if forced_text_tool is not None and finish_reason != "stop":
+        incomplete = to_plain_data(
+            getattr(state.completed_response, "incomplete_details", None)
+        )
+        raise ResponsesProtocolError(
+            f"JSON Schema tool response incomplete: {incomplete!r}"
+        )
     final_output = to_plain_data(getattr(state.completed_response, "output", None))
     final_items = _validated_response_items(final_output)
     if len(final_items) != len(state.output_items) or not all(
         _output_items_agree(streamed, terminal)
         for streamed, terminal in zip(state.output_items, final_items, strict=True)
     ):
-        raise ResponsesProtocolError("response.completed output disagrees with streamed output items")
+        raise ResponsesProtocolError(
+            "terminal Responses output disagrees with streamed output items"
+        )
     state.output_items = [
         _merge_terminal_projection(streamed, terminal)
         for streamed, terminal in zip(state.output_items, final_items, strict=True)
@@ -644,7 +687,9 @@ def _parse_stream(
             content,
             tool_calls,
         ),
-        finish_reason="tool_calls" if tool_calls else "stop",
+        finish_reason=(
+            "tool_calls" if tool_calls and finish_reason == "stop" else finish_reason
+        ),
         reasoning=reasoning,
         provider_items=state.output_items,
         provider_model=actual_model,
@@ -659,7 +704,7 @@ def parse_responses_response(
     forced_text_tool: ForcedTextTool | None = None,
 ) -> LLMResponse:
     """Parse one completed non-streaming Responses object."""
-    _validate_completed_response(response, expected_model)
+    _validate_terminal_response(response, expected_model)
     state = _StreamState(completed_response=response)
     output = to_plain_data(getattr(response, "output", None))
     if not isinstance(output, list):

--- a/opencollab/adapters/llm/retry.py
+++ b/opencollab/adapters/llm/retry.py
@@ -14,7 +14,7 @@ from typing import Any
 from opencollab.adapters.llm.errors import TransientProviderError, is_context_overflow_error
 
 # HTTP statuses worth retrying: timeouts, conflicts, rate limits, server errors.
-RETRYABLE_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504}
+RETRYABLE_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504, 529}
 
 # Error-message fragments that signal a transient failure when no status is set.
 RETRYABLE_MESSAGE_FRAGMENTS = (

--- a/opencollab/adapters/llm/tool_contracts.py
+++ b/opencollab/adapters/llm/tool_contracts.py
@@ -1,0 +1,167 @@
+"""Provider-neutral validation for text messages and function tools."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from opencollab.domain.tools import validate_unique_tool_names
+
+_FUNCTION_FIELDS = frozenset({"name", "description", "parameters", "strict"})
+_STRING_TOOL_CHOICES = frozenset({"auto", "none", "required"})
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+@dataclass(frozen=True)
+class NormalizedToolChoice:
+    """One provider-independent tool selection."""
+
+    mode: str
+    name: str | None = None
+
+
+def normalize_text_content(content: Any) -> str:
+    """Flatten supported text content without dropping other modalities."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        raise ValueError("message content must be text or a text block list")
+    parts: list[str] = []
+    for index, part in enumerate(content):
+        if isinstance(part, str):
+            parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            raise ValueError(
+                f"message content block {index} must be text or an object"
+            )
+        part_type = part.get("type")
+        if part_type not in {None, "text", "input_text", "output_text"}:
+            raise ValueError(
+                f"message content block {index} has unsupported type {part_type!r}"
+            )
+        text = part.get("text")
+        if not isinstance(text, str):
+            raise ValueError(f"message content block {index} is missing text")
+        parts.append(text)
+    return "\n".join(parts)
+
+
+def normalize_function_tools(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Validate and copy OpenAI-shaped function tool definitions."""
+    if tools is None:
+        return []
+    if not isinstance(tools, list):
+        raise ValueError("tools must be a list")
+
+    normalized: list[dict[str, Any]] = []
+    names: list[str] = []
+    for index, tool in enumerate(tools):
+        if not isinstance(tool, dict):
+            raise ValueError(f"tool {index} must be an object")
+        unknown_tool_fields = set(tool) - {"type", "function"}
+        if unknown_tool_fields:
+            fields = ", ".join(sorted(map(str, unknown_tool_fields)))
+            raise ValueError(f"tool {index} has unsupported field(s): {fields}")
+        if tool.get("type", "function") != "function":
+            raise ValueError(f"tool {index} must have type 'function'")
+
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            raise ValueError(f"tool {index}.function must be an object")
+        unknown_function_fields = set(function) - _FUNCTION_FIELDS
+        if unknown_function_fields:
+            fields = ", ".join(sorted(map(str, unknown_function_fields)))
+            raise ValueError(
+                f"tool {index}.function has unsupported field(s): {fields}"
+            )
+
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"tool {index}.function.name must be a non-empty string")
+        if _TOOL_NAME_RE.fullmatch(name) is None:
+            raise ValueError(
+                f"tool {index}.function.name must contain 1-64 letters, digits, "
+                "underscores, or hyphens"
+            )
+        description = function.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError(f"tool {index}.function.description must be a string")
+        parameters = function.get(
+            "parameters", {"type": "object", "properties": {}}
+        )
+        if not isinstance(parameters, dict):
+            raise ValueError(f"tool {index}.function.parameters must be an object")
+        strict = function.get("strict")
+        if "strict" in function and not isinstance(strict, bool):
+            raise ValueError(f"tool {index}.function.strict must be a boolean")
+
+        normalized_function = copy.deepcopy(function)
+        normalized_function["parameters"] = copy.deepcopy(parameters)
+        normalized.append({"type": "function", "function": normalized_function})
+        names.append(name)
+
+    validate_unique_tool_names(names)
+    return normalized
+
+
+def normalize_tool_choice(value: Any) -> NormalizedToolChoice | None:
+    """Normalize supported string and named-function tool choices."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if value not in _STRING_TOOL_CHOICES:
+            raise ValueError(f"unsupported tool_choice {value!r}")
+        return NormalizedToolChoice(value)
+    if not isinstance(value, dict):
+        raise ValueError("tool_choice must be a string or object")
+
+    choice_type = value.get("type")
+    if choice_type in {"auto", "none", "any"}:
+        if set(value) != {"type"}:
+            raise ValueError(f"tool_choice type {choice_type!r} has unsupported fields")
+        mode = "required" if choice_type == "any" else choice_type
+        return NormalizedToolChoice(mode)
+
+    if choice_type == "function":
+        if isinstance(value.get("function"), dict):
+            if set(value) != {"type", "function"}:
+                raise ValueError("named function tool_choice has unsupported fields")
+            function = value["function"]
+            if set(function) != {"name"}:
+                raise ValueError("named function tool_choice requires only function.name")
+            name = function.get("name")
+        else:
+            if set(value) != {"type", "name"}:
+                raise ValueError("named function tool_choice requires only name")
+            name = value.get("name")
+    elif choice_type == "tool":
+        if set(value) != {"type", "name"}:
+            raise ValueError("named tool_choice requires only name")
+        name = value.get("name")
+    else:
+        raise ValueError(f"unsupported tool_choice type {choice_type!r}")
+
+    if not isinstance(name, str) or not name:
+        raise ValueError("named tool_choice requires a non-empty name")
+    return NormalizedToolChoice("named", name)
+
+
+def validate_tool_choice_target(
+    choice: NormalizedToolChoice | None,
+    tools: list[dict[str, Any]],
+) -> None:
+    """Require forced choices to reference an available function tool."""
+    if choice is None or choice.mode in {"auto", "none"}:
+        return
+    names = {tool["function"]["name"] for tool in tools}
+    if choice.mode == "required" and not names:
+        raise ValueError("tool_choice 'required' needs at least one tool")
+    if choice.mode == "named" and choice.name not in names:
+        raise ValueError(f"tool_choice names unavailable tool {choice.name!r}")

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -640,7 +640,11 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         if has_content:
             await self.event_publisher.emit(self.event_factory.text_delta(response.content))
 
-        if response.finish_reason in {"length", "max_tokens"}:
+        if response.finish_reason in {
+            "length",
+            "max_tokens",
+            "model_context_window_exceeded",
+        }:
             reason = "output truncated: provider reached its generation limit"
             self.state.append_message(
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
-    "openai>=1.30",
+    "openai>=1.99.2",
     "anthropic>=0.78",
     "typer>=0.12",
     "rich>=13.0",

--- a/tests/test_anthropic_thinking.py
+++ b/tests/test_anthropic_thinking.py
@@ -225,3 +225,30 @@ def test_tool_round_preserves_all_anthropic_content_in_order():
             {"type": "tool_result", "tool_use_id": "call-1", "content": "passed"}
         ],
     }
+
+
+def test_non_thinking_tool_round_preserves_interleaved_content_in_order():
+    blocks = [
+        SimpleNamespace(type="text", text="First."),
+        SimpleNamespace(type="tool_use", id="call-1", name="run", input={"cmd": "one"}),
+        SimpleNamespace(type="text", text="Second."),
+        SimpleNamespace(type="tool_use", id="call-2", name="run", input={"cmd": "two"}),
+    ]
+    response = parse_anthropic_response(
+        SimpleNamespace(
+            content=blocks,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            stop_reason="tool_use",
+        )
+    )
+    state = SessionState(messages=[{"role": "user", "content": "inspect"}])
+    build_runner(state=state).append_assistant_message(response)
+
+    _, messages = convert_to_anthropic_messages(state.messages)
+
+    assert messages[1]["content"] == [
+        {"type": "text", "text": "First."},
+        {"type": "tool_use", "id": "call-1", "name": "run", "input": {"cmd": "one"}},
+        {"type": "text", "text": "Second."},
+        {"type": "tool_use", "id": "call-2", "name": "run", "input": {"cmd": "two"}},
+    ]

--- a/tests/test_llm_provider_contracts.py
+++ b/tests/test_llm_provider_contracts.py
@@ -1,0 +1,538 @@
+"""Cross-provider request, response, and error contract tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from responses_provider_test_support import FakeStream, completed_response, message_item, ns
+
+from opencollab.adapters.llm.anthropic_provider import (
+    _build_request_kwargs as build_anthropic_kwargs,
+)
+from opencollab.adapters.llm.anthropic_provider import (
+    _parse_response as parse_anthropic_response,
+)
+from opencollab.adapters.llm.errors import is_context_overflow_error
+from opencollab.adapters.llm.openai_provider import (
+    _build_request_kwargs as build_openai_kwargs,
+)
+from opencollab.adapters.llm.openai_provider import (
+    _parse_response as parse_openai_response,
+)
+from opencollab.adapters.llm.responses_provider import (
+    ResponsesProtocolError,
+    _consume_stream,
+    _messages_to_input,
+    _parse_stream,
+)
+from opencollab.adapters.llm.responses_provider import (
+    _build_request_kwargs as build_responses_kwargs,
+)
+
+
+def _schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+
+
+@pytest.mark.parametrize("model", ["o4-mini", "gpt-5", "gateway/gpt-5.6-sol"])
+def test_chat_reasoning_models_use_reasoning_request_fields(model):
+    kwargs = build_openai_kwargs(
+        model,
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        top_p=0.9,
+        max_output_tokens=321,
+        reasoning_effort="max",
+    )
+
+    assert kwargs["reasoning_effort"] == "max"
+    assert kwargs["max_completion_tokens"] == 321
+    assert "max_tokens" not in kwargs
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+
+
+def test_chat_reasoning_effort_is_forwarded_for_compatible_models():
+    kwargs = build_openai_kwargs(
+        "deepseek-v4-flash-0731",
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        reasoning_effort="max",
+    )
+
+    assert kwargs["reasoning_effort"] == "max"
+
+
+def test_chat_thinking_params_cannot_override_reasoning_effort():
+    with pytest.raises(ValueError, match="reasoning_effort"):
+        build_openai_kwargs(
+            "deepseek-v4-flash",
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            thinking=True,
+            thinking_params={"reasoning_effort": "low"},
+            reasoning_effort="max",
+        )
+
+
+def test_anthropic_effort_works_without_explicit_thinking():
+    kwargs = build_anthropic_kwargs(
+        "claude-sonnet-5",
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        reasoning_effort="max",
+    )
+
+    assert kwargs["output_config"] == {"effort": "max"}
+    assert "temperature" not in kwargs
+    assert "thinking" not in kwargs
+
+
+def test_anthropic_default_on_model_honors_thinking_false():
+    kwargs = build_anthropic_kwargs(
+        "claude-sonnet-5",
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        thinking=False,
+    )
+
+    assert kwargs["thinking"] == {"type": "disabled"}
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-fable-5", "claude-mythos-5", "claude-mythos-preview"],
+)
+def test_anthropic_always_on_models_reject_thinking_false(model):
+    with pytest.raises(ValueError, match="cannot disable adaptive thinking"):
+        build_anthropic_kwargs(
+            model,
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            thinking=False,
+        )
+
+
+def test_anthropic_mythos_preview_still_accepts_manual_thinking():
+    kwargs = build_anthropic_kwargs(
+        "claude-mythos-preview",
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        thinking=True,
+        thinking_params={
+            "thinking": {"type": "enabled", "budget_tokens": 4096}
+        },
+        max_output_tokens=8192,
+    )
+
+    assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+
+
+def test_anthropic_modern_models_omit_sampling_without_explicit_thinking():
+    kwargs = build_anthropic_kwargs(
+        "gateway/claude-opus-4-8-20260801",
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        top_p=1.0,
+    )
+
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+
+
+def test_anthropic_modern_models_reject_non_default_top_p():
+    with pytest.raises(ValueError, match="provider-default top_p"):
+        build_anthropic_kwargs(
+            "claude-sonnet-5",
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            top_p=0.9,
+        )
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-5"],
+)
+def test_anthropic_adaptive_only_models_reject_manual_thinking(model):
+    with pytest.raises(ValueError, match="requires adaptive thinking"):
+        build_anthropic_kwargs(
+            model,
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            thinking=True,
+            thinking_params={
+                "thinking": {"type": "enabled", "budget_tokens": 4096}
+            },
+            max_output_tokens=8192,
+        )
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"],
+)
+def test_anthropic_manual_only_models_reject_adaptive_thinking(model):
+    with pytest.raises(ValueError, match="does not support adaptive thinking"):
+        build_anthropic_kwargs(
+            model,
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            thinking=True,
+            thinking_params={"thinking": {"type": "adaptive"}},
+        )
+
+
+def test_anthropic_effort_merges_with_native_output_format():
+    schema = _schema()
+    kwargs = build_anthropic_kwargs(
+        "claude-sonnet-5",
+        [{"role": "user", "content": "solve"}],
+        None,
+        0.2,
+        thinking=True,
+        thinking_params={
+            "thinking": {"type": "adaptive"},
+            "output_config": {
+                "effort": "max",
+                "format": {"type": "json_schema", "schema": schema},
+            },
+        },
+        reasoning_effort="max",
+    )
+
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert kwargs["output_config"] == {
+        "effort": "max",
+        "format": {"type": "json_schema", "schema": schema},
+    }
+
+
+def test_anthropic_rejects_conflicting_effort_sources():
+    with pytest.raises(ValueError, match="conflicts"):
+        build_anthropic_kwargs(
+            "claude-sonnet-5",
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            thinking=True,
+            thinking_params={
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": "low"},
+            },
+            reasoning_effort="max",
+        )
+
+
+@pytest.mark.parametrize("effort", ["none", "minimal"])
+def test_anthropic_rejects_unsupported_generic_effort(effort):
+    with pytest.raises(ValueError, match="unsupported Anthropic reasoning_effort"):
+        build_anthropic_kwargs(
+            "claude-sonnet-5",
+            [{"role": "user", "content": "solve"}],
+            None,
+            0.2,
+            reasoning_effort=effort,
+        )
+
+
+def test_anthropic_preserves_strict_tool_contract():
+    kwargs = build_anthropic_kwargs(
+        "claude-sonnet-5",
+        [{"role": "user", "content": "use the tool"}],
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "submit",
+                    "description": "Submit one value.",
+                    "parameters": _schema(),
+                    "strict": True,
+                },
+            }
+        ],
+        0.2,
+    )
+
+    assert kwargs["tools"] == [
+        {
+            "name": "submit",
+            "description": "Submit one value.",
+            "input_schema": _schema(),
+            "strict": True,
+        }
+    ]
+
+
+def _function_tool(*, strict: object = True, parameters: object = None) -> dict:
+    function: dict[str, object] = {
+        "name": "submit",
+        "description": "Submit one value.",
+        "parameters": _schema() if parameters is None else parameters,
+        "strict": strict,
+    }
+    return {"type": "function", "function": function}
+
+
+def test_all_provider_paths_preserve_false_strict_and_empty_schema():
+    tool = _function_tool(strict=False, parameters={})
+    messages = [{"role": "user", "content": "submit"}]
+
+    chat = build_openai_kwargs("gpt-4o", messages, [tool], 0.2)
+    anthropic = build_anthropic_kwargs("claude-sonnet-5", messages, [tool], 0.2)
+    responses = build_responses_kwargs("gpt-5", messages, [tool], 0.2)
+
+    assert chat["tools"][0]["function"]["strict"] is False
+    assert chat["tools"][0]["function"]["parameters"] == {}
+    assert anthropic["tools"][0]["strict"] is False
+    assert anthropic["tools"][0]["input_schema"] == {}
+    assert responses["tools"][0]["strict"] is False
+    assert responses["tools"][0]["parameters"] == {}
+
+
+@pytest.mark.parametrize("strict", ["false", 0, 1, None])
+def test_all_provider_paths_reject_non_boolean_strict(strict):
+    tool = _function_tool(strict=strict)
+    messages = [{"role": "user", "content": "submit"}]
+
+    with pytest.raises(ValueError, match="strict must be a boolean"):
+        build_openai_kwargs("gpt-4o", messages, [tool], 0.2)
+    with pytest.raises(ValueError, match="strict must be a boolean"):
+        build_anthropic_kwargs("claude-sonnet-5", messages, [tool], 0.2)
+    with pytest.raises(ResponsesProtocolError, match="strict must be a boolean"):
+        build_responses_kwargs("gpt-5", messages, [tool], 0.2)
+
+
+@pytest.mark.parametrize("name", ["has space", "é", "x" * 65])
+def test_all_provider_paths_reject_non_portable_tool_names(name):
+    tool = _function_tool()
+    tool["function"]["name"] = name
+    messages = [{"role": "user", "content": "submit"}]
+
+    with pytest.raises(ValueError, match="1-64"):
+        build_openai_kwargs("gpt-4o", messages, [tool], 0.2)
+    with pytest.raises(ValueError, match="1-64"):
+        build_anthropic_kwargs("claude-sonnet-5", messages, [tool], 0.2)
+    with pytest.raises(ResponsesProtocolError, match="1-64"):
+        build_responses_kwargs("gpt-5", messages, [tool], 0.2)
+
+
+def test_named_tool_choice_has_one_cross_provider_meaning():
+    tool = _function_tool()
+    messages = [{"role": "user", "content": "submit"}]
+    choice = {"type": "function", "name": "submit"}
+
+    chat = build_openai_kwargs(
+        "gpt-4o", messages, [tool], 0.2, tool_choice=choice
+    )
+    anthropic = build_anthropic_kwargs(
+        "claude-sonnet-5", messages, [tool], 0.2, tool_choice=choice
+    )
+    responses = build_responses_kwargs(
+        "gpt-5", messages, [tool], 0.2, tool_choice=choice
+    )
+
+    assert chat["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "submit"},
+    }
+    assert anthropic["tool_choice"] == {"type": "tool", "name": "submit"}
+    assert responses["tool_choice"] == {"type": "function", "name": "submit"}
+
+
+@pytest.mark.parametrize(
+    "choice",
+    [
+        "sometimes",
+        {"type": "function", "function": {}},
+        {"type": "function", "name": "submit", "unexpected": True},
+        {"type": "unknown"},
+    ],
+)
+def test_all_provider_paths_reject_malformed_tool_choice(choice):
+    tool = _function_tool()
+    messages = [{"role": "user", "content": "submit"}]
+
+    with pytest.raises(ValueError, match="tool_choice"):
+        build_openai_kwargs("gpt-4o", messages, [tool], 0.2, tool_choice=choice)
+    with pytest.raises(ValueError, match="tool_choice"):
+        build_anthropic_kwargs(
+            "claude-sonnet-5", messages, [tool], 0.2, tool_choice=choice
+        )
+    with pytest.raises(ResponsesProtocolError, match="tool_choice"):
+        build_responses_kwargs("gpt-5", messages, [tool], 0.2, tool_choice=choice)
+
+
+def test_all_provider_paths_reject_unavailable_named_tool():
+    tool = _function_tool()
+    messages = [{"role": "user", "content": "submit"}]
+    choice = {"type": "function", "function": {"name": "missing"}}
+
+    with pytest.raises(ValueError, match="unavailable tool"):
+        build_openai_kwargs("gpt-4o", messages, [tool], 0.2, tool_choice=choice)
+    with pytest.raises(ValueError, match="unavailable tool"):
+        build_anthropic_kwargs(
+            "claude-sonnet-5", messages, [tool], 0.2, tool_choice=choice
+        )
+    with pytest.raises(ResponsesProtocolError, match="unavailable tool"):
+        build_responses_kwargs("gpt-5", messages, [tool], 0.2, tool_choice=choice)
+
+
+def test_responses_keeps_compaction_record_in_conversation_order():
+    instructions, items = _messages_to_input(
+        [
+            {"role": "system", "content": "global identity"},
+            {"role": "user", "content": "old request"},
+            {"role": "assistant", "content": "old answer"},
+            {
+                "role": "system",
+                "content": "[Context auto-compacted]: earlier work",
+                "compacted": True,
+            },
+            {"role": "user", "content": "new request"},
+        ]
+    )
+
+    assert instructions == "global identity"
+    assert items == [
+        {"role": "user", "content": "old request"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "[Context auto-compacted]: earlier work"},
+        {"role": "user", "content": "new request"},
+    ]
+
+
+def test_responses_rejects_unsupported_content_instead_of_dropping_it():
+    with pytest.raises(ResponsesProtocolError, match="unsupported type 'image_url'"):
+        _messages_to_input(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "inspect"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.test/image.png"},
+                        },
+                    ],
+                }
+            ]
+        )
+
+
+def test_anthropic_rejects_unknown_message_role_instead_of_dropping_it():
+    with pytest.raises(ValueError, match="unsupported role 'developer'"):
+        build_anthropic_kwargs(
+            "claude-sonnet-5",
+            [{"role": "developer", "content": "hidden instruction"}],
+            None,
+            0.2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_responses_typed_context_overflow_keeps_machine_identity():
+    event = ns(
+        type="response.failed",
+        response=ns(
+            error={
+                "code": "context_length_exceeded",
+                "message": "request exceeds the context window",
+            }
+        ),
+    )
+
+    with pytest.raises(ResponsesProtocolError) as captured:
+        await _consume_stream(FakeStream([event]), 1, 1, "gpt-fake")
+
+    assert is_context_overflow_error(captured.value) is True
+    assert captured.value.code == "context_length_exceeded"
+    assert captured.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_responses_max_token_terminal_preserves_partial_output():
+    item = message_item("partial answer")
+    response = completed_response(
+        status="incomplete",
+        incomplete_details={"reason": "max_tokens"},
+        output=[item],
+    )
+    state = await _consume_stream(
+        FakeStream(
+            [
+                ns(type="response.output_item.done", output_index=0, item=item),
+                ns(type="response.incomplete", response=response),
+            ]
+        ),
+        1,
+        1,
+        "gpt-fake",
+    )
+
+    parsed = _parse_stream(
+        state,
+        [{"role": "user", "content": "solve"}],
+        "gpt-fake",
+    )
+
+    assert parsed.content == "partial answer"
+    assert parsed.finish_reason == "max_tokens"
+
+
+def test_chat_response_records_reasoning_usage_and_provider_model():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=20,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=7),
+    )
+    message = SimpleNamespace(content="answer", tool_calls=None, reasoning_content="work")
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=usage,
+        model="provider/gpt-5.6-sol-2026-08-07",
+    )
+
+    parsed = parse_openai_response(response, [{"role": "user", "content": "solve"}])
+
+    assert parsed.usage.reasoning_tokens == 7
+    assert parsed.provider_model == "provider/gpt-5.6-sol-2026-08-07"
+
+
+def test_anthropic_response_records_reasoning_usage_and_provider_model():
+    usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=20,
+        cache_read_input_tokens=40,
+        cache_creation_input_tokens=10,
+        output_tokens_details=SimpleNamespace(thinking_tokens=7),
+    )
+    response = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="answer")],
+        usage=usage,
+        stop_reason="end_turn",
+        model="claude-sonnet-5-20260801",
+    )
+
+    parsed = parse_anthropic_response(response)
+
+    assert parsed.usage.reasoning_tokens == 7
+    assert parsed.provider_model == "claude-sonnet-5-20260801"

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -30,3 +30,10 @@ def test_transport_cause_chain_is_retryable():
 
 def test_unrelated_application_error_is_not_retryable():
     assert is_retryable_error(ValueError("connection error in candidate schema")) is False
+
+
+def test_anthropic_overloaded_status_is_retryable():
+    error = RuntimeError("provider unavailable")
+    error.status_code = 529
+
+    assert is_retryable_error(error) is True

--- a/tests/test_provider_retry_budget_wiring.py
+++ b/tests/test_provider_retry_budget_wiring.py
@@ -99,7 +99,12 @@ async def test_all_provider_paths_receive_the_shared_retry_budget(monkeypatch, m
     captured = []
 
     async def fake_complete(*_args, **kwargs):
-        captured.append(kwargs["provider_error_time_budget"])
+        captured.append(
+            (
+                kwargs["provider_error_time_budget"],
+                kwargs["reasoning_effort"],
+            )
+        )
         return object()
 
     async def skip_usage(**_kwargs):
@@ -122,6 +127,9 @@ async def test_all_provider_paths_receive_the_shared_retry_budget(monkeypatch, m
         client._anthropic = object()
         client._openai = None
 
-    await client.complete([{"role": "user", "content": "hello"}])
+    await client.complete(
+        [{"role": "user", "content": "hello"}],
+        reasoning_effort="max",
+    )
 
-    assert captured == [budget]
+    assert captured == [(budget, "max")]

--- a/tests/test_session_run_loop.py
+++ b/tests/test_session_run_loop.py
@@ -714,7 +714,9 @@ def test_llm_trace_omits_reasoning_when_absent():
     llm_calls = [s for s in tracer.steps if s["step_type"] == "llm_call"]
     assert "reasoning" not in llm_calls[0]["payload"]
 
-@pytest.mark.parametrize("finish_reason", ["length", "max_tokens"])
+@pytest.mark.parametrize(
+    "finish_reason", ["length", "max_tokens", "model_context_window_exceeded"]
+)
 @pytest.mark.parametrize("content", [None, "partial answer"])
 def test_length_finish_reason_stops_with_partial_output(content, finish_reason):
     # A provider length stop is truncated regardless of whether it returned a

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.78" },
     { name = "filelock", specifier = ">=3.15" },
-    { name = "openai", specifier = ">=1.30" },
+    { name = "openai", specifier = ">=1.99.2" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
## Changes

This PR aligns reasoning parameters, function tools, and message content contracts across Chat Completions, Anthropic Messages, and Responses. Chat and Anthropic requests now forward `reasoning_effort`. OpenAI reasoning model detection covers the o4 and GPT-5 families. Provider model identity, reasoning tokens, and cache usage are retained in the common response record.

All three providers now share the same function tool validation. Tool names, parameter schemas, `strict` values, duplicate names, and named `tool_choice` targets are validated before a request is sent. Explicit empty schemas remain unchanged and invalid boolean values are rejected. Responses and Anthropic report unsupported message content or roles as contract errors so input cannot disappear silently.

Anthropic requests select thinking and sampling behavior from the native Claude model generation. Manual, adaptive, always-on, and disabled combinations are validated before the HTTP request. Ordinary tool-use turns retain provider-native content order so later requests can replay text, thinking, and tool-use blocks correctly.

Responses preserves the chronological order of compaction records, retains typed error status and error codes, identifies context overflow, and passes legal output-limit incomplete responses to the session layer. Anthropic HTTP 529 overload responses use bounded retry behavior. The minimum OpenAI SDK version is raised to 1.99.2 to avoid the Responses resource import failure in 1.99.0.

## Validation

Repository-wide Ruff checks pass. The complete test suite passes with 2,332 tests, including 156 focused provider regression tests. Added-file limits and staged diff checks pass. The source distribution and wheel were rebuilt from source, passed Twine metadata validation, and were inspected to confirm that the new tool contract module is present in both artifacts.

The DeepSeek Responses path has real end-to-end request evidence. The OpenAI and Anthropic paths are covered by official SDK type contracts, official protocol documentation, local HTTP and SSE tests, and deterministic regression tests.
