### PR TITLE
fix(tui): print settled output to scrollback instead of redrawing it

### DIFF
--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -21,6 +21,7 @@ import asyncio
 import os
 import sys
 import uuid
+from functools import partial
 from typing import Any, Optional
 
 import typer
@@ -254,16 +255,31 @@ def _print_hint(label: str, value: str) -> None:
     console.print(line)
 
 
+async def _read_line_at_prompt(tui, prompt_text: Any, **kwargs: Any) -> str:
+    """Read one line with the TUI's scrollback routed through prompt_toolkit.
+
+    Every prompt owns the screen, not just the REPL's: an ``ask_user`` question
+    and a permission y/N are up while other agents keep running, and a settled
+    block printed straight to the console corrupts the prompt's redraw. So the
+    gate belongs to *reading a line*, not to one call site.
+    """
+    tui.set_scrollback_gate(_prompt_scrollback_gate)
+    try:
+        return await _read_line(prompt_text, **kwargs)
+    finally:
+        tui.set_scrollback_gate(None)
+
+
 async def _read_command(tui, bottom_toolbar: Any = None) -> str | None:
     """Prompt for a user line, returning None on EOF/interrupt.
 
-    Tab reprints the newly selected agent while this prompt is on screen, so the
-    TUI's scrollback writes are routed through prompt_toolkit for the duration.
+    Tab reprints the newly selected agent while this prompt is on screen, which
+    is one of the writes ``_read_line_at_prompt`` gates.
     """
     was_suspended = tui.suspend_live()
-    tui.set_scrollback_gate(_prompt_scrollback_gate)
     try:
-        return await _read_line(
+        return await _read_line_at_prompt(
+            tui,
             _PROMPT,
             bottom_toolbar=bottom_toolbar,
             key_bindings=build_agent_navigation_bindings(tui),
@@ -271,7 +287,6 @@ async def _read_command(tui, bottom_toolbar: Any = None) -> str | None:
     except (EOFError, KeyboardInterrupt):
         return None
     finally:
-        tui.set_scrollback_gate(None)
         tui.resume_live(was_suspended)
 
 
@@ -393,10 +408,11 @@ async def _run(
 
     # ``--yolo`` only auto-approves risky commands; a human is still present, so
     # the ask-user tool stays interactive (routed through the TUI's suspend/resume).
+    gated_read_line = partial(_read_line_at_prompt, tui)
     permission_policy = None
     if not yolo:
-        permission_policy = TuiPermissionPolicy(render=tui, read_line=_read_line)
-    ask_policy = TuiAskUserPolicy(render=tui, read_line=_read_line)
+        permission_policy = TuiPermissionPolicy(render=tui, read_line=gated_read_line)
+    ask_policy = TuiAskUserPolicy(render=tui, read_line=gated_read_line)
 
     event_sink = TuiEventSink(tui)
     events_file = os.environ.get("OPENCOLLAB_EVENTS_FILE")
@@ -449,6 +465,12 @@ async def _run(
                     if completed and one_shot_prompt is not None and hold_after_run:
                         await tui.hold_live()
                 finally:
+                    if one_shot_prompt is not None:
+                        # Only the focused agent's blocks reach scrollback, and a
+                        # one-shot run has no "later" in which to Tab back. If the
+                        # user wandered off to watch a teammate, end the run on the
+                        # agent that owes them an answer.
+                        tui.select_agent(target_aid)
                     tui.stop_live()
                     tui.print_stats(
                         scheduler.used_tokens,

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -34,10 +34,7 @@ from opencollab.adapters.cli.config_resolve import (
     print_missing_key_hint,
     resolve_config,
 )
-from opencollab.adapters.cli.prompt_view import (
-    build_agent_navigation_bindings,
-    build_agent_prompt,
-)
+from opencollab.adapters.cli.prompt_view import build_agent_navigation_bindings
 from opencollab.adapters.cli.toolbar import format_team_toolbar
 from opencollab.adapters.cli.workflow import app as workflow_app
 from opencollab.adapters.safe_files import read_regular_text
@@ -230,18 +227,51 @@ def _resolve_one_shot_prompt(prompt: str | None, prompt_file: str | None) -> str
 # ---------------------------------------------------------------------------
 
 
+def _prompt_scrollback_gate(emit: Any) -> None:
+    """Print above a live prompt via prompt_toolkit, which owns the screen."""
+    from prompt_toolkit.application import run_in_terminal
+
+    run_in_terminal(emit)
+
+
+def _print_hint(label: str, value: str) -> None:
+    """One hairline-led chrome line, home-shortened and kept to a single row.
+
+    Session and trajectory paths are long enough to wrap into three or four rows
+    and push real output off the top. The head is elided rather than the tail:
+    the run id and filename at the end are what identify the file.
+    """
+    home = os.path.expanduser("~")
+    if home != "~" and value.startswith(home):
+        value = "~" + value[len(home):]
+    prefix = f"─ {label} → "
+    budget = max(8, console.width - len(prefix))
+    if len(value) > budget:
+        value = "…" + value[-(budget - 1):]
+    line = Text()
+    line.append("─ ", style="grey46")
+    line.append(f"{label} → {value}", style="grey58")
+    console.print(line)
+
+
 async def _read_command(tui, bottom_toolbar: Any = None) -> str | None:
-    """Prompt for a user line, returning None on EOF/interrupt."""
+    """Prompt for a user line, returning None on EOF/interrupt.
+
+    Tab reprints the newly selected agent while this prompt is on screen, so the
+    TUI's scrollback writes are routed through prompt_toolkit for the duration.
+    """
     was_suspended = tui.suspend_live()
+    tui.set_scrollback_gate(_prompt_scrollback_gate)
     try:
         return await _read_line(
-            build_agent_prompt(tui, _PROMPT),
+            _PROMPT,
             bottom_toolbar=bottom_toolbar,
             key_bindings=build_agent_navigation_bindings(tui),
         )
     except (EOFError, KeyboardInterrupt):
         return None
     finally:
+        tui.set_scrollback_gate(None)
         tui.resume_live(was_suspended)
 
 
@@ -399,13 +429,9 @@ async def _run(
         tui.set_team_provider(scheduler.team_roster)
         lead = scheduler.lead_session
         if session_file and os.path.exists(session_file):
-            console.print(
-                f"[grey46]─[/grey46] [grey58]restored from {session_file}[/grey58]"
-            )
+            _print_hint("restored from", str(session_file))
         elif lead.auto_save_path:
-            console.print(
-                f"[grey46]─[/grey46] [grey58]session → {lead.auto_save_path}[/grey58]"
-            )
+            _print_hint("session", str(lead.auto_save_path))
 
         async def turn(line: str, target_aid: int) -> None:
             tui.select_agent(target_aid)
@@ -423,10 +449,7 @@ async def _run(
                     if completed and one_shot_prompt is not None and hold_after_run:
                         await tui.hold_live()
                 finally:
-                    tui.stop_live(
-                        persist=one_shot_prompt is not None,
-                        aid=target_aid,
-                    )
+                    tui.stop_live()
                     tui.print_stats(
                         scheduler.used_tokens,
                         scheduler.agent_step_count(target_aid),
@@ -461,10 +484,7 @@ async def _run(
                 )
             else:
                 try:
-                    console.print(
-                        f"[grey46]─[/grey46] "
-                        f"[grey58]trajectory → {ctx.tracer.path}[/grey58]"
-                    )
+                    _print_hint("trajectory", str(ctx.tracer.path))
                 except BaseException as exc:
                     tracer_failure = exc
     if file_event_sink is not None:

--- a/opencollab/adapters/cli/main.py
+++ b/opencollab/adapters/cli/main.py
@@ -341,7 +341,10 @@ async def _repl_loop(tui: Any, handle_turn, lead: Any, bottom_toolbar: Any = Non
         try:
             result = await handle_turn(line, target_aid)
         except SchedulerTurnError as exc:
-            if exc.partial_answer:
+            # The half-finished answer is salvage: print it only if the turn's
+            # cleanup did not already settle the streamed text into scrollback,
+            # or the user reads the same partial answer twice.
+            if exc.partial_answer and not tui.drained_partial_answer(exc.aid):
                 console.print(Text(exc.partial_answer))
             reason = exc.terminal_reason or exc.phase.value
             style = "yellow" if exc.phase.value == "stopped" else "red"
@@ -465,13 +468,15 @@ async def _run(
                     if completed and one_shot_prompt is not None and hold_after_run:
                         await tui.hold_live()
                 finally:
-                    if one_shot_prompt is not None:
-                        # Only the focused agent's blocks reach scrollback, and a
-                        # one-shot run has no "later" in which to Tab back. If the
-                        # user wandered off to watch a teammate, end the run on the
-                        # agent that owes them an answer.
-                        tui.select_agent(target_aid)
-                    tui.stop_live()
+                    # Only the focused agent's blocks reach scrollback, and a
+                    # one-shot run has no "later" in which to Tab back. If the
+                    # user wandered off to watch a teammate, flush the tail of
+                    # the agent that owes them an answer. The tail, not a focus
+                    # switch: a switch reprints in full and would repeat every
+                    # row this agent already put on screen.
+                    tui.stop_live(
+                        final_aid=target_aid if one_shot_prompt is not None else None
+                    )
                     tui.print_stats(
                         scheduler.used_tokens,
                         scheduler.agent_step_count(target_aid),

--- a/opencollab/adapters/cli/prompt_view.py
+++ b/opencollab/adapters/cli/prompt_view.py
@@ -1,50 +1,19 @@
-"""Prompt Toolkit bindings and redrawable selected-agent history."""
+"""Prompt Toolkit key bindings for selecting the agent a line is addressed to."""
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from typing import Any
 
-from prompt_toolkit.formatted_text import ANSI, to_formatted_text
 from prompt_toolkit.key_binding import KeyBindings
-
-HISTORY_CACHE_MAX_ENTRIES = 16
-
-
-def build_agent_prompt(tui: Any, base_prompt: Any) -> Any:
-    """Return a dynamic prompt containing the selected agent's latest history.
-
-    Prompt Toolkit owns this viewport and erases it when input is submitted, so
-    switching focus replaces the prior agent instead of adding terminal scrollback.
-    The revision-aware cache avoids re-rendering Rich history on every keystroke.
-    """
-    history_cache: OrderedDict[tuple[int, int, int], str] = OrderedDict()
-
-    def prompt() -> list[tuple[str, str]]:
-        key = tui.selected_history_cache_key
-        if key not in history_cache:
-            try:
-                history_cache[key] = tui.render_selected_history()
-            except Exception:
-                history_cache[key] = ""
-            while len(history_cache) > HISTORY_CACHE_MAX_ENTRIES:
-                history_cache.popitem(last=False)
-        else:
-            history_cache.move_to_end(key)
-        history = history_cache[key]
-
-        fragments = []
-        if history:
-            fragments.extend(to_formatted_text(ANSI(history)))
-            fragments.append(("", "\n"))
-        fragments.extend(to_formatted_text(base_prompt))
-        return fragments
-
-    return prompt
 
 
 def build_agent_navigation_bindings(tui: Any) -> KeyBindings:
-    """Bind prompt-owned Tab navigation without touching the input buffer."""
+    """Bind prompt-owned Tab navigation without touching the input buffer.
+
+    Selecting an agent reprints it, and that print has to go through the
+    scrollback gate the CLI installs for the duration of the prompt — otherwise
+    it lands in the middle of prompt_toolkit's own redraw.
+    """
     bindings = KeyBindings()
 
     @bindings.add("tab")
@@ -60,4 +29,4 @@ def build_agent_navigation_bindings(tui: Any) -> KeyBindings:
     return bindings
 
 
-__all__ = ["build_agent_navigation_bindings", "build_agent_prompt"]
+__all__ = ["build_agent_navigation_bindings"]

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -120,7 +120,11 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         # Settled blocks are written straight to the terminal. While a prompt is
         # on screen that write has to be handed to prompt_toolkit instead, or it
         # corrupts the prompt's redraw — the CLI swaps in ``run_in_terminal``.
-        self._scrollback_gate: Callable[[Callable[[], None]], Any] | None = None
+        # A stack, not a slot: prompts overlap (see ``set_scrollback_gate``).
+        self._scrollback_gates: list[Callable[[Callable[[], None]], Any]] = []
+        # Agents whose trailing streamed text the last ``stop_live()`` committed
+        # to scrollback, so a failed turn is not reported twice.
+        self._drained_partial_aids: frozenset[int] = frozenset()
 
     def _state_for(self, aid: int) -> _AgentRenderState:
         """Return one agent's render state, creating it on first observation."""
@@ -134,14 +138,29 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             state.history_omitted_blocks += overflow
             state.printed_blocks = max(0, state.printed_blocks - overflow)
 
+    @property
+    def _scrollback_gate(self) -> Callable[[Callable[[], None]], Any] | None:
+        """The gate currently owning the screen, if any."""
+        return self._scrollback_gates[-1] if self._scrollback_gates else None
+
     def set_scrollback_gate(self, gate: Callable[[Callable[[], None]], Any] | None) -> None:
-        """Route scrollback writes through ``gate`` (``None`` writes directly).
+        """Claim the scrollback gate with ``gate``, or release one with ``None``.
 
         Rich's Live renders ordinary prints above its own region, so a running
         turn needs no gate. A prompt_toolkit prompt owns the screen instead, so
         the CLI installs ``run_in_terminal`` for the duration of the prompt.
+
+        Ownership is a stack rather than a slot because prompts overlap: an
+        ``ask_user`` question and a permission y/N come from two agents running
+        concurrently, and the first to be answered must not uninstall the gate
+        the other one is still relying on. Claims and releases pair up; a
+        release with nothing claimed is a no-op.
         """
-        self._scrollback_gate = gate
+        if gate is None:
+            if self._scrollback_gates:
+                self._scrollback_gates.pop()
+            return
+        self._scrollback_gates.append(gate)
 
     def _write_scrollback(self, emit: Callable[[], None]) -> None:
         gate = self._scrollback_gate
@@ -160,12 +179,29 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         target_aid = self._selected_aid if aid is None else aid
         if target_aid != self._selected_aid:
             return
-        state = self._state_for(target_aid)
+        self._drain_agent_tail(target_aid)
+
+    def _drain_agent_tail(self, aid: int) -> None:
+        """Print one agent's not-yet-printed blocks, focused or not.
+
+        The tail, never a full reprint: a full reprint is what a focus switch
+        owes the user (see ``_reprint_focused_agent``), but everything this
+        agent settled while it *held* focus already reached scrollback, so
+        replaying it would print the transcript twice. An unfocused agent gets
+        a band first, because the rows above it belong to a teammate.
+        """
+        state = self._state_for(aid)
         pending = state.history_blocks[state.printed_blocks:]
         if not pending:
             return
         state.printed_blocks = len(state.history_blocks)
-        self._write_scrollback(lambda: self._print_blocks(pending))
+        blocks = pending if aid == self._selected_aid else [self._focus_band(aid), *pending]
+        self._write_scrollback(lambda: self._print_blocks(blocks))
+
+    def _fully_printed(self, aid: int) -> bool:
+        """Has everything this agent has settled reached scrollback?"""
+        state = self._state_for(aid)
+        return state.printed_blocks == len(state.history_blocks)
 
     def _print_blocks(self, blocks: list[Any]) -> None:
         for block in blocks:
@@ -517,11 +553,16 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             self._keyboard_controller.start()
         self._keyboard_resume_pending = False
 
-    def stop_live(self) -> None:
+    def stop_live(self, final_aid: int | None = None) -> None:
         """Stop the live HUD, settling whatever it still held.
 
         Everything settled during the turn already reached scrollback, so this
         only has to commit the trailing streamed text and drop live-only chrome.
+
+        ``final_aid`` names an agent that must not leave anything unprinted —
+        the one a one-shot run asked, which has no later turn in which the user
+        could Tab back to it. Its tail is flushed even if focus wandered off to
+        a teammate.
         """
         set_quit_callback = getattr(self._keyboard_controller, "set_quit_callback", None)
         if callable(set_quit_callback):
@@ -530,6 +571,7 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         if self._keyboard_controller is not None:
             self._keyboard_controller.stop()
         self._keyboard_resume_pending = False
+        streaming = {aid for aid, state in self._agent_states.items() if state.current_text}
         for state in self._agent_states.values():
             self._flush_current_text_to_timeline(state)
             state.status_lines.clear()
@@ -538,6 +580,22 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             self._live = None
         self._live_paused = False
         self._drain_pending()
+        if final_aid is not None:
+            self._drain_agent_tail(final_aid)
+        self._drained_partial_aids = frozenset(
+            aid for aid in streaming if self._fully_printed(aid)
+        )
+
+    def drained_partial_answer(self, aid: int) -> bool:
+        """Did the last ``stop_live()`` commit this agent's trailing text?
+
+        A turn that ends in ``SchedulerTurnError`` carries the half-finished
+        answer as ``partial_answer``, and the CLI used to print it because the
+        transient Live frame discarded whatever it still held. It no longer
+        does — the text settles into scrollback — so the salvage print now has
+        to ask first, or the user reads the same partial answer twice.
+        """
+        return aid in self._drained_partial_aids
 
     def print_welcome(
         self,

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -24,7 +24,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from rich.console import Console
+from rich.console import Console, Group
+from rich.control import Control
 from rich.live import Live
 from rich.panel import Panel
 from rich.text import Text
@@ -169,6 +170,25 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
     def _print_blocks(self, blocks: list[Any]) -> None:
         for block in blocks:
             self.console.print(block)
+
+    def _scroll_to_screen_top(self) -> None:
+        """Push the visible screen into scrollback, then home the cursor.
+
+        A focus switch reads as a change of view, so the newly focused agent has
+        to open on the terminal's first row. Erasing (``ESC[2J``) would clear the
+        screen too, but erased rows never reach scrollback: the previous agent's
+        last screenful would vanish while its older rows survived, leaving a hole
+        in the very transcript this renderer exists to keep. Scrolling loses
+        nothing — the screen of blank rows is the separator between two agents.
+
+        One print, not two: Live wraps every print with a redraw of its own
+        region, so a redraw landing between the newlines and the home would
+        scroll a live region's worth of blank rows into scrollback.
+        """
+        height = self.console.height
+        if not self.console.is_terminal or height < 1:
+            return
+        self.console.print(Group(Text("\n" * (height - 1)), Control.home()), end="")
 
     def _track_agent_render_lifecycle(self, aid: int, state: str) -> None:
         if aid in self._terminal_summary_order:
@@ -349,12 +369,18 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         return self._selected_aid
 
     def _reprint_focused_agent(self) -> None:
-        """Redraw the newly focused agent in full, under a labelled band.
+        """Redraw the newly focused agent from the top of the screen, under a
+        labelled band.
 
         A full redraw rather than only the unprinted tail: focus is how the user
         asks to look at an agent, and the answer to that has to be its whole
         retained trajectory, not whatever happened to accumulate since they last
         looked. Blocks evicted by the per-agent bound are named, not silently dropped.
+
+        The redraw opens at the first row (see ``_scroll_to_screen_top``) so the
+        agent the user asked for is the only one on screen. A trajectory taller
+        than the terminal still scrolls off the top — the guarantee is where the
+        redraw starts, not that all of it fits.
         """
         state = self._selected_state
         band = self._focus_band(self._selected_aid)
@@ -370,7 +396,11 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
                     style=self._STYLE_MUTED,
                 ),
             )
-        self._write_scrollback(lambda: self._print_blocks([band, *blocks]))
+        def emit() -> None:
+            self._scroll_to_screen_top()
+            self._print_blocks([band, *blocks])
+
+        self._write_scrollback(emit)
 
     def select_agent(self, aid: int) -> int:
         """Select an existing agent and return the resulting aid."""

--- a/opencollab/adapters/tui/renderer.py
+++ b/opencollab/adapters/tui/renderer.py
@@ -5,9 +5,14 @@ Ref:
 - opencode: processor.ts events — text_delta, tool_start, tool_end, etc.
 - openclaw: Rich terminal palette with dynamic updates
 
+Settled output goes to ordinary terminal scrollback the moment it settles, so
+the terminal's own scrollback is the transcript and nothing is ever erased. The
+Live region holds only in-flight chrome — streaming text, tool spinners, the
+wait indicator, and the roster footer — so it stays a few lines tall.
+
 Split by concern (``self`` is unchanged — mixins run on the one TUI instance):
 
-- ``renderer_events``  — event dispatch + timeline/status/roster updates
+- ``renderer_events``  — event dispatch + history/status/roster updates
 - ``renderer_display`` — Rich renderable building + style palette
 - this module          — ``TUI`` state, Live lifecycle, and turn-level API
 """
@@ -15,6 +20,7 @@ Split by concern (``self`` is unchanged — mixins run on the one TUI instance):
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -26,10 +32,7 @@ from rich.text import Text
 from opencollab.adapters.tui.brand_motion import MARK_HEX, PulseDot
 from opencollab.adapters.tui.keyboard import TabKeyNavigator
 from opencollab.adapters.tui.renderer_display import _RendererDisplayMixin
-from opencollab.adapters.tui.renderer_events import (
-    MAX_TIMELINE_BLOCKS,
-    _RendererEventsMixin,
-)
+from opencollab.adapters.tui.renderer_events import _RendererEventsMixin
 from opencollab.domain.session import TERMINAL_PHASES
 
 MAX_HISTORY_BLOCKS_PER_AGENT = 400
@@ -47,16 +50,20 @@ _TERMINAL_RENDER_STATES = frozenset(
 
 @dataclass
 class _AgentRenderState:
-    """Mutable live-render state owned by one scheduler agent."""
+    """Mutable live-render state owned by one scheduler agent.
+
+    ``history_blocks`` is the agent's bounded settled transcript; it is retained
+    after printing because switching focus reprints an agent in full.
+    ``printed_blocks`` is how much of it has already reached scrollback, so an
+    agent that holds focus streams incrementally instead of reprinting.
+    """
 
     current_text: str = ""
     active_tools: dict[str, dict] = field(default_factory=dict)
     status_lines: list[Text] = field(default_factory=list)
     history_blocks: list[Any] = field(default_factory=list)
     history_omitted_blocks: int = 0
-    timeline_blocks: list[Any] = field(default_factory=list)
-    turn_history_start: int = 0
-    history_revision: int = 0
+    printed_blocks: int = 0
     step: int = 0
     thinking: PulseDot | None = None
 
@@ -109,6 +116,10 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         )
         self._keyboard_resume_pending = False
         self._holding_for_exit = False
+        # Settled blocks are written straight to the terminal. While a prompt is
+        # on screen that write has to be handed to prompt_toolkit instead, or it
+        # corrupts the prompt's redraw — the CLI swaps in ``run_in_terminal``.
+        self._scrollback_gate: Callable[[Callable[[], None]], Any] | None = None
 
     def _state_for(self, aid: int) -> _AgentRenderState:
         """Return one agent's render state, creating it on first observation."""
@@ -120,13 +131,44 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         if overflow > 0:
             del state.history_blocks[:overflow]
             state.history_omitted_blocks += overflow
-            state.turn_history_start = max(0, state.turn_history_start - overflow)
+            state.printed_blocks = max(0, state.printed_blocks - overflow)
 
-    def _append_timeline_block(self, state: _AgentRenderState, block: Any) -> None:
-        state.timeline_blocks.append(block)
-        overflow = len(state.timeline_blocks) - MAX_TIMELINE_BLOCKS
-        if overflow > 0:
-            del state.timeline_blocks[:overflow]
+    def set_scrollback_gate(self, gate: Callable[[Callable[[], None]], Any] | None) -> None:
+        """Route scrollback writes through ``gate`` (``None`` writes directly).
+
+        Rich's Live renders ordinary prints above its own region, so a running
+        turn needs no gate. A prompt_toolkit prompt owns the screen instead, so
+        the CLI installs ``run_in_terminal`` for the duration of the prompt.
+        """
+        self._scrollback_gate = gate
+
+    def _write_scrollback(self, emit: Callable[[], None]) -> None:
+        gate = self._scrollback_gate
+        if gate is None:
+            emit()
+            return
+        try:
+            gate(emit)
+        except Exception:
+            # A gate can only fail when its owning prompt is already gone; the
+            # transcript is worth more than the redraw it was protecting.
+            emit()
+
+    def _drain_pending(self, aid: int | None = None) -> None:
+        """Print the focused agent's not-yet-printed settled blocks."""
+        target_aid = self._selected_aid if aid is None else aid
+        if target_aid != self._selected_aid:
+            return
+        state = self._state_for(target_aid)
+        pending = state.history_blocks[state.printed_blocks:]
+        if not pending:
+            return
+        state.printed_blocks = len(state.history_blocks)
+        self._write_scrollback(lambda: self._print_blocks(pending))
+
+    def _print_blocks(self, blocks: list[Any]) -> None:
+        for block in blocks:
+            self.console.print(block)
 
     def _track_agent_render_lifecycle(self, aid: int, state: str) -> None:
         if aid in self._terminal_summary_order:
@@ -201,10 +243,7 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
 
     @_current_text.setter
     def _current_text(self, value: str) -> None:
-        state = self._selected_state
-        if state.current_text != value:
-            state.current_text = value
-            state.history_revision += 1
+        self._selected_state.current_text = value
 
     @property
     def _active_tools(self) -> dict[str, dict]:
@@ -221,20 +260,6 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
     @_status_lines.setter
     def _status_lines(self, value: list[Text]) -> None:
         self._selected_state.status_lines = value
-
-    @property
-    def _timeline_blocks(self) -> list[Any]:
-        return self._selected_state.timeline_blocks
-
-    @_timeline_blocks.setter
-    def _timeline_blocks(self, value: list[Any]) -> None:
-        blocks = list(value)
-        self._selected_state.timeline_blocks = blocks[-MAX_TIMELINE_BLOCKS:]
-        self._selected_state.history_blocks = blocks[-MAX_HISTORY_BLOCKS_PER_AGENT:]
-        self._selected_state.history_omitted_blocks = max(
-            0, len(blocks) - MAX_HISTORY_BLOCKS_PER_AGENT
-        )
-        self._selected_state.history_revision += 1
 
     @property
     def _step(self) -> int:
@@ -283,12 +308,6 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         """Compatibility view: configured-only roles are not input targets."""
         return None
 
-    @property
-    def selected_history_cache_key(self) -> tuple[int, int, int]:
-        """Stable Prompt Toolkit cache key for the current history rendering."""
-        state = self._selected_state
-        return self._selected_aid, state.history_revision, self.console.width
-
     def _focus_targets(self) -> list[_AgentFocusTarget]:
         """Return live agents in stable aid order.
 
@@ -325,8 +344,33 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         changed = not self._focus_is_selected(target)
         self._selected_aid = target.aid
         if changed:
+            self._reprint_focused_agent()
             self._refresh()
         return self._selected_aid
+
+    def _reprint_focused_agent(self) -> None:
+        """Redraw the newly focused agent in full, under a labelled band.
+
+        A full redraw rather than only the unprinted tail: focus is how the user
+        asks to look at an agent, and the answer to that has to be its whole
+        retained trajectory, not whatever happened to accumulate since they last
+        looked. Blocks evicted by the per-agent bound are named, not silently dropped.
+        """
+        state = self._selected_state
+        band = self._focus_band(self._selected_aid)
+        blocks = list(state.history_blocks)
+        omitted = state.history_omitted_blocks
+        state.printed_blocks = len(state.history_blocks)
+        if omitted:
+            blocks.insert(
+                0,
+                Text(
+                    f"... {omitted} older history blocks omitted; "
+                    "full history remains in the run trace.",
+                    style=self._STYLE_MUTED,
+                ),
+            )
+        self._write_scrollback(lambda: self._print_blocks([band, *blocks]))
 
     def select_agent(self, aid: int) -> int:
         """Select an existing agent and return the resulting aid."""
@@ -358,13 +402,11 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         return self.select_relative_agent(1)
 
     def record_user_message(self, aid: int, content: str) -> None:
-        """Add one user turn to the target's redrawable transcript."""
+        """Add one user turn to the target's transcript and settle it."""
         state = self._state_for(aid)
         self._flush_current_text_to_timeline(state)
-        block = self._user_block(content)
-        self._append_history_block(state, block)
-        self._append_timeline_block(state, block)
-        state.history_revision += 1
+        self._append_history_block(state, self._user_block(content))
+        self._drain_pending(aid)
 
     def _refresh(self) -> None:
         """Re-render the current state."""
@@ -445,14 +487,11 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             self._keyboard_controller.start()
         self._keyboard_resume_pending = False
 
-    def stop_live(self, *, persist: bool = False, aid: int | None = None) -> None:
-        """Stop the live HUD while retaining each bounded recent transcript.
+    def stop_live(self) -> None:
+        """Stop the live HUD, settling whatever it still held.
 
-        Interactive transcripts stay inside the redrawable Prompt Toolkit view
-        with an explicit marker when older blocks were omitted. Full history
-        remains owned by the persistent transcript/trace. One-shot callers opt
-        into ``persist`` to print the target's settled turn to ordinary terminal
-        scrollback.
+        Everything settled during the turn already reached scrollback, so this
+        only has to commit the trailing streamed text and drop live-only chrome.
         """
         set_quit_callback = getattr(self._keyboard_controller, "set_quit_callback", None)
         if callable(set_quit_callback):
@@ -461,20 +500,14 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
         if self._keyboard_controller is not None:
             self._keyboard_controller.stop()
         self._keyboard_resume_pending = False
-        settled = None
-        if self._live:
-            if persist:
-                settled = self._build_settled_display(
-                    aid=self._selected_aid if aid is None else aid
-                )
-            self._live.stop()
-            self._live = None
-        if settled is not None:
-            self.console.print(settled)
-        self._live_paused = False
         for state in self._agent_states.values():
             self._flush_current_text_to_timeline(state)
             state.status_lines.clear()
+        if self._live:
+            self._live.stop()
+            self._live = None
+        self._live_paused = False
+        self._drain_pending()
 
     def print_welcome(
         self,
@@ -555,8 +588,6 @@ class TUI(_RendererEventsMixin, _RendererDisplayMixin):
             self._flush_current_text_to_timeline(state)
             state.active_tools.clear()
             state.status_lines.clear()
-            state.timeline_blocks.clear()
-            state.turn_history_start = len(state.history_blocks)
             state.step = 0
             state.thinking = None
         self._state_for(0)

--- a/opencollab/adapters/tui/renderer_display.py
+++ b/opencollab/adapters/tui/renderer_display.py
@@ -10,9 +10,10 @@ to its content instead of claiming the whole terminal.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.markdown import Markdown
 from rich.segment import Segment
 from rich.text import Text
@@ -37,16 +38,38 @@ MAX_LIVE_BODY_LINES = 12
 
 
 class _LineViewport:
-    """A pre-rendered, bottom-aligned live viewport."""
+    """A pre-rendered, bottom-aligned live viewport.
 
-    def __init__(self, lines: list[list[Segment]]) -> None:
+    ``close`` terminates the final line. Every ordinary Rich renderable does,
+    and a group relies on it: left open, the renderable that follows is
+    appended to a row that is already the full terminal width, and the crop
+    to that width silently swallows it.
+    """
+
+    def __init__(self, lines: list[list[Segment]], *, close: bool = False) -> None:
         self.lines = lines
+        self.close = close
 
     def __rich_console__(self, console: Console, options: Any) -> Any:
         for index, line in enumerate(self.lines):
             yield from line
-            if index < len(self.lines) - 1:
+            if self.close or index < len(self.lines) - 1:
                 yield Segment.line()
+
+
+class _LiveLine:
+    """One row, rebuilt on every Live frame.
+
+    The pulsing dot and its seconds counter are functions of wall time, so the
+    status row has to be recomputed per frame — Live re-renders the object it
+    was handed, and a ``Text`` built once would sit frozen between events.
+    """
+
+    def __init__(self, build: Callable[[], Text | None]) -> None:
+        self._build = build
+
+    def __rich__(self) -> Text:
+        return self._build() or Text("")
 
 
 class _RendererDisplayMixin:
@@ -125,8 +148,13 @@ class _RendererDisplayMixin:
             for aid in sorted(self._roster)
         ]
 
-    def _build_team_panel(self) -> Any | None:
-        """One-line bottom status roster, or None when no team exists."""
+    def _build_team_panel(self, *, width: int | None = None) -> Any | None:
+        """The roster half of the status row, or None when no team exists.
+
+        ``width`` is the space left after the activity half; it defaults to the
+        whole terminal for callers that render the roster on its own.
+        """
+        available = max(1, self.console.width if width is None else width)
         entries = self._team_entries()
         if not entries:
             return None
@@ -180,9 +208,61 @@ class _RendererDisplayMixin:
             return line
 
         line = build_line(compact=False)
-        if line.cell_len > self.console.width:
+        if line.cell_len > available:
             line = build_line(compact=True)
-        line.truncate(max(1, self.console.width), overflow="ellipsis")
+        line.truncate(available, overflow="ellipsis")
+        return line
+
+    def _activity_text(self) -> Text | None:
+        """The activity half of the status row: what this agent is doing now.
+
+        One line, so the three in-flight signals are ranked rather than stacked:
+        a running tool is the most concrete, the model wait is next, and a
+        transient status note only shows when nothing else is happening.
+        """
+        if self._active_tools:
+            label, data = next(iter(self._active_tools.items()))
+            text = self._motion.render()
+            text.append("  ", style=self._STYLE_MUTED)
+            text.append(str(data.get("_display_label", label)), style=self._STYLE_ACCENT)
+            text.append(self._args_preview(data, limit=40, code=True), style=self._STYLE_MUTED)
+            if len(self._active_tools) > 1:
+                text.append(f"  +{len(self._active_tools) - 1}", style=self._STYLE_MUTED)
+            return text
+        if self._thinking is not None:
+            return self._thinking.render()
+        if self._status_lines:
+            text = self._motion.render()
+            text.append("  ", style=self._STYLE_MUTED)
+            text.append_text(self._status_lines[-1])
+            return text
+        return None
+
+    def _build_status_row(self) -> Text | None:
+        """The whole live frame's chrome on one row: activity, then roster.
+
+        Everything the frame says about *state* shares this single row — it is
+        the terminal's bottom status bar. Stacking it (a heading per tool, a row
+        per status note, a roster line) cost up to a dozen rows and pushed the
+        settled transcript off the screen it belongs on.
+
+        Activity goes left because it is the volatile half and the half that
+        must never be the one truncated; the roster already knows how to shrink
+        into whatever width is left.
+        """
+        width = max(1, self.console.width)
+        line = Text(no_wrap=True, overflow="ellipsis")
+        activity = self._activity_text()
+        if activity is not None:
+            line.append_text(activity)
+        roster = self._build_team_panel(width=width - line.cell_len - 2)
+        if roster is not None:
+            if line.cell_len:
+                line.append("  ", style=self._STYLE_MUTED)
+            line.append_text(roster)
+        if not line.cell_len:
+            return None
+        line.truncate(width, overflow="ellipsis")
         return line
 
     def _new_thinking_bar(self, label: str) -> PulseDot:
@@ -233,77 +313,54 @@ class _RendererDisplayMixin:
         title = f"{label} {role}" if role and aid != 0 else label
         return Rule(Text(title, style=self._STYLE_HEADING), style=self._STYLE_MUTED)
 
-    def _build_display(self, *, include_team_panel: bool = True) -> Any:
-        """Build the Rich renderable for the in-flight state.
+    def _build_body(self) -> Any | None:
+        """The in-flight content above the status row: the streaming answer.
 
-        Settled blocks are not included: they already went to scrollback.
+        Settled blocks are not included: they already went to scrollback. Tool
+        progress, status notes and the roster are not here either — they are
+        chrome, and chrome lives on the one status row.
         """
-        parts = []
-
+        if not self._current_text:
+            return None
         # Current streaming chunk — fronted by the brand ◆ gutter marker.
-        if self._current_text:
-            parts.append(self._assistant_block(Markdown(self._current_text)))
-            parts.append(Text("", style=""))
+        return self._assistant_block(Markdown(self._current_text))
 
-        # Active tool spinners — the shared pulsing brand dot, one calm
-        # motion for every tool. Each tool is a one-row Table.grid so the spinner
-        # cell and label cell stay on a single render line (the block is captured
-        # by render_lines in _build_live_display).
-        if self._active_tools:
-            from rich.table import Table
-
-            parts.append(Text("Running", style=self._STYLE_HEADING))
-            for label, data in self._active_tools.items():
-                args_preview = self._args_preview(data, limit=60, code=True)
-                display_label = data.get("_display_label", label)
-
-                label_text = Text.assemble(
-                    (display_label, self._STYLE_ACCENT),  # tool name carries the accent
-                    (args_preview, self._STYLE_MUTED),  # preview stays dim (" `ls -la`")
-                )
-                row = Table.grid(padding=(0, 1))
-                row.add_column(no_wrap=True)            # spinner cell
-                row.add_column(ratio=1)                 # label + args cell
-                row.add_row(self._motion, label_text)
-                parts.append(row)
-            parts.append(Text("", style=""))
-
-        if self._status_lines:
-            parts.extend(self._status_lines)
-            parts.append(Text("", style=""))
-
-        # LLM-wait indicator: the animated pulsing dot (replaces the old static
-        # "thinking" line). Shown while waiting on the model; cleared as soon as
-        # text or tool progress arrives. Being time-driven, it keeps pulsing on
-        # Live's refresh even when no new events land — so it never looks frozen.
-        if self._thinking is not None:
-            parts.append(self._thinking)
-            parts.append(Text("", style=""))
-
-        if include_team_panel:
-            team_panel = self._build_team_panel()
-            if team_panel is not None:
-                parts.append(team_panel)
-
-        if not parts:
+    def _build_display(self) -> Any:
+        """The whole in-flight frame, uncropped: body then status row."""
+        body = self._build_body()
+        status = self._status_renderable()
+        if body is None:
             # Nothing yet — still animate the wait so first-token latency doesn't
             # look frozen. Route the placeholder through the same pulsing dot.
-            return self._thinking or self._new_thinking_bar("Thinking…")
+            return status or self._thinking or self._new_thinking_bar("Thinking…")
+        return Group(body, status) if status is not None else body
 
-        from rich.console import Group
-        return Group(*parts)
+    def _status_renderable(self) -> Any | None:
+        """The status row as a per-frame renderable, or None when it is empty."""
+        if self._build_status_row() is None:
+            return None
+        return _LiveLine(self._build_status_row)
 
     def _build_live_display(self) -> Any:
-        """Build a live frame sized to its content, roster footer last.
+        """Build a live frame sized to its content, the status row last.
 
-        The frame is capped at ``MAX_LIVE_BODY_LINES`` (and at the terminal
-        height) and shows the tail when it overflows. It is never padded out to
+        The body is capped at ``MAX_LIVE_BODY_LINES`` (and at the terminal
+        height) and shows its tail when it overflows. It is never padded out to
         the terminal height: a short frame must occupy few rows so the settled
         transcript printed above it stays on screen.
+
+        The status row is cropped out of the body budget rather than out of the
+        frame, and stays a live renderable instead of pre-rendered lines — it is
+        the row that has to keep animating between events.
         """
+        status = self._status_renderable()
         max_height = max(1, min(MAX_LIVE_BODY_LINES, self.console.height))
-        display = self._build_display()
-        lines = self.console.render_lines(display, self.console.options, pad=False)
-        if len(lines) <= max_height:
-            return display
-        return _LineViewport(lines[-max_height:])
+        if status is not None:
+            max_height -= 1
+        body = self._build_body()
+        if body is None or max_height < 1:
+            return status or self._thinking or self._new_thinking_bar("Thinking…")
+        lines = self.console.render_lines(body, self.console.options, pad=False)
+        if len(lines) > max_height:
+            body = _LineViewport(lines[-max_height:], close=status is not None)
+        return Group(body, status) if status is not None else body

--- a/opencollab/adapters/tui/renderer_display.py
+++ b/opencollab/adapters/tui/renderer_display.py
@@ -37,6 +37,31 @@ from opencollab.application.scheduler_types import roster_display_state
 MAX_LIVE_BODY_LINES = 12
 
 
+def collapse_rows(value: str) -> str:
+    """Fold CR/LF into spaces so one line of chrome stays one terminal row.
+
+    Chrome quotes text the renderer does not control — a shell command, a tool
+    argument, an error reason. A newline in any of them turns the single shared
+    status row into three, which is the regression the one-row chrome exists to
+    prevent. Width is already handled downstream by truncation.
+    """
+    if "\n" not in value and "\r" not in value:
+        return value
+    return " ".join(value.replace("\r\n", "\n").replace("\r", "\n").split("\n"))
+
+
+def collapse_text_rows(text: Text) -> Text:
+    """``collapse_rows`` for a styled ``Text``.
+
+    Status lines carry a single base style rather than per-word spans, so
+    rebuilding the string keeps the line looking the same.
+    """
+    plain = text.plain
+    if "\n" not in plain and "\r" not in plain:
+        return text
+    return Text(collapse_rows(plain), style=text.style)
+
+
 class _LineViewport:
     """A pre-rendered, bottom-aligned live viewport.
 
@@ -126,7 +151,7 @@ class _RendererDisplayMixin:
             for key in self._PREVIEW_KEYS:
                 value = source.get(key)
                 if isinstance(value, str):
-                    text = value[:limit]
+                    text = collapse_rows(value)[:limit]
                     return f" `{text}`" if code and key == "command" else f" {text}"
         return ""
 

--- a/opencollab/adapters/tui/renderer_display.py
+++ b/opencollab/adapters/tui/renderer_display.py
@@ -1,7 +1,11 @@
-"""Display building for the TUI: team panel, timeline, and live viewport.
+"""Display building for the TUI: team panel, live viewport, and block chrome.
 
 Mixed into ``renderer.TUI`` — methods render the state that
 ``renderer_events`` maintains. Also owns the shared style palette.
+
+Settled blocks are printed to scrollback by ``renderer``; what is built here for
+the Live region is only the in-flight remainder, so the frame stays proportional
+to its content instead of claiming the whole terminal.
 """
 
 from __future__ import annotations
@@ -25,6 +29,12 @@ from opencollab.adapters.tui.theme import (
 )
 from opencollab.application.scheduler_types import roster_display_state
 
+# Ceiling on the Live region, in terminal rows. The live frame carries only
+# in-flight chrome, so it is normally far shorter; this bounds the pathological
+# case (a long streamed answer) so the region can never take over the terminal
+# the way a full-height frame did.
+MAX_LIVE_BODY_LINES = 12
+
 
 class _LineViewport:
     """A pre-rendered, bottom-aligned live viewport."""
@@ -37,27 +47,6 @@ class _LineViewport:
             yield from line
             if index < len(self.lines) - 1:
                 yield Segment.line()
-
-
-class _PinnedFooterViewport:
-    """A live body that reserves the terminal's physical bottom row for status."""
-
-    def __init__(self, body: Any, footer: Any) -> None:
-        self.body = body
-        self.footer = footer
-
-    def __rich_console__(self, console: Console, options: Any) -> Any:
-        max_height = max(1, console.height)
-        body_lines = console.render_lines(self.body, options, pad=False)
-        footer_lines = console.render_lines(self.footer, options, pad=False)
-        if len(footer_lines) >= max_height:
-            lines = footer_lines[-max_height:]
-        else:
-            body_height = max_height - len(footer_lines)
-            visible_body = body_lines[-body_height:] if body_height else []
-            spacer = [[] for _ in range(body_height - len(visible_body))]
-            lines = [*visible_body, *spacer, *footer_lines]
-        yield from _LineViewport(lines).__rich_console__(console, options)
 
 
 class _RendererDisplayMixin:
@@ -228,14 +217,28 @@ class _RendererDisplayMixin:
         )
         return grid
 
-    def _build_display(self, *, include_team_panel: bool = True) -> Any:
-        """Build the Rich renderable for current state."""
-        parts = []
+    def _focus_band(self, aid: int) -> Any:
+        """The labelled rule that opens a newly focused agent's redraw."""
+        from rich.rule import Rule
 
-        # Chronological blocks (assistant text snapshots + activity lines).
-        if self._timeline_blocks:
-            parts.extend(self._timeline_blocks)
-            parts.append(Text("", style=""))
+        role = next(
+            (
+                str(entry_role)
+                for entry_aid, entry_role, _state in self._team_entries()
+                if entry_aid == aid
+            ),
+            "",
+        )
+        label = self._agent_label(aid)
+        title = f"{label} {role}" if role and aid != 0 else label
+        return Rule(Text(title, style=self._STYLE_HEADING), style=self._STYLE_MUTED)
+
+    def _build_display(self, *, include_team_panel: bool = True) -> Any:
+        """Build the Rich renderable for the in-flight state.
+
+        Settled blocks are not included: they already went to scrollback.
+        """
+        parts = []
 
         # Current streaming chunk — fronted by the brand ◆ gutter marker.
         if self._current_text:
@@ -291,56 +294,16 @@ class _RendererDisplayMixin:
         return Group(*parts)
 
     def _build_live_display(self) -> Any:
-        """Build a live frame with the team status on the terminal's bottom row."""
-        max_height = max(1, self.console.height)
-        team_panel = self._build_team_panel()
-        if team_panel is None:
-            display = self._build_display()
-            lines = self.console.render_lines(display, self.console.options, pad=False)
-            if len(lines) <= max_height:
-                return display
-            return _LineViewport(lines[-max_height:])
+        """Build a live frame sized to its content, roster footer last.
 
-        body = self._build_display(include_team_panel=False)
-        return _PinnedFooterViewport(body, team_panel)
-
-    def _build_settled_display(self, *, aid: int = 0) -> Any | None:
-        """Build one settled turn for an explicit scrollback handoff.
-
-        Interactive mode keeps this material in the redrawable history viewport;
-        one-shot mode uses this slice so it still leaves a normal terminal result.
-        Live-only chrome (spinner, transient status, roster) is excluded.
+        The frame is capped at ``MAX_LIVE_BODY_LINES`` (and at the terminal
+        height) and shows the tail when it overflows. It is never padded out to
+        the terminal height: a short frame must occupy few rows so the settled
+        transcript printed above it stays on screen.
         """
-        state = self._state_for(aid)
-        if state.current_text:
-            self._flush_current_text_to_timeline(state)
-        return self._build_history_display(state, start=state.turn_history_start)
-
-    def _build_history_display(self, state: Any, *, start: int = 0) -> Any | None:
-        """Build the requested slice of one agent's history without live chrome."""
-        blocks = list(state.history_blocks[start:])
-        if start == 0 and state.history_omitted_blocks:
-            blocks.insert(
-                0,
-                Text(
-                    f"... {state.history_omitted_blocks} older history blocks "
-                    "omitted; full history remains in the run trace.",
-                    style=self._STYLE_MUTED,
-                ),
-            )
-        if state.current_text:
-            blocks.append(self._assistant_block(Markdown(state.current_text)))
-        if not blocks:
-            return None
-        from rich.console import Group
-
-        return Group(*blocks)
-
-    def render_selected_history(self) -> str:
-        """Render the selected agent's complete history for Prompt Toolkit."""
-        display = self._build_history_display(self._selected_state)
-        if display is None:
-            return ""
-        with self.console.capture() as capture:
-            self.console.print(display, end="")
-        return capture.get().rstrip("\n")
+        max_height = max(1, min(MAX_LIVE_BODY_LINES, self.console.height))
+        display = self._build_display()
+        lines = self.console.render_lines(display, self.console.options, pad=False)
+        if len(lines) <= max_height:
+            return display
+        return _LineViewport(lines[-max_height:])

--- a/opencollab/adapters/tui/renderer_events.py
+++ b/opencollab/adapters/tui/renderer_events.py
@@ -12,6 +12,7 @@ from typing import Any
 from rich.markdown import Markdown
 from rich.text import Text
 
+from opencollab.adapters.tui.renderer_display import collapse_text_rows
 from opencollab.domain.events import SchedulerEvent
 
 MAX_STATUS_LINES = 40
@@ -304,7 +305,9 @@ class _RendererEventsMixin:
             self._append_history_block(target, status)
             self._drain_pending(target_aid)
         if self._live or self._live_paused:
-            target.status_lines.append(status)
+            # The status row is one row. The preserved copy above keeps the
+            # message whole in scrollback, so nothing is lost by folding it.
+            target.status_lines.append(collapse_text_rows(status))
             overflow = len(target.status_lines) - MAX_STATUS_LINES
             if overflow > 0:
                 del target.status_lines[:overflow]

--- a/opencollab/adapters/tui/renderer_events.py
+++ b/opencollab/adapters/tui/renderer_events.py
@@ -1,7 +1,8 @@
 """Event handling for the TUI: session-runtime + scheduler event dispatch.
 
 Mixed into ``renderer.TUI`` — methods run on the TUI instance and feed the
-timeline/status/roster state that ``renderer_display`` renders.
+history/status/roster state that ``renderer_display`` renders. A block that
+settles here is handed straight to scrollback for the focused agent.
 """
 
 from __future__ import annotations
@@ -13,8 +14,6 @@ from rich.text import Text
 
 from opencollab.domain.events import SchedulerEvent
 
-# Cap on retained timeline blocks so long sessions don't grow render cost.
-MAX_TIMELINE_BLOCKS = 80
 MAX_STATUS_LINES = 40
 
 
@@ -72,9 +71,7 @@ class _RendererEventsMixin:
 
         if etype == "text_delta":
             self._clear_thinking_status(state)
-            content = event.data.get("content", "")
-            state.current_text += content
-            state.history_revision += 1
+            state.current_text += event.data.get("content", "")
             self._refresh()
 
         elif etype == "tool_start":
@@ -297,10 +294,11 @@ class _RendererEventsMixin:
         """Route status lines to Live when active; print directly otherwise."""
         status = message if isinstance(message, Text) else Text.from_markup(message)
         target = state or self._selected_state
+        target_aid = self._aid_of(target)
         if preserve:
             self._flush_current_text_to_timeline(target)
             self._append_history_block(target, status)
-            target.history_revision += 1
+            self._drain_pending(target_aid)
         if self._live or self._live_paused:
             target.status_lines.append(status)
             overflow = len(target.status_lines) - MAX_STATUS_LINES
@@ -308,7 +306,11 @@ class _RendererEventsMixin:
                 del target.status_lines[:overflow]
             self._refresh()
             return
-        self.console.print(status)
+        # No live frame to hold a transient line. Printing it is the only way to
+        # show it at all — but it still obeys focus, and a preserved line has
+        # already been printed as part of the transcript.
+        if not preserve and target_aid == self._selected_aid:
+            self.console.print(status)
 
     def _append_activity(
         self,
@@ -322,10 +324,8 @@ class _RendererEventsMixin:
         self._flush_current_text_to_timeline(target)
         styled_segments: list[tuple[str, str]] = [marker or self._MARK_DOT]
         styled_segments.extend((text, style) for text, style in segments if text)
-        line = Text.assemble(*styled_segments)
-        self._append_history_block(target, line)
-        self._append_timeline_block(target, line)
-        target.history_revision += 1
+        self._append_history_block(target, Text.assemble(*styled_segments))
+        self._drain_pending(self._aid_of(target))
 
     def _flush_current_text_to_timeline(self, state: Any | None = None) -> None:
         """Commit accumulated assistant text so later events appear in-order."""
@@ -333,10 +333,21 @@ class _RendererEventsMixin:
         if not target.current_text:
             return
         block = self._assistant_block(Markdown(target.current_text))
-        self._append_history_block(target, block)
-        self._append_timeline_block(target, block)
         target.current_text = ""
-        target.history_revision += 1
+        self._append_history_block(target, block)
+        self._drain_pending(self._aid_of(target))
+
+    def _aid_of(self, state: Any) -> int:
+        """Reverse-lookup an agent id from its render state.
+
+        Event handlers thread the state object, not the aid, and only the
+        focused agent's blocks may be printed — so the printer needs the aid
+        back. An unregistered state yields ``-1``, which can never be focused.
+        """
+        return next(
+            (aid for aid, candidate in self._agent_states.items() if candidate is state),
+            -1,
+        )
 
     def _clear_thinking_status(self, state: Any | None = None) -> None:
         """Drop the transient LLM-wait indicator before fresher progress shows."""

--- a/opencollab/adapters/tui/renderer_events.py
+++ b/opencollab/adapters/tui/renderer_events.py
@@ -127,15 +127,19 @@ class _RendererEventsMixin:
         elif etype == "loop_detected":
             tool = event.data.get("tool", "?")
             count = event.data.get("count", 0)
+            # Preserved: with the live chrome down to one shared row, a warning
+            # that only lived there would be overwritten by the next tool.
             self._emit_status(
                 Text(f"Loop detected: {tool} called {count}x with same args", style=self._STYLE_WARNING),
                 state=state,
+                preserve=True,
             )
 
         elif etype == "budget_warning":
             self._emit_status(
                 Text("Token budget running low", style=self._STYLE_WARNING),
                 state=state,
+                preserve=True,
             )
 
         elif etype == "error":

--- a/tests/test_cli_main_lifecycle.py
+++ b/tests/test_cli_main_lifecycle.py
@@ -360,6 +360,10 @@ async def test_one_shot_prints_the_answer_even_if_focus_wandered_to_a_teammate(
     Only the focused agent's blocks reach scrollback, so a run that ends while
     the user is watching a teammate would exit with the answer it was asked for
     settled in memory and never printed.
+
+    Exactly once, too: the flush is a tail drain, not a focus switch. A focus
+    switch reprints an agent in full, which would repeat every row the lead had
+    already put on screen before the user wandered off.
     """
     from io import StringIO
 
@@ -390,6 +394,13 @@ async def test_one_shot_prints_the_answer_even_if_focus_wandered_to_a_teammate(
 
         async def run_turn(self, aid, line):
             tui = holder["tui"]
+            # Settled while the lead still holds focus: already in scrollback.
+            tui.event_handler(
+                SessionRuntimeEvent("text_delta", {"content": "an early lead line", "aid": 0})
+            )
+            tui.event_handler(
+                SessionRuntimeEvent("tool_start", {"tool": "bash", "args": {"command": "pwd"}, "aid": 0})
+            )
             tui.event_handler(
                 SessionRuntimeEvent("text_delta", {"content": "the final answer", "aid": 0})
             )
@@ -423,7 +434,8 @@ async def test_one_shot_prints_the_answer_even_if_focus_wandered_to_a_teammate(
 
     scrollback = console.file.getvalue()
     assert "teammate notes" in scrollback
-    assert "the final answer" in scrollback
+    assert scrollback.count("the final answer") == 1
+    assert scrollback.count("an early lead line") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_main_lifecycle.py
+++ b/tests/test_cli_main_lifecycle.py
@@ -351,6 +351,82 @@ async def test_cli_successful_one_shot_holds_before_stopping_and_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_one_shot_prints_the_answer_even_if_focus_wandered_to_a_teammate(
+    monkeypatch,
+    tmp_path,
+):
+    """A one-shot run has no "later" in which to Tab back to the lead.
+
+    Only the focused agent's blocks reach scrollback, so a run that ends while
+    the user is watching a teammate would exit with the answer it was asked for
+    settled in memory and never printed.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+
+    from opencollab.adapters.tui import TUI
+    from opencollab.domain.events import SessionRuntimeEvent
+
+    console = Console(file=StringIO(), width=100, color_system=None)
+    holder: dict[str, TUI] = {}
+
+    class OneShotTUI(TUI):
+        def __init__(self, *args, **kwargs):
+            super().__init__(console)
+            holder["tui"] = self
+
+        async def hold_live(self):
+            # The user Tabs to a teammate to read its trajectory, then quits.
+            self.select_agent(1)
+            return True
+
+    class Scheduler:
+        used_tokens = 7
+        lead_session = SimpleNamespace(auto_save_path=None, step_count=1)
+
+        def team_roster(self):
+            return []
+
+        async def run_turn(self, aid, line):
+            tui = holder["tui"]
+            tui.event_handler(
+                SessionRuntimeEvent("text_delta", {"content": "the final answer", "aid": 0})
+            )
+            tui.event_handler(
+                SessionRuntimeEvent("text_delta", {"content": "teammate notes", "aid": 1})
+            )
+            # Settles the teammate's text, so focusing it has something to show.
+            tui.event_handler(
+                SessionRuntimeEvent("tool_start", {"tool": "bash", "args": {"command": "ls"}, "aid": 1})
+            )
+
+        def agent_step_count(self, aid):
+            return 1
+
+        async def cleanup(self):
+            return None
+
+    install_cli_fakes(monkeypatch, Scheduler(), FakeTracer())
+    monkeypatch.setattr(tui_mod, "TUI", OneShotTUI)
+
+    await cli_main._run(
+        str(tmp_path),
+        config(),
+        None,
+        True,
+        True,
+        False,
+        one_shot_prompt="do work",
+        hold_after_run=True,
+    )
+
+    scrollback = console.file.getvalue()
+    assert "teammate notes" in scrollback
+    assert "the final answer" in scrollback
+
+
+@pytest.mark.asyncio
 async def test_cli_warns_when_event_log_persistence_is_degraded(
     monkeypatch,
     tmp_path,

--- a/tests/test_cli_main_lifecycle.py
+++ b/tests/test_cli_main_lifecycle.py
@@ -102,6 +102,9 @@ def test_cli_preserves_nonblank_unicode_prompt():
 
 
 class FakeConsole:
+    # Chrome lines are truncated to the console width, as a real Console has.
+    width = 80
+
     def print(self, *args, **kwargs):
         return None
 

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -29,9 +29,13 @@ class _FakeTUI:
     def __init__(self) -> None:
         self.selected_aid = 0
         self.gates: list = []
+        self.drained_partials: set[int] = set()
 
     def set_scrollback_gate(self, gate) -> None:
         self.gates.append(gate)
+
+    def drained_partial_answer(self, aid: int) -> bool:
+        return aid in self.drained_partials
 
     def select_next_agent(self) -> int | None:
         self.selected_aid = 1 if self.selected_aid == 0 else 2
@@ -351,6 +355,39 @@ async def test_repl_reports_stopped_turn_and_accepts_next_input(monkeypatch):
         "Agent 2 stopped: token budget exhausted",
     ]
     assert len(dividers) == 2
+
+
+@pytest.mark.asyncio
+async def test_stopped_turn_does_not_print_a_partial_answer_already_in_scrollback(monkeypatch):
+    """The partial answer is salvage, and the turn's cleanup may have got there first.
+
+    ``stop_live`` settles the trailing streamed text into scrollback, so printing
+    ``partial_answer`` unconditionally shows the user the same text twice.
+    """
+    tui = _FakeTUI()
+    tui.selected_aid = 2
+    tui.drained_partials = {2}
+    lines = iter(["first", None])
+    monkeypatch.setattr(
+        cli_main,
+        "_read_command",
+        lambda *_args, **_kwargs: asyncio.sleep(0, result=next(lines)),
+    )
+    printed: list[str] = []
+    monkeypatch.setattr(
+        cli_main,
+        "console",
+        SimpleNamespace(print=lambda value: printed.append(str(value))),
+    )
+
+    async def handle_turn(line: str, aid: int) -> None:
+        raise SchedulerTurnError(aid, SessionPhase.STOPPED, "token budget exhausted", "partial answer")
+
+    tui.print_turn_divider = lambda: None
+
+    await cli_main._repl_loop(tui, handle_turn, object())
+
+    assert printed == ["Agent 2 stopped: token budget exhausted"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 import prompt_toolkit
 import pytest
 from prompt_toolkit import PromptSession
-from prompt_toolkit.formatted_text import HTML, fragment_list_to_text, to_formatted_text
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.output import DummyOutput
@@ -19,10 +18,8 @@ from prompt_toolkit.output.vt100 import Vt100_Output
 from rich.console import Console
 
 from opencollab.adapters.cli import main as cli_main
-from opencollab.adapters.cli.prompt_view import (
-    build_agent_navigation_bindings,
-    build_agent_prompt,
-)
+from opencollab.adapters.cli.prompt_view import build_agent_navigation_bindings
+from opencollab.adapters.tui import TUI
 from opencollab.application.scheduler_types import SchedulerTurnError
 from opencollab.domain.session import SessionPhase
 
@@ -30,13 +27,10 @@ from opencollab.domain.session import SessionPhase
 class _FakeTUI:
     def __init__(self) -> None:
         self.selected_aid = 0
-        self.history = {1: "agent one full history", 2: "agent two full history"}
-        self.revisions = {0: 0, 1: 0, 2: 0}
-        self.render_calls = 0
+        self.gates: list = []
 
-    @property
-    def selected_history_cache_key(self) -> tuple[int, int, int]:
-        return self.selected_aid, self.revisions[self.selected_aid], 80
+    def set_scrollback_gate(self, gate) -> None:
+        self.gates.append(gate)
 
     def select_next_agent(self) -> int | None:
         self.selected_aid = 1 if self.selected_aid == 0 else 2
@@ -46,67 +40,19 @@ class _FakeTUI:
         self.selected_aid = 1
         return self.selected_aid
 
-    def render_selected_history(self) -> str:
-        self.render_calls += 1
-        return self.history.get(self.selected_aid, "")
 
+def test_prompt_scrollback_gate_hands_printing_to_prompt_toolkit(monkeypatch):
+    import prompt_toolkit.application as pt_application
 
-def _plain_prompt(prompt) -> str:
-    return fragment_list_to_text(to_formatted_text(prompt))
+    handed: list = []
+    monkeypatch.setattr(pt_application, "run_in_terminal", handed.append)
 
+    def emit() -> None:
+        raise AssertionError("the gate must not print behind prompt_toolkit's back")
 
-def test_agent_prompt_replaces_history_and_refreshes_on_revision():
-    tui = _FakeTUI()
-    prompt = build_agent_prompt(tui, HTML("<b>&gt;</b> "))
+    cli_main._prompt_scrollback_gate(emit)
 
-    assert _plain_prompt(prompt) == "> "
-    tui.selected_aid = 1
-    assert _plain_prompt(prompt) == "agent one full history\n> "
-    assert _plain_prompt(prompt) == "agent one full history\n> "
-    assert tui.render_calls == 2
-
-    tui.history[1] = "agent one latest history"
-    tui.revisions[1] += 1
-    assert _plain_prompt(prompt) == "agent one latest history\n> "
-    assert tui.render_calls == 3
-
-    tui.selected_aid = 2
-    assert _plain_prompt(prompt) == "agent two full history\n> "
-    assert tui.render_calls == 4
-
-
-def test_agent_prompt_render_failure_falls_back_to_plain_input():
-    tui = _FakeTUI()
-    tui.selected_aid = 1
-
-    def fail_render() -> str:
-        raise RuntimeError("render failed")
-
-    tui.render_selected_history = fail_render
-    prompt = build_agent_prompt(tui, "> ")
-
-    assert _plain_prompt(prompt) == "> "
-
-
-def test_agent_prompt_history_cache_evicts_old_revisions():
-    tui = _FakeTUI()
-    tui.selected_aid = 1
-    prompt = build_agent_prompt(tui, "> ")
-
-    for revision in range(17):
-        tui.revisions[1] = revision
-        tui.history[1] = f"revision {revision}"
-        assert f"revision {revision}" in _plain_prompt(prompt)
-
-    assert tui.render_calls == 17
-    tui.revisions[1] = 0
-    tui.history[1] = "revision zero rerendered"
-    assert "revision zero rerendered" in _plain_prompt(prompt)
-    assert tui.render_calls == 18
-
-    tui.revisions[1] = 16
-    assert "revision 16" in _plain_prompt(prompt)
-    assert tui.render_calls == 18
+    assert handed == [emit]
 
 
 @pytest.mark.asyncio
@@ -210,24 +156,34 @@ async def test_prompt_session_processes_tab_navigation_without_editing_text():
 
 
 @pytest.mark.asyncio
-async def test_prompt_pty_redraw_clears_rows_from_longer_agent_history(monkeypatch):
+async def test_prompt_tab_reprints_agent_into_scrollback_without_erasing_it(monkeypatch):
+    """Tab appends the newly focused agent to scrollback; it never rewrites it.
+
+    The old renderer carried each agent's history *inside* the prompt, so a
+    switch had to erase the previous agent's rows — and once that history grew
+    past the terminal height the erase could no longer reach them. Here the
+    reprint is ordinary terminal output that prompt_toolkit scrolls away from.
+    """
     monkeypatch.setenv("PROMPT_TOOLKIT_NO_CPR", "1")
-    tui = _FakeTUI()
-    tui.selected_aid = 1
-    tui.history[1] = "OLD-ONE\nOLD-TWO\nOLD-THREE"
-    tui.history[2] = "NEW-TWO"
     master_fd, slave_fd = os.openpty()
     os.set_blocking(master_fd, False)
-    fcntl.ioctl(
-        slave_fd,
-        termios.TIOCSWINSZ,
-        struct.pack("HHHH", 12, 80, 0, 0),
-    )
+    fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", 12, 80, 0, 0))
     output_stream = os.fdopen(os.dup(slave_fd), "w", encoding="utf-8", buffering=1)
     output = Vt100_Output.from_pty(output_stream, term="xterm")
+
+    console = Console(file=output_stream, force_terminal=True, width=80, height=12)
+    tui = TUI(console)
+    tui.set_team_provider(lambda: [
+        {"aid": 0, "role": "analyst", "phase": "idle", "busy": False},
+        {"aid": 1, "role": "coder", "phase": "idle", "busy": False},
+    ])
+    # Focus is on agent 0, so agent 1's transcript stays unprinted until Tab.
+    tui.record_user_message(0, "SETTLED-ON-ANALYST")
+    tui.record_user_message(1, "PENDING-ON-CODER")
+
     raw = bytearray()
-    old_rendered = asyncio.Event()
-    new_rendered = asyncio.Event()
+    settled_seen = asyncio.Event()
+    reprint_seen = asyncio.Event()
     loop = asyncio.get_running_loop()
 
     def drain_output() -> None:
@@ -239,30 +195,24 @@ async def test_prompt_pty_redraw_clears_rows_from_longer_agent_history(monkeypat
             if not data:
                 break
             raw.extend(data)
-        if b"OLD-THREE" in raw:
-            old_rendered.set()
-        if b"NEW-TWO" in raw:
-            new_rendered.set()
+        if b"SETTLED-ON-ANALYST" in raw:
+            settled_seen.set()
+        if b"PENDING-ON-CODER" in raw:
+            reprint_seen.set()
 
     loop.add_reader(master_fd, drain_output)
     try:
         with create_pipe_input() as pipe_input:
             session = PromptSession(
-                input=pipe_input,
-                output=output,
-                erase_when_done=True,
+                input=pipe_input, output=output, erase_when_done=True
             )
-            prompt = asyncio.create_task(
-                session.prompt_async(
-                    build_agent_prompt(tui, "> "),
-                    key_bindings=build_agent_navigation_bindings(tui),
-                )
-            )
-            await asyncio.wait_for(old_rendered.wait(), timeout=2)
+            monkeypatch.setattr(cli_main, "_get_prompt_session", lambda: session)
+            command = asyncio.create_task(cli_main._read_command(tui))
+            await asyncio.wait_for(settled_seen.wait(), timeout=2)
             pipe_input.send_bytes(b"\t")
-            await asyncio.wait_for(new_rendered.wait(), timeout=2)
-            pipe_input.send_bytes(b"\r")
-            assert await asyncio.wait_for(prompt, timeout=2) == ""
+            await asyncio.wait_for(reprint_seen.wait(), timeout=2)
+            pipe_input.send_text("hello\r")
+            assert await asyncio.wait_for(command, timeout=2) == "hello"
             await asyncio.sleep(0)
     finally:
         loop.remove_reader(master_fd)
@@ -271,15 +221,19 @@ async def test_prompt_pty_redraw_clears_rows_from_longer_agent_history(monkeypat
         os.close(master_fd)
         os.close(slave_fd)
 
-    redraw = bytes(raw).split(b"OLD-THREE", 1)[1]
-    before_new, after_new = redraw.split(b"NEW-TWO", 1)
-    assert b"\x1b[3A" in before_new
-    assert after_new.count(b"\x1b[K") >= 2
-    assert b"\x1b[J" in after_new
+    stream = bytes(raw)
+    assert tui.selected_aid == 1
+    # The band names the agent being redrawn, and the redraw is appended after
+    # the analyst's settled line rather than replacing it.
+    assert b"A1" in stream
+    assert stream.index(b"SETTLED-ON-ANALYST") < stream.index(b"PENDING-ON-CODER")
+    assert b"\x1b[2J" not in stream  # never a full-screen wipe
+    # The gate is prompt-scoped: it is removed once the line is read.
+    assert tui._scrollback_gate is None
 
 
 @pytest.mark.asyncio
-async def test_read_command_wires_dynamic_prompt_and_navigation(monkeypatch):
+async def test_read_command_uses_a_static_prompt_and_a_prompt_scoped_gate(monkeypatch):
     tui = _FakeTUI()
     tui.suspend_live = lambda: False
     resumed: list[bool] = []
@@ -290,6 +244,7 @@ async def test_read_command_wires_dynamic_prompt_and_navigation(monkeypatch):
         captured["prompt"] = prompt_text
         captured["toolbar"] = bottom_toolbar
         captured["bindings"] = key_bindings
+        captured["gate_during_prompt"] = tui.gates[-1]
         return "do work"
 
     monkeypatch.setattr(cli_main, "_read_line", fake_read_line)
@@ -299,8 +254,11 @@ async def test_read_command_wires_dynamic_prompt_and_navigation(monkeypatch):
 
     assert await cli_main._read_command(tui, bottom_toolbar=toolbar) == "do work"
     assert captured["toolbar"] is toolbar
-    assert callable(captured["prompt"])
+    # No history is smuggled into the prompt any more — it is the bare chevron.
+    assert captured["prompt"] is cli_main._PROMPT
     assert captured["bindings"].get_bindings_for_keys((Keys.ControlI,))
+    assert captured["gate_during_prompt"] is cli_main._prompt_scrollback_gate
+    assert tui.gates == [cli_main._prompt_scrollback_gate, None]
     assert resumed == [False]
 
 

--- a/tests/test_cli_prompt_view.py
+++ b/tests/test_cli_prompt_view.py
@@ -6,6 +6,7 @@ import io
 import os
 import struct
 import termios
+from functools import partial
 from types import SimpleNamespace
 
 import prompt_toolkit
@@ -260,6 +261,34 @@ async def test_read_command_uses_a_static_prompt_and_a_prompt_scoped_gate(monkey
     assert captured["gate_during_prompt"] is cli_main._prompt_scrollback_gate
     assert tui.gates == [cli_main._prompt_scrollback_gate, None]
     assert resumed == [False]
+
+
+@pytest.mark.asyncio
+async def test_agent_asked_prompts_are_gated_like_the_repl_prompt(monkeypatch):
+    """A permission y/N and an ask_user question own the screen too.
+
+    Both are read while other agents keep running, so an ungated settled block
+    from a concurrent agent would print into prompt_toolkit's redraw.
+    """
+    from opencollab.adapters.tui import TuiAskUserPolicy, TuiPermissionPolicy
+
+    tui = _FakeTUI()
+    tui.suspend_live = lambda: True
+    tui.resume_live = lambda was_suspended: None
+    seen: list = []
+
+    async def fake_read_line(prompt_text, **kwargs):
+        seen.append((prompt_text, tui.gates[-1]))
+        return "y"
+
+    monkeypatch.setattr(cli_main, "_read_line", fake_read_line)
+    read_line = partial(cli_main._read_line_at_prompt, tui)
+
+    assert await TuiPermissionPolicy(render=tui, read_line=read_line).confirm("Allow?") is True
+    assert await TuiAskUserPolicy(render=tui, read_line=read_line).ask("Which one?") == "y"
+
+    assert [gate for _prompt, gate in seen] == [cli_main._prompt_scrollback_gate] * 2
+    assert tui.gates[-1] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -16,17 +16,30 @@ from rich.text import Text
 
 from opencollab.adapters.tui import TUI
 from opencollab.adapters.tui import renderer as renderer_mod
-from opencollab.adapters.tui import renderer_events as renderer_events_mod
+from opencollab.adapters.tui import renderer_display as renderer_display_mod
 from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
 
 
 def _make_tui() -> TUI:
-    return TUI()
+    return TUI(Console(file=StringIO(), width=100, color_system=None))
 
 
 def _status_plains(tui: TUI, aid: int | None = None) -> list[str]:
     state = tui._selected_state if aid is None else tui._state_for(aid)
     return [line.plain for line in state.status_lines]
+
+
+def _scrollback(tui: TUI) -> str:
+    """Everything the TUI has committed to the terminal so far."""
+    return tui.console.file.getvalue()
+
+
+def _history_plains(tui: TUI, aid: int) -> list[str]:
+    return [
+        block.plain
+        for block in tui._state_for(aid).history_blocks
+        if isinstance(block, Text)
+    ]
 
 
 
@@ -266,11 +279,7 @@ def test_follow_up_completion_is_not_labeled_as_another_spawn():
         )
     )
 
-    lines = [
-        block.plain
-        for block in tui._state_for(1).timeline_blocks
-        if isinstance(block, Text)
-    ]
+    lines = _history_plains(tui, 1)
     assert any("A1 completed" in line for line in lines)
     assert all("A1:spawn" not in line for line in lines)
 
@@ -437,50 +446,47 @@ def test_failed_agent_remains_selectable_with_retained_output_and_error():
 
     assert tui.select_agent(2) == 2
     assert any("model failed" in status for status in _status_plains(tui, 2))
+    # Streamed text that has not settled yet stays in the live frame...
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "still typing", "aid": 2}))
     with console.capture() as capture:
         console.print(tui._build_display())
-    rendered = capture.get()
-    assert "partial output" in rendered
-    assert "boom" in rendered
+    assert "still typing" in capture.get()
+    # ...while everything already settled reached scrollback when focus landed.
+    scrollback = _scrollback(tui)
+    assert "partial output" in scrollback
+    assert "boom" in scrollback
     assert "◆ A2 reviewer failed" in tui._build_team_panel().plain
 
 
-def test_live_timeline_cap_does_not_truncate_complete_agent_history():
-    console = Console(file=StringIO(), width=100, color_system=None)
+def test_live_frame_stays_bounded_while_full_history_reaches_scrollback():
+    console = Console(file=StringIO(), width=100, height=24, color_system=None)
     tui = TUI(console)
-    state = tui._state_for(1)
+    tui.select_agent(1)
 
     for index in range(100):
-        tui._append_activity(
-            (f"activity {index}", tui._STYLE_MUTED),
-            state=state,
-        )
+        tui._append_activity((f"activity {index}", tui._STYLE_MUTED))
 
-    assert len(state.timeline_blocks) == 80
-    assert len(state.history_blocks) == 100
-    tui.select_agent(1)
-    history = tui.render_selected_history()
-    assert "activity 0" in history
-    assert "activity 99" in history
+    frame = console.render_lines(tui._build_live_display(), console.options, pad=False)
+    assert len(frame) <= renderer_display_mod.MAX_LIVE_BODY_LINES
+    scrollback = _scrollback(tui)
+    assert "activity 0" in scrollback
+    assert "activity 99" in scrollback
 
 
-def test_all_timeline_append_paths_share_one_global_bound():
+def test_every_settled_block_path_reaches_scrollback_for_the_focused_agent():
     tui = TUI(Console(file=StringIO(), width=100, color_system=None))
-    state = tui._state_for(1)
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "assistant say", "aid": 1}))
+    assert tui.select_agent(1) == 1
 
-    for index in range(renderer_events_mod.MAX_TIMELINE_BLOCKS * 3):
-        tui.event_handler(
-            SessionRuntimeEvent(
-                "text_delta",
-                {"content": f"assistant {index}", "aid": 1},
-            )
-        )
-        tui.event_handler(
-            SessionRuntimeEvent("error", {"reason": f"failure {index}", "aid": 1})
-        )
-        tui.record_user_message(1, f"user {index}")
+    tui.event_handler(SessionRuntimeEvent("error", {"reason": "failure here", "aid": 1}))
+    tui.record_user_message(1, "user asks")
+    tui.event_handler(
+        SessionRuntimeEvent("tool_start", {"tool": "bash", "args": {"command": "pwd"}, "aid": 1})
+    )
 
-    assert len(state.timeline_blocks) == renderer_events_mod.MAX_TIMELINE_BLOCKS
+    scrollback = _scrollback(tui)
+    for expected in ("assistant say", "failure here", "user asks", "A1:bash started"):
+        assert expected in scrollback
 
 
 def test_agent_history_has_a_global_per_agent_bound():
@@ -495,10 +501,10 @@ def test_agent_history_has_a_global_per_agent_bound():
 
     assert len(state.history_blocks) == renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT
     tui.select_agent(1)
-    history = tui.render_selected_history()
-    assert "bounded activity 0" not in history
-    assert "20 older history blocks omitted" in history
-    assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in history
+    scrollback = _scrollback(tui)
+    assert "bounded activity 0" not in scrollback
+    assert "20 older history blocks omitted" in scrollback
+    assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in scrollback
 
 
 def test_completed_agent_render_states_have_a_global_bound():
@@ -590,27 +596,27 @@ def test_terminal_provider_entries_cannot_recreate_evicted_render_states(
     retained = len(tui._agent_states)
     for aid in range(1, total + 1):
         tui.select_agent(aid)
-        tui.render_selected_history()
 
     assert retained <= renderer_mod.MAX_TERMINAL_AGENT_STATES + 1
     assert len(tui._agent_states) == retained
 
 
-def test_user_message_is_recorded_only_in_target_history_and_revises_cache_key():
+def test_user_message_is_recorded_only_in_target_and_printed_only_when_focused():
     console = Console(file=StringIO(), width=100, color_system=None)
     tui = TUI(console)
-    before = tui._state_for(2).history_revision
 
     tui.record_user_message(2, "please inspect the renderer")
 
-    assert tui._state_for(2).history_revision == before + 1
     assert tui._state_for(0).history_blocks == []
+    assert len(tui._state_for(2).history_blocks) == 1
+    # Focus is still agent 0, so agent 2's line has not reached the terminal.
+    assert "please inspect the renderer" not in _scrollback(tui)
+
     tui.select_agent(2)
-    assert tui.selected_history_cache_key == (2, before + 1, 100)
-    assert "please inspect the renderer" in tui.render_selected_history()
+    assert "please inspect the renderer" in _scrollback(tui)
 
 
-def test_stop_live_preserves_child_final_text_and_error_for_prompt_view():
+def test_stop_live_settles_child_final_text_and_error_into_its_history():
     console = Console(file=StringIO(), width=100, color_system=None)
     tui = TUI(console)
     tui._live_paused = True
@@ -619,11 +625,11 @@ def test_stop_live_preserves_child_final_text_and_error_for_prompt_view():
 
     tui.stop_live()
     tui.select_agent(1)
-    history = tui.render_selected_history()
 
     assert tui._state_for(1).current_text == ""
-    assert "final child text" in history
-    assert "Error: child error" in history
+    scrollback = _scrollback(tui)
+    assert "final child text" in scrollback
+    assert "Error: child error" in scrollback
 
 
 def test_agent_history_accumulates_across_turn_resets():
@@ -637,30 +643,30 @@ def test_agent_history_accumulates_across_turn_resets():
     tui.stop_live()
     tui.select_agent(1)
 
-    history = tui.render_selected_history()
-    assert "turn one" in history
-    assert "turn two" in history
+    scrollback = _scrollback(tui)
+    assert "turn one" in scrollback
+    assert "turn two" in scrollback
 
 
-def test_lead_settled_display_contains_only_current_turn_after_reset():
+def test_scrollback_is_append_only_across_turns_for_the_focused_agent():
+    """A new turn must not reprint the previous one — the terminal already has it."""
     console = Console(file=StringIO(), width=100, color_system=None)
     tui = TUI(console)
     tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "old answer", "aid": 0}))
-    tui._build_settled_display(aid=0)
+    tui.stop_live()
 
     tui.reset()
     tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "new answer", "aid": 0}))
-    settled = tui._build_settled_display(aid=0)
-    with console.capture() as capture:
-        console.print(settled)
+    tui.stop_live()
 
-    output = capture.get()
-    assert "new answer" in output
-    assert "old answer" not in output
+    scrollback = _scrollback(tui)
+    assert scrollback.count("old answer") == 1
+    assert scrollback.count("new answer") == 1
+    assert scrollback.index("old answer") < scrollback.index("new answer")
 
 
-def test_switching_does_not_lose_partial_text_or_timeline_order():
-    tui = TUI()
+def test_switching_does_not_lose_partial_text_or_history_order():
+    tui = _make_tui()
     tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead-a", "aid": 0}))
     tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child-a", "aid": 1}))
     tui.event_handler(
@@ -673,7 +679,8 @@ def test_switching_does_not_lose_partial_text_or_timeline_order():
 
     assert tui._state_for(0).current_text == "lead-alead-b"
     assert tui._state_for(1).current_text == ""
-    assert len(tui._state_for(1).timeline_blocks) == 2
+    assert _history_plains(tui, 1) == ["▸ A1:bash started pwd"]
+    assert len(tui._state_for(1).history_blocks) == 2
     tui.select_agent(1)
     assert "A1:bash" in tui._active_tools
 
@@ -689,20 +696,22 @@ def test_legacy_event_without_aid_routes_to_lead_not_current_focus():
     assert tui._state_for(1).current_text == "child"
 
 
-def test_settled_display_always_commits_lead_when_child_is_selected():
-    tui = TUI()
+def test_stop_live_settles_every_agent_but_prints_only_the_focused_one():
+    tui = _make_tui()
     tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead answer", "aid": 0}))
     tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child notes", "aid": 1}))
+
+    tui.stop_live()
+
+    # Both agents' streamed text is committed, so neither is lost on a later switch.
+    assert tui._state_for(0).current_text == ""
+    assert tui._state_for(1).current_text == ""
+    scrollback = _scrollback(tui)
+    assert "lead answer" in scrollback
+    assert "child notes" not in scrollback
+
     tui.select_agent(1)
-
-    settled = tui._build_settled_display(aid=0)
-
-    console = Console(file=StringIO(), width=80)
-    with console.capture() as capture:
-        console.print(settled)
-    output = capture.get()
-    assert "lead answer" in output
-    assert "child notes" not in output
+    assert "child notes" in _scrollback(tui)
 
 
 def test_live_suspend_and_resume_transfer_keyboard_ownership():

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -41,8 +41,6 @@ def _history_plains(tui: TUI, aid: int) -> list[str]:
     ]
 
 
-
-
 def test_one_shot_welcome_describes_a_running_issue_without_an_input_prompt():
     output = StringIO()
     tui = TUI(Console(file=output, width=120, color_system=None))

--- a/tests/test_tui_event_rendering.py
+++ b/tests/test_tui_event_rendering.py
@@ -16,7 +16,6 @@ from rich.text import Text
 
 from opencollab.adapters.tui import TUI
 from opencollab.adapters.tui import renderer as renderer_mod
-from opencollab.adapters.tui import renderer_display as renderer_display_mod
 from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
 
 
@@ -458,55 +457,6 @@ def test_failed_agent_remains_selectable_with_retained_output_and_error():
     assert "◆ A2 reviewer failed" in tui._build_team_panel().plain
 
 
-def test_live_frame_stays_bounded_while_full_history_reaches_scrollback():
-    console = Console(file=StringIO(), width=100, height=24, color_system=None)
-    tui = TUI(console)
-    tui.select_agent(1)
-
-    for index in range(100):
-        tui._append_activity((f"activity {index}", tui._STYLE_MUTED))
-
-    frame = console.render_lines(tui._build_live_display(), console.options, pad=False)
-    assert len(frame) <= renderer_display_mod.MAX_LIVE_BODY_LINES
-    scrollback = _scrollback(tui)
-    assert "activity 0" in scrollback
-    assert "activity 99" in scrollback
-
-
-def test_every_settled_block_path_reaches_scrollback_for_the_focused_agent():
-    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "assistant say", "aid": 1}))
-    assert tui.select_agent(1) == 1
-
-    tui.event_handler(SessionRuntimeEvent("error", {"reason": "failure here", "aid": 1}))
-    tui.record_user_message(1, "user asks")
-    tui.event_handler(
-        SessionRuntimeEvent("tool_start", {"tool": "bash", "args": {"command": "pwd"}, "aid": 1})
-    )
-
-    scrollback = _scrollback(tui)
-    for expected in ("assistant say", "failure here", "user asks", "A1:bash started"):
-        assert expected in scrollback
-
-
-def test_agent_history_has_a_global_per_agent_bound():
-    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
-    state = tui._state_for(1)
-
-    for index in range(renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 20):
-        tui._append_activity(
-            (f"bounded activity {index}", tui._STYLE_MUTED),
-            state=state,
-        )
-
-    assert len(state.history_blocks) == renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT
-    tui.select_agent(1)
-    scrollback = _scrollback(tui)
-    assert "bounded activity 0" not in scrollback
-    assert "20 older history blocks omitted" in scrollback
-    assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in scrollback
-
-
 def test_completed_agent_render_states_have_a_global_bound():
     tui = TUI()
 
@@ -599,119 +549,6 @@ def test_terminal_provider_entries_cannot_recreate_evicted_render_states(
 
     assert retained <= renderer_mod.MAX_TERMINAL_AGENT_STATES + 1
     assert len(tui._agent_states) == retained
-
-
-def test_user_message_is_recorded_only_in_target_and_printed_only_when_focused():
-    console = Console(file=StringIO(), width=100, color_system=None)
-    tui = TUI(console)
-
-    tui.record_user_message(2, "please inspect the renderer")
-
-    assert tui._state_for(0).history_blocks == []
-    assert len(tui._state_for(2).history_blocks) == 1
-    # Focus is still agent 0, so agent 2's line has not reached the terminal.
-    assert "please inspect the renderer" not in _scrollback(tui)
-
-    tui.select_agent(2)
-    assert "please inspect the renderer" in _scrollback(tui)
-
-
-def test_stop_live_settles_child_final_text_and_error_into_its_history():
-    console = Console(file=StringIO(), width=100, color_system=None)
-    tui = TUI(console)
-    tui._live_paused = True
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "final child text", "aid": 1}))
-    tui.event_handler(SessionRuntimeEvent("error", {"reason": "child error", "aid": 1}))
-
-    tui.stop_live()
-    tui.select_agent(1)
-
-    assert tui._state_for(1).current_text == ""
-    scrollback = _scrollback(tui)
-    assert "final child text" in scrollback
-    assert "Error: child error" in scrollback
-
-
-def test_agent_history_accumulates_across_turn_resets():
-    console = Console(file=StringIO(), width=100, color_system=None)
-    tui = TUI(console)
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "turn one", "aid": 1}))
-    tui.stop_live()
-
-    tui.reset()
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "turn two", "aid": 1}))
-    tui.stop_live()
-    tui.select_agent(1)
-
-    scrollback = _scrollback(tui)
-    assert "turn one" in scrollback
-    assert "turn two" in scrollback
-
-
-def test_scrollback_is_append_only_across_turns_for_the_focused_agent():
-    """A new turn must not reprint the previous one — the terminal already has it."""
-    console = Console(file=StringIO(), width=100, color_system=None)
-    tui = TUI(console)
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "old answer", "aid": 0}))
-    tui.stop_live()
-
-    tui.reset()
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "new answer", "aid": 0}))
-    tui.stop_live()
-
-    scrollback = _scrollback(tui)
-    assert scrollback.count("old answer") == 1
-    assert scrollback.count("new answer") == 1
-    assert scrollback.index("old answer") < scrollback.index("new answer")
-
-
-def test_switching_does_not_lose_partial_text_or_history_order():
-    tui = _make_tui()
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead-a", "aid": 0}))
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child-a", "aid": 1}))
-    tui.event_handler(
-        SessionRuntimeEvent(
-            "tool_start",
-            {"tool": "bash", "args": {"command": "pwd"}, "aid": 1},
-        )
-    )
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead-b", "aid": 0}))
-
-    assert tui._state_for(0).current_text == "lead-alead-b"
-    assert tui._state_for(1).current_text == ""
-    assert _history_plains(tui, 1) == ["▸ A1:bash started pwd"]
-    assert len(tui._state_for(1).history_blocks) == 2
-    tui.select_agent(1)
-    assert "A1:bash" in tui._active_tools
-
-
-def test_legacy_event_without_aid_routes_to_lead_not_current_focus():
-    tui = TUI()
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child", "aid": 1}))
-    tui.select_agent(1)
-
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead"}))
-
-    assert tui._state_for(0).current_text == "lead"
-    assert tui._state_for(1).current_text == "child"
-
-
-def test_stop_live_settles_every_agent_but_prints_only_the_focused_one():
-    tui = _make_tui()
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead answer", "aid": 0}))
-    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child notes", "aid": 1}))
-
-    tui.stop_live()
-
-    # Both agents' streamed text is committed, so neither is lost on a later switch.
-    assert tui._state_for(0).current_text == ""
-    assert tui._state_for(1).current_text == ""
-    scrollback = _scrollback(tui)
-    assert "lead answer" in scrollback
-    assert "child notes" not in scrollback
-
-    tui.select_agent(1)
-    assert "child notes" in _scrollback(tui)
 
 
 def test_live_suspend_and_resume_transfer_keyboard_ownership():

--- a/tests/test_tui_scrollback.py
+++ b/tests/test_tui_scrollback.py
@@ -1,0 +1,195 @@
+"""Scrollback behaviour of the TUI: what reaches the terminal, and when.
+
+Split out of ``test_tui_event_rendering`` — those tests cover event dispatch,
+these cover the printing contract: only the focused agent's settled blocks are
+written, each exactly once, and focusing an agent redraws it in full.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+from rich.text import Text
+
+from opencollab.adapters.tui import TUI
+from opencollab.adapters.tui import renderer as renderer_mod
+from opencollab.adapters.tui import renderer_display as renderer_display_mod
+from opencollab.domain.events import SessionRuntimeEvent
+
+
+def _make_tui() -> TUI:
+    return TUI(Console(file=StringIO(), width=100, color_system=None))
+
+
+def _scrollback(tui: TUI) -> str:
+    """Everything the TUI has committed to the terminal so far."""
+    return tui.console.file.getvalue()
+
+
+def _history_plains(tui: TUI, aid: int) -> list[str]:
+    return [
+        block.plain
+        for block in tui._state_for(aid).history_blocks
+        if isinstance(block, Text)
+    ]
+
+
+def test_live_frame_stays_bounded_while_full_history_reaches_scrollback():
+    console = Console(file=StringIO(), width=100, height=24, color_system=None)
+    tui = TUI(console)
+    tui.select_agent(1)
+
+    for index in range(100):
+        tui._append_activity((f"activity {index}", tui._STYLE_MUTED))
+
+    frame = console.render_lines(tui._build_live_display(), console.options, pad=False)
+    assert len(frame) <= renderer_display_mod.MAX_LIVE_BODY_LINES
+    scrollback = _scrollback(tui)
+    assert "activity 0" in scrollback
+    assert "activity 99" in scrollback
+
+
+def test_every_settled_block_path_reaches_scrollback_for_the_focused_agent():
+    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "assistant say", "aid": 1}))
+    assert tui.select_agent(1) == 1
+
+    tui.event_handler(SessionRuntimeEvent("error", {"reason": "failure here", "aid": 1}))
+    tui.record_user_message(1, "user asks")
+    tui.event_handler(
+        SessionRuntimeEvent("tool_start", {"tool": "bash", "args": {"command": "pwd"}, "aid": 1})
+    )
+
+    scrollback = _scrollback(tui)
+    for expected in ("assistant say", "failure here", "user asks", "A1:bash started"):
+        assert expected in scrollback
+
+
+def test_agent_history_has_a_global_per_agent_bound():
+    tui = TUI(Console(file=StringIO(), width=100, color_system=None))
+    state = tui._state_for(1)
+
+    for index in range(renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 20):
+        tui._append_activity(
+            (f"bounded activity {index}", tui._STYLE_MUTED),
+            state=state,
+        )
+
+    assert len(state.history_blocks) == renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT
+    tui.select_agent(1)
+    scrollback = _scrollback(tui)
+    assert "bounded activity 0" not in scrollback
+    assert "20 older history blocks omitted" in scrollback
+    assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in scrollback
+def test_user_message_is_recorded_only_in_target_and_printed_only_when_focused():
+    console = Console(file=StringIO(), width=100, color_system=None)
+    tui = TUI(console)
+
+    tui.record_user_message(2, "please inspect the renderer")
+
+    assert tui._state_for(0).history_blocks == []
+    assert len(tui._state_for(2).history_blocks) == 1
+    # Focus is still agent 0, so agent 2's line has not reached the terminal.
+    assert "please inspect the renderer" not in _scrollback(tui)
+
+    tui.select_agent(2)
+    assert "please inspect the renderer" in _scrollback(tui)
+
+
+def test_stop_live_settles_child_final_text_and_error_into_its_history():
+    console = Console(file=StringIO(), width=100, color_system=None)
+    tui = TUI(console)
+    tui._live_paused = True
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "final child text", "aid": 1}))
+    tui.event_handler(SessionRuntimeEvent("error", {"reason": "child error", "aid": 1}))
+
+    tui.stop_live()
+    tui.select_agent(1)
+
+    assert tui._state_for(1).current_text == ""
+    scrollback = _scrollback(tui)
+    assert "final child text" in scrollback
+    assert "Error: child error" in scrollback
+
+
+def test_agent_history_accumulates_across_turn_resets():
+    console = Console(file=StringIO(), width=100, color_system=None)
+    tui = TUI(console)
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "turn one", "aid": 1}))
+    tui.stop_live()
+
+    tui.reset()
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "turn two", "aid": 1}))
+    tui.stop_live()
+    tui.select_agent(1)
+
+    scrollback = _scrollback(tui)
+    assert "turn one" in scrollback
+    assert "turn two" in scrollback
+
+
+def test_scrollback_is_append_only_across_turns_for_the_focused_agent():
+    """A new turn must not reprint the previous one — the terminal already has it."""
+    console = Console(file=StringIO(), width=100, color_system=None)
+    tui = TUI(console)
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "old answer", "aid": 0}))
+    tui.stop_live()
+
+    tui.reset()
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "new answer", "aid": 0}))
+    tui.stop_live()
+
+    scrollback = _scrollback(tui)
+    assert scrollback.count("old answer") == 1
+    assert scrollback.count("new answer") == 1
+    assert scrollback.index("old answer") < scrollback.index("new answer")
+
+
+def test_switching_does_not_lose_partial_text_or_history_order():
+    tui = _make_tui()
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead-a", "aid": 0}))
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child-a", "aid": 1}))
+    tui.event_handler(
+        SessionRuntimeEvent(
+            "tool_start",
+            {"tool": "bash", "args": {"command": "pwd"}, "aid": 1},
+        )
+    )
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead-b", "aid": 0}))
+
+    assert tui._state_for(0).current_text == "lead-alead-b"
+    assert tui._state_for(1).current_text == ""
+    assert _history_plains(tui, 1) == ["▸ A1:bash started pwd"]
+    assert len(tui._state_for(1).history_blocks) == 2
+    tui.select_agent(1)
+    assert "A1:bash" in tui._active_tools
+
+
+def test_legacy_event_without_aid_routes_to_lead_not_current_focus():
+    tui = TUI()
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child", "aid": 1}))
+    tui.select_agent(1)
+
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead"}))
+
+    assert tui._state_for(0).current_text == "lead"
+    assert tui._state_for(1).current_text == "child"
+
+
+def test_stop_live_settles_every_agent_but_prints_only_the_focused_one():
+    tui = _make_tui()
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead answer", "aid": 0}))
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child notes", "aid": 1}))
+
+    tui.stop_live()
+
+    # Both agents' streamed text is committed, so neither is lost on a later switch.
+    assert tui._state_for(0).current_text == ""
+    assert tui._state_for(1).current_text == ""
+    scrollback = _scrollback(tui)
+    assert "lead answer" in scrollback
+    assert "child notes" not in scrollback
+
+    tui.select_agent(1)
+    assert "child notes" in _scrollback(tui)

--- a/tests/test_tui_scrollback.py
+++ b/tests/test_tui_scrollback.py
@@ -15,7 +15,7 @@ from rich.text import Text
 from opencollab.adapters.tui import TUI
 from opencollab.adapters.tui import renderer as renderer_mod
 from opencollab.adapters.tui import renderer_display as renderer_display_mod
-from opencollab.domain.events import SessionRuntimeEvent
+from opencollab.domain.events import SchedulerEvent, SessionRuntimeEvent
 
 
 def _make_tui() -> TUI:
@@ -82,6 +82,8 @@ def test_agent_history_has_a_global_per_agent_bound():
     assert "bounded activity 0" not in scrollback
     assert "20 older history blocks omitted" in scrollback
     assert f"bounded activity {renderer_mod.MAX_HISTORY_BLOCKS_PER_AGENT + 19}" in scrollback
+
+
 def test_user_message_is_recorded_only_in_target_and_printed_only_when_focused():
     console = Console(file=StringIO(), width=100, color_system=None)
     tui = TUI(console)
@@ -193,6 +195,75 @@ def test_stop_live_settles_every_agent_but_prints_only_the_focused_one():
 
     tui.select_agent(1)
     assert "child notes" in _scrollback(tui)
+
+
+def test_finishing_on_an_unfocused_agent_prints_its_tail_exactly_once():
+    """The one-shot flush drains a tail; it must not replay the transcript.
+
+    A focus switch reprints an agent in full, which is right when the user asks
+    to look at one. Ending a run is not that ask: everything the target settled
+    while it held focus is already on screen.
+    """
+    tui = _make_tui()
+    tui.event_handler(SchedulerEvent("agent_spawned", {"aid": 1, "parent_aid": 0, "role": "coder"}))
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "early lead line", "aid": 0}))
+    tui.event_handler(
+        SessionRuntimeEvent("tool_start", {"tool": "bash", "args": {"command": "pwd"}, "aid": 0})
+    )
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "the final answer", "aid": 0}))
+
+    tui.select_agent(1)  # the user wanders off to watch a teammate
+    tui.stop_live(final_aid=0)
+
+    scrollback = _scrollback(tui)
+    assert scrollback.count("early lead line") == 1
+    assert scrollback.count("the final answer") == 1
+    # Under a band naming the lead, because the rows above belong to the teammate.
+    band = tui._agent_label(0)
+    assert scrollback.rindex(band) < scrollback.index("the final answer")
+
+
+def test_stop_live_reports_whose_trailing_text_it_committed():
+    """The CLI salvages a failed turn's partial answer only if this says no."""
+    tui = _make_tui()
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "lead partial", "aid": 0}))
+    tui.event_handler(SessionRuntimeEvent("text_delta", {"content": "child partial", "aid": 1}))
+
+    tui.stop_live()
+
+    # The lead held focus, so its partial reached scrollback; the child's did not.
+    assert tui.drained_partial_answer(0) is True
+    assert tui.drained_partial_answer(1) is False
+    # An agent that streamed nothing has no partial to have been committed.
+    assert tui.drained_partial_answer(2) is False
+
+
+def test_overlapping_prompts_keep_the_gate_until_the_last_one_releases():
+    """Two agents can hold a prompt at once; the first to finish must not
+    uninstall the gate the other is still relying on."""
+    tui = _make_tui()
+    withheld: list[object] = []
+
+    def outer_gate(emit) -> None:
+        withheld.append(emit)
+
+    def inner_gate(emit) -> None:
+        withheld.append(emit)
+
+    tui.set_scrollback_gate(outer_gate)   # agent 1's permission y/N
+    tui.set_scrollback_gate(inner_gate)   # agent 2's ask_user question
+    tui.set_scrollback_gate(None)         # agent 2 answers first
+
+    assert tui._scrollback_gate is outer_gate
+
+    tui.record_user_message(0, "settled while the first prompt is still up")
+
+    # Withheld, not printed behind the surviving prompt's back.
+    assert len(withheld) == 1
+    assert _scrollback(tui) == ""
+
+    tui.set_scrollback_gate(None)
+    assert tui._scrollback_gate is None
 
 
 def test_focus_switch_scrolls_the_screen_away_instead_of_erasing_it():

--- a/tests/test_tui_scrollback.py
+++ b/tests/test_tui_scrollback.py
@@ -193,3 +193,60 @@ def test_stop_live_settles_every_agent_but_prints_only_the_focused_one():
 
     tui.select_agent(1)
     assert "child notes" in _scrollback(tui)
+
+
+def test_focus_switch_scrolls_the_screen_away_instead_of_erasing_it():
+    """The redraw opens on row 1, and the rows it displaced stay in scrollback.
+
+    ``ESC[2J`` would also blank the screen, but erased rows never reach
+    scrollback — the previous agent's last screenful would be lost.
+    """
+    console = Console(
+        file=StringIO(), width=100, height=24, force_terminal=True, color_system=None
+    )
+    tui = TUI(console)
+    tui.record_user_message(0, "lead line")
+    tui.record_user_message(1, "child line")
+
+    tui.select_agent(1)
+
+    scrollback = _scrollback(tui)
+    scroll_to_top = "\n" * console.height + "\x1b[H"
+    assert scrollback.count(scroll_to_top) == 1
+    before, after = scrollback.split(scroll_to_top)
+    # Displaced, not erased: the lead's line is still above the switch.
+    assert "lead line" in before
+    assert "child line" in after
+    assert "\x1b[2J" not in scrollback and "\x1b[3J" not in scrollback
+
+
+def test_focus_switch_leaves_a_redirected_terminal_alone():
+    """Cursor control is meaningless in a file or a CI capture — emit none of it."""
+    tui = _make_tui()
+    tui.record_user_message(1, "child line")
+
+    tui.select_agent(1)
+
+    scrollback = _scrollback(tui)
+    assert "child line" in scrollback
+    assert "\x1b[" not in scrollback
+
+
+def test_focus_switch_scroll_is_gated_with_the_redraw_it_belongs_to():
+    """The scroll must reach the terminal through the same gate as the blocks.
+
+    Splitting them would let a prompt_toolkit redraw land between the scroll and
+    the agent it was making room for.
+    """
+    console = Console(
+        file=StringIO(), width=100, height=24, force_terminal=True, color_system=None
+    )
+    tui = TUI(console)
+    tui.record_user_message(1, "child line")
+    withheld: list[object] = []
+    tui.set_scrollback_gate(withheld.append)
+
+    tui.select_agent(1)
+
+    assert len(withheld) == 1
+    assert _scrollback(tui) == ""

--- a/tests/test_tui_team_display.py
+++ b/tests/test_tui_team_display.py
@@ -182,10 +182,7 @@ def test_status_chrome_renderables_avoid_default_text_color():
         if isinstance(block, Text):
             _assert_visible_text_has_non_white_style(block)
 
-    display = tui._build_display()
-    for renderable in display.renderables:
-        if isinstance(renderable, Text):
-            _assert_visible_text_has_non_white_style(renderable)
+    _assert_visible_text_has_non_white_style(tui._build_status_row())
 
 
 def test_live_display_tails_when_content_exceeds_terminal_height():
@@ -223,6 +220,19 @@ def test_narrow_agent_status_keeps_selected_agent_visible():
     assert plain.index("Lead") < plain.index("A1") < plain.index("◆ A5")
 
 
+def _live_rows(tui: TUI) -> list[str]:
+    console = tui.console
+    rendered = console.render_lines(tui._build_live_display(), console.options, pad=False)
+    return ["".join(segment.text for segment in line) for line in rendered]
+
+
+def _stream(tui: TUI, paragraphs: int) -> None:
+    """Give the frame a body taller than any terminal under test."""
+    tui._state_for(0).current_text = "\n\n".join(
+        f"streamed paragraph {index}" for index in range(paragraphs)
+    )
+
+
 def test_agent_status_remains_last_row_when_live_view_is_cropped():
     console = Console(file=StringIO(), width=50, height=3, color_system=None)
     tui = TUI(console)
@@ -230,14 +240,15 @@ def test_agent_status_remains_last_row_when_live_view_is_cropped():
         {"aid": 0, "role": "lead", "phase": "done", "busy": False},
         {"aid": 1, "role": "coder", "phase": "executing_tools", "busy": True},
     ])
-    for index in range(8):
-        tui._status_lines.append(Text(f"status {index}", style="#6B7280"))
+    _stream(tui, 8)
 
-    rendered = console.render_lines(tui._build_live_display(), console.options, pad=False)
-    last_row = "".join(segment.text for segment in rendered[-1])
+    rows = _live_rows(tui)
 
-    assert len(rendered) == console.height
-    assert last_row.startswith("AGENTS")
+    assert len(rows) == console.height
+    # The body is cropped to its tail; the status row is not part of that budget.
+    assert "AGENTS" in rows[-1]
+    assert "streamed paragraph 7" in "\n".join(rows[:-1])
+    assert "streamed paragraph 0" not in "\n".join(rows)
 
 
 def test_agent_status_is_pinned_to_terminal_bottom_when_content_is_short():
@@ -247,17 +258,16 @@ def test_agent_status_is_pinned_to_terminal_bottom_when_content_is_short():
         {"aid": 0, "role": "analyst", "phase": "done", "busy": False},
         {"aid": 1, "role": "coder", "phase": "done", "busy": False},
     ])
-    tui._status_lines.append(Text("short body", style="#6B7280"))
+    tui._state_for(0).current_text = "short body"
 
-    rendered = console.render_lines(tui._build_live_display(), console.options, pad=False)
-    rows = ["".join(segment.text for segment in line) for line in rendered]
+    rows = _live_rows(tui)
 
     # A short frame must claim only the rows it needs. Padding it out to the
     # terminal height is what buried the settled transcript printed above it.
     assert len(rows) < console.height
-    assert "short body" in rows
-    assert rows[-1].startswith("AGENTS")
-    assert all(not row.startswith("AGENTS") for row in rows[:-1])
+    assert "short body" in rows[0]
+    assert "AGENTS" in rows[-1]
+    assert all("AGENTS" not in row for row in rows[:-1])
 
 
 def test_agent_status_owns_only_row_in_one_line_terminal():
@@ -266,30 +276,29 @@ def test_agent_status_owns_only_row_in_one_line_terminal():
     tui.set_team_provider(lambda: [
         {"aid": 0, "role": "lead", "phase": "done", "busy": False},
     ])
-    tui._status_lines.append(Text("body is hidden", style="#6B7280"))
+    tui._state_for(0).current_text = "body is hidden"
 
-    rendered = console.render_lines(tui._build_live_display(), console.options, pad=False)
-    rows = ["".join(segment.text for segment in line) for line in rendered]
+    rows = _live_rows(tui)
 
     assert len(rows) == 1
-    assert rows[0].startswith("AGENTS")
+    assert "AGENTS" in rows[0]
+    assert "body is hidden" not in rows[0]
 
 
 def test_pinned_agent_status_reflows_to_resized_terminal_height():
-    initial_console = Console(file=StringIO(), width=50, height=6, color_system=None)
-    tui = TUI(initial_console)
+    console = Console(file=StringIO(), width=50, height=6, color_system=None)
+    tui = TUI(console)
     tui.set_team_provider(lambda: [
         {"aid": 0, "role": "lead", "phase": "done", "busy": False},
     ])
-    tui._status_lines.append(Text("short body", style="#6B7280"))
-    display = tui._build_live_display()
+    _stream(tui, 8)
+    assert len(_live_rows(tui)) == 6
 
-    resized_console = Console(file=StringIO(), width=50, height=3, color_system=None)
-    rendered = resized_console.render_lines(display, resized_console.options, pad=False)
-    rows = ["".join(segment.text for segment in line) for line in rendered]
+    console.height = 3
 
-    assert len(rows) == resized_console.height
-    assert rows[-1].startswith("AGENTS")
+    rows = _live_rows(tui)
+    assert len(rows) == 3
+    assert "AGENTS" in rows[-1]
 
 
 def test_reset_clears_live_state_but_preserves_agent_history_and_roster():

--- a/tests/test_tui_team_display.py
+++ b/tests/test_tui_team_display.py
@@ -140,18 +140,18 @@ def test_message_events_append_activity_lines():
     tui.event_handler(SchedulerEvent("agent_message_sent", {"from_aid": 0, "to_aid": 2}))
     tui.event_handler(SchedulerEvent("agent_message_delivered", {"to_aid": 2, "result_len": 10}))
 
-    sent_timeline = "\n".join(
+    sent_history = "\n".join(
         block.plain
-        for block in tui._state_for(0).timeline_blocks
+        for block in tui._state_for(0).history_blocks
         if hasattr(block, "plain")
     )
-    delivered_timeline = "\n".join(
+    delivered_history = "\n".join(
         block.plain
-        for block in tui._state_for(2).timeline_blocks
+        for block in tui._state_for(2).history_blocks
         if hasattr(block, "plain")
     )
-    assert "A0 → A2 message" in sent_timeline
-    assert "A2 received message" in delivered_timeline
+    assert "A0 → A2 message" in sent_history
+    assert "A2 received message" in delivered_history
 
 
 def test_status_lines_use_explicit_non_white_styles():
@@ -178,7 +178,7 @@ def test_status_chrome_renderables_avoid_default_text_color():
     )
     tui.event_handler(SchedulerEvent("agent_spawned", {"aid": 2, "parent_aid": 0, "role": "reviewer"}))
 
-    for block in tui._timeline_blocks:
+    for block in tui._selected_state.history_blocks:
         if isinstance(block, Text):
             _assert_visible_text_has_non_white_style(block)
 
@@ -252,7 +252,9 @@ def test_agent_status_is_pinned_to_terminal_bottom_when_content_is_short():
     rendered = console.render_lines(tui._build_live_display(), console.options, pad=False)
     rows = ["".join(segment.text for segment in line) for line in rendered]
 
-    assert len(rows) == console.height
+    # A short frame must claim only the rows it needs. Padding it out to the
+    # terminal height is what buried the settled transcript printed above it.
+    assert len(rows) < console.height
     assert "short body" in rows
     assert rows[-1].startswith("AGENTS")
     assert all(not row.startswith("AGENTS") for row in rows[:-1])
@@ -300,4 +302,6 @@ def test_reset_clears_live_state_but_preserves_agent_history_and_roster():
     assert tui.selected_aid == 1
     assert list(tui._agent_states) == [0, 1]
     assert tui._state_for(1).history_blocks == history
-    assert tui._state_for(1).timeline_blocks == []
+    assert tui._state_for(1).active_tools == {}
+    assert tui._state_for(1).status_lines == []
+    assert tui._state_for(1).thinking is None

--- a/tests/test_tui_team_display.py
+++ b/tests/test_tui_team_display.py
@@ -185,6 +185,39 @@ def test_status_chrome_renderables_avoid_default_text_color():
     _assert_visible_text_has_non_white_style(tui._build_status_row())
 
 
+def test_status_row_stays_one_row_when_the_text_it_quotes_has_newlines():
+    """The chrome quotes text the renderer does not control.
+
+    A shell command, a tool argument and an error reason all reach the status
+    row verbatim, and a newline in any of them turns the single shared row into
+    three — undoing the whole point of collapsing the chrome onto one row.
+    """
+    console = Console(file=StringIO(), width=100, color_system=None)
+    tui = TUI(console)
+
+    tui.event_handler(
+        SessionRuntimeEvent(
+            "tool_start",
+            {"tool": "bash", "args": {"command": "echo one\necho two\r\necho three"}, "aid": 0},
+        )
+    )
+    row = tui._build_status_row()
+    assert "\n" not in row.plain and "\r" not in row.plain
+    assert len(console.render_lines(row, console.options.update(width=100))) == 1
+
+    # Same for the error path, whose reason comes straight from the runtime.
+    tui._live_paused = True
+    tui.event_handler(
+        SessionRuntimeEvent("error", {"reason": "boom\n  File x.py, line 1\n  KeyError", "aid": 0})
+    )
+    tui._active_tools.clear()
+    row = tui._build_status_row()
+    assert "\n" not in row.plain
+    assert len(console.render_lines(row, console.options.update(width=100))) == 1
+    # Scrollback still gets the whole message — only the one-row chrome folds.
+    assert "File x.py" in console.file.getvalue()
+
+
 def test_live_display_tails_when_content_exceeds_terminal_height():
     console = Console(file=StringIO(), width=40, height=4)
     tui = TUI(console)


### PR DESCRIPTION
## The bug

The interactive TUI kept **nothing** in terminal scrollback. Settled blocks were re-rendered into the prompt_toolkit *prompt* on every keystroke, and the Live frame padded itself to the full terminal height ten times a second before being erased (`transient=True`).

Measured on an 80×24 terminal, before:

```
live frame, 1 line of content : 24 rendered lines   (terminal height 24)
live frame, 12 events         : 24 rendered lines
live frame, no team panel     : 15 rendered lines

prompt history after turn 1 : 14 lines
turn 2 : 32   turn 3 : 50   turn 4 : 68   turn 6 : 104
```

From the second turn on the prompt exceeded the terminal, so prompt_toolkit's cursor-based erase could no longer reach the rows that had scrolled off — the reported screen wipe.

After: **24 → 3 rendered lines** for a one-line frame, and no history in the prompt at all.

## The change

Settled blocks go to ordinary scrollback the moment they settle, so the terminal's own scrollback is the transcript and nothing is erased. The Live region carries only in-flight chrome (streaming text, tool spinners, wait indicator, roster footer), is sized to its content, and is capped rather than padded.

Selecting an agent reprints it **in full** under a labelled band — a full redraw rather than only the unprinted tail, because focus is how a user asks to look at an agent. Blocks already printed are not printed again.

Printing has two contexts and one is not free: while a turn runs, Rich's Live renders ordinary prints above its own region; a prompt_toolkit prompt owns the screen, so the CLI installs `run_in_terminal` as a prompt-scoped gate.

Removed along the way, all of it in service of the redrawable view: the per-agent timeline mirror, the settled-turn slice, the prompt history cache, and their render-revision bookkeeping.

Also fixed: `_emit_status` printed an unfocused agent's line directly when no live frame was up; long session/trajectory paths wrapped to four rows.

## Verification

Driven end-to-end against a real model inside a pty, replayed through a terminal emulator to see what a user actually sees:

- **0** full-screen wipes (`ESC[2J`), **0** alt-screen switches
- 1941 raw stream lines collapse to **131** visible lines — Rich redraws in place
- The user's typed line appears exactly **once**
- Tab → `──── A1 tester ────` band + that agent's full trajectory; Tab back → `──── Analyst ────` + its full trajectory, with no duplicate of already-printed blocks
- Messaging a Tab-selected child works: the follow-up was answered by the tester in the first person about its own tool calls, followed by `▪ A1 completed (1.6s)`
- One-shot with redirected (non-TTY) output still lands the answer, which previously depended on the now-removed `persist=True` path

Four `test_tui_team_display` tests asserted the full-height frame as a contract and are rewritten against the fixed behaviour.

## Notes

- Reprinting on every switch is the direct cost of full redraw; toggling back and forth repeats a trajectory in scrollback. That is the intended semantics, not an oversight.
- The second commit splits `test_tui_event_rendering.py` (806 lines) because the 800-line ceiling is measured differently on PR vs push — this would have gone green here and broken `main`.
