### PR TITLE
fix(llm): report Responses incomplete details

### DIFF
--- a/opencollab/adapters/llm/responses_provider.py
+++ b/opencollab/adapters/llm/responses_provider.py
@@ -378,12 +378,17 @@ def _accept_output_item(event: Any, state: _StreamState) -> None:
 
 def _validate_completed_response(response: Any, expected_model: str | None) -> str:
     status = getattr(response, "status", None)
-    if status != "completed":
-        raise ResponsesProtocolError(f"Responses request ended with status {status!r}")
     error = to_plain_data(getattr(response, "error", None))
+    incomplete = to_plain_data(getattr(response, "incomplete_details", None))
+    if status != "completed":
+        terminal_detail = error if error is not None else incomplete
+        if terminal_detail is not None:
+            raise ResponsesProtocolError(
+                f"Responses request ended with status {status!r}: {terminal_detail!r}"
+            )
+        raise ResponsesProtocolError(f"Responses request ended with status {status!r}")
     if error is not None:
         raise ResponsesProtocolError(f"completed Responses object contains error {error!r}")
-    incomplete = to_plain_data(getattr(response, "incomplete_details", None))
     if incomplete is not None:
         raise ResponsesProtocolError(f"completed Responses object contains incomplete details {incomplete!r}")
     actual_model = getattr(response, "model", None)

--- a/tests/test_responses_provider.py
+++ b/tests/test_responses_provider.py
@@ -307,6 +307,13 @@ async def test_completed_empty_output_exhausts_retry_budget(monkeypatch):
     "response,match",
     [
         (completed_response(status="failed"), "status 'failed'"),
+        (
+            completed_response(
+                status="incomplete",
+                incomplete_details={"reason": "max_output_tokens"},
+            ),
+            "max_output_tokens",
+        ),
         (completed_response(error={"message": "late failure"}), "contains error"),
         (
             completed_response(incomplete_details={"reason": "max_output_tokens"}),


### PR DESCRIPTION
Preserve terminal error and incomplete details when a Responses stream emits response.completed with a non-completed response status. This makes causes such as max_output_tokens observable without changing the protocol failure class or retry behavior. Adds a regression test for the provider event shape observed during evaluation. Verification completed with Ruff, 2284 pytest cases, file hygiene checks, and an independent review.