### PR TITLE
feat: hold one resource equal, and count the other

### DIFF
--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import logging
 import math
 import time
 import uuid
@@ -38,6 +39,8 @@ from opencollab.application.ports import (
 from opencollab.application.tool_execution import ToolExecutionUseCase
 from opencollab.domain.events import SessionRuntimeEvent
 from opencollab.domain.session import SessionPhase, SessionState
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "DEFAULT_COMMIT_RESERVE",
@@ -148,6 +151,10 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         # (None|'soft'|'hard'). Drives _maybe_trace_steering to log only UPWARD
         # crossings, re-arming on a write reset. Never persisted.
         self._last_steering_level: str | None = None
+        # One ``session_terminal`` row per session, not per turn: ``run_loop``
+        # can be re-entered on an already-finished session as a read-only query
+        # for its answer, and that must not add a second disposition.
+        self._session_terminal_traced = False
         # Enforcement wind-down (STEP 0). Off by default: when ``off`` the precheck
         # wind-down branch is never taken, so the FSM is byte-for-byte identical to
         # the pre-enforcement code. ``commit_reserve`` is carved FROM the cap (not
@@ -264,11 +271,13 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
             raise
         except Exception as exc:
             self.state.fail(reason=f"{type(exc).__name__}: {exc}")
+            self._trace_session_terminal()
             raise
 
         answer = self._last_turn_answer()
         if self.is_terminal_phase():
             self.state.clear_active_turn()
+            self._trace_session_terminal()
         return answer
 
     def _prepare_turn(self) -> None:
@@ -308,6 +317,55 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
     def is_terminal_phase(self) -> bool:
         """Whether the session has finished its turn (done/failed/limits)."""
         return self.state.phase.is_terminal()
+
+    def _trace_session_terminal(self) -> None:
+        """Record how this session ended, and what it had left when it did.
+
+        Two resources can stop a session: the tokens it was given and the steps
+        it was allowed. They cannot both be equalized across differently
+        organized runs — a solo agent carries one long history and pays more per
+        step than a teammate carrying a short one — so a comparison holds one of
+        them equal and lets the other vary. This repository holds tokens equal.
+
+        That makes the step ceiling a runaway guard rather than an allowance,
+        and a guard is only honest if it never actually fires. Nothing recorded
+        that. A session stopped at its step ceiling with tokens still unspent
+        looked exactly like a session that finished: the phase collapsed to
+        STOPPED, the reason string lived only in memory, and the trajectory —
+        the file the run is read from afterwards — said nothing at all. The
+        claim "steps were counted, never enforced" was unfalsifiable.
+
+        So each session writes one row naming its disposition beside both
+        counters and both ceilings. ``step_ceiling_reached`` is derivable from
+        the two step fields and is written anyway: it is the exact question this
+        record exists to answer, and a reader should not have to re-derive the
+        rule to ask it.
+
+        Observation only, and guarded: a record that cannot be built must not
+        change how the session ended.
+        """
+        if self._session_terminal_traced or self.tracer is None:
+            return
+        self._session_terminal_traced = True
+        try:
+            step_count = int(self.state.step_count)
+            max_steps = int(self.max_steps)
+            self.tracer.log_step(
+                step_type="session_terminal",
+                payload={
+                    "aid": self.state.aid,
+                    "role": getattr(self.agent, "name", None),
+                    "phase": self.state.phase.value,
+                    "terminal_reason": self.state.terminal_reason,
+                    "step_count": step_count,
+                    "max_steps": max_steps,
+                    "step_ceiling_reached": step_count >= max_steps,
+                    "used_tokens": int(self.state.used_tokens),
+                    "max_budget_tokens": int(self.max_budget_tokens),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — observability is non-authoritative
+            logger.error("session terminal trace failed: %s", exc)
 
     def _should_suspend(self) -> bool:
         """The loop stops on a terminal phase (turn finished) OR on the

--- a/opencollab/bootstrap/programmatic.py
+++ b/opencollab/bootstrap/programmatic.py
@@ -42,6 +42,7 @@ from opencollab.bootstrap.agent_runtime import (
 )
 from opencollab.bootstrap.config import resolve_thinking_params
 from opencollab.bootstrap.scheduler_factory import build_scheduler  # noqa: F401
+from opencollab.bootstrap.session_factory import SESSION_MAX_STEPS
 from opencollab.bootstrap.tool_registry import build_tools_for_role
 from opencollab.bootstrap.workflow_runtime import (
     WORKFLOW_AGENT_PROMPT,
@@ -685,12 +686,14 @@ async def run_team(
     use_worktrees: bool,
     prebuild_team: bool = False,
     allow_unisolated_shell: bool | None = None,
+    max_steps: int = SESSION_MAX_STEPS,
 ) -> ProgrammaticResult:
     """Run the scheduler regime once, including bounded team cleanup.
 
     A forwarder kept so ``programmatic`` stays the one import surface for the
     three regimes; the implementation lives in ``programmatic_team``, whose
-    docstring documents ``prebuild_team`` and ``allow_unisolated_shell``.
+    docstring documents ``prebuild_team``, ``allow_unisolated_shell`` and
+    ``max_steps``.
     """
     from opencollab.bootstrap.programmatic_team import run_team as _run_team
 
@@ -707,6 +710,7 @@ async def run_team(
         use_worktrees=use_worktrees,
         prebuild_team=prebuild_team,
         allow_unisolated_shell=allow_unisolated_shell,
+        max_steps=max_steps,
     )
 
 

--- a/opencollab/bootstrap/programmatic_team.py
+++ b/opencollab/bootstrap/programmatic_team.py
@@ -22,6 +22,7 @@ from opencollab.bootstrap.programmatic import (
     ProgrammaticResult,
 )
 from opencollab.bootstrap.runtime_context import build_runtime_context
+from opencollab.bootstrap.session_factory import SESSION_MAX_STEPS
 from opencollab.bootstrap.team_config import load_team_config
 from opencollab.domain.session import SessionPhase
 
@@ -40,11 +41,12 @@ async def run_team(
     use_worktrees: bool,
     prebuild_team: bool = False,
     allow_unisolated_shell: bool | None = None,
+    max_steps: int = SESSION_MAX_STEPS,
 ) -> ProgrammaticResult:
     """Run the scheduler regime once, including bounded team cleanup.
 
-    ``prebuild_team`` and ``allow_unisolated_shell`` are handed straight to
-    ``build_scheduler``; see its docstring for what each decides. Both default
+    ``prebuild_team``, ``allow_unisolated_shell`` and ``max_steps`` are handed
+    straight to ``build_scheduler``; see its docstring for what each decides. Both default
     to the values that reproduce today's run: no roster is seated up front, and
     the shell answer still follows ``interactive``, which is ``False`` here
     because a programmatic run has no human at it. Stating them is how an
@@ -76,6 +78,7 @@ async def run_team(
             resolved_team_config=team_config,
             save_dir=artifacts,
             prebuild_team=prebuild_team,
+            max_steps=max_steps,
         )
     except BaseException as exc:
         tracer_failure = _programmatic._close_tracer(context.tracer)

--- a/opencollab/bootstrap/scheduler_factory.py
+++ b/opencollab/bootstrap/scheduler_factory.py
@@ -28,6 +28,7 @@ from opencollab.bootstrap.config import (
 from opencollab.bootstrap.container import RuntimeContext, build_workspace_safety_policy
 from opencollab.bootstrap.context_builder import SpawnConfig
 from opencollab.bootstrap.session_factory import (
+    SESSION_MAX_STEPS,
     DefaultSessionFactory,
     agent_save_path,
     make_run_dir,
@@ -112,6 +113,7 @@ def build_scheduler(
     allow_unisolated_child_tests: bool = False,
     prebuild_team: bool = False,
     allow_unisolated_shell: bool | None = None,
+    max_steps: int = SESSION_MAX_STEPS,
 ) -> Scheduler:
     """Build the Scheduler and let it create agent 0 (the init process).
 
@@ -148,6 +150,13 @@ def build_scheduler(
     watching it, which is why one boolean used to answer both. An unattended
     batch run pulls them apart: its agents must be able to run ``git`` in their
     worktrees, and there is nobody for them to ask anything. Passing
+    ``max_steps`` is the step ceiling every seat is built with — the entry agent
+    and each teammate alike. It is a runaway guard rather than an allowance:
+    tokens are the resource a run is held to, and steps are counted and
+    reported. Before this parameter existed the ceiling could not be set at all
+    on this path, and the two hard-coded defaults gave the entry agent twice
+    what a teammate got.
+
     ``allow_unisolated_shell=True`` with ``interactive=False`` is exactly that
     run, and it is not expressible with one flag.
 
@@ -216,6 +225,7 @@ def build_scheduler(
         # the hardened default it gives a child a model spawned mid-run.
         prebuilt_roster=prebuild_team,
         allow_unisolated_shell=allow_unisolated_shell,
+        max_steps=max_steps,
     )
     worktree_pool = WorktreePool(ctx.workspace, use_worktrees=use_worktrees)
 

--- a/opencollab/bootstrap/session_factory.py
+++ b/opencollab/bootstrap/session_factory.py
@@ -342,6 +342,32 @@ def _fork_snapshot_environment(environment: Any) -> Environment:
     return snapshot_environment
 
 
+SESSION_MAX_STEPS = 100
+"""The step ceiling every session in a run is built with.
+
+A runaway guard, not an allowance. Steps and tokens cannot both be equalized
+across differently-organized runs: a solo agent carries one long history and
+pays more per step, while a team's members each carry a short one and pay less,
+so holding the token pool equal makes the team's step count higher and holding
+the step count equal makes its token spend lower. Exactly one of the two can be
+the aligned resource, and it is tokens — that is the cost, the thing the
+provider bills, and the thing a budget claim is about. Steps are counted and
+reported instead, which makes them a result rather than a control.
+
+A guard is therefore only useful if it never fires: a session stopped by this
+ceiling while it still held tokens would be a limit acting under the name of a
+statistic. It has to sit above what the pool can physically fund, and every
+step must send the system prompt and the tool schemas, which compaction cannot
+remove — so the cheapest possible step has a floor and the pool divided by that
+floor bounds the steps a run can reach. Measured on the arms this repository
+ships, that bound is under 500 steps for a 1,000,000-token pool.
+
+The value is the same for every seat. A teammate used to get half the entry
+agent's allowance for no reason anyone could state, which is the same kind of
+unearned privilege difference the shell gate had.
+"""
+
+
 def build_spawn_session(
     *,
     role: str,
@@ -410,6 +436,7 @@ class DefaultSessionFactory:
         allow_unisolated_child_tests: bool = False,
         prebuilt_roster: bool = False,
         allow_unisolated_shell: bool | None = None,
+        max_steps: int = SESSION_MAX_STEPS,
     ):
         self._cfg = cfg
         self._provider_retry_budget = (
@@ -429,6 +456,7 @@ class DefaultSessionFactory:
         # Run folder where every agent's transcript is persisted. When set,
         # spawned children get their own ``agent_<aid>_<role>.json`` autosave.
         self._save_dir = save_dir
+        self._max_steps = int(max_steps)
 
     def _validate_responses_tool_support(self) -> None:
         """Reject statically incompatible team roles before opening a workspace."""
@@ -528,13 +556,17 @@ class DefaultSessionFactory:
         role: str,
         env: Environment,
         budget: int,
-        max_steps: int = 50,
+        max_steps: int | None = None,
         aid: int = -1,
         scheduler: SchedulerPort | None = None,
         task: str | None = None,
         context: str = "",
     ) -> Session:
         role = validate_role_identity(role)
+        # ``None`` means "whatever this run is using", which is the run's single
+        # ceiling. A caller that names a number still gets it, so the standalone
+        # ``build_spawn_session`` helper keeps its own documented default.
+        max_steps = self._max_steps if max_steps is None else int(max_steps)
         cfg = self._cfg
         safety_policy = (
             cfg.safety_policy_factory(env)
@@ -614,6 +646,7 @@ class DefaultSessionFactory:
             env=env,
             tracer=cfg.tracer,
             max_budget_tokens=budget,
+            max_steps=self._max_steps,
             event_sink=cfg.event_bus,
             permission_policy=cfg.permission_policy,
             ask_policy=cfg.ask_policy,
@@ -635,6 +668,7 @@ __all__ = [
     "SnapshotSessionError",
     "agent_save_path",
     "build_session",
+    "SESSION_MAX_STEPS",
     "build_spawn_session",
     "load_session",
     "make_run_dir",

--- a/opencollab/sdk/client.py
+++ b/opencollab/sdk/client.py
@@ -21,6 +21,7 @@ from opencollab.bootstrap.programmatic import (
     run_team,
     run_workflow,
 )
+from opencollab.bootstrap.session_factory import SESSION_MAX_STEPS
 
 from .result import RunError, RunResult
 
@@ -230,6 +231,7 @@ class OpenCollab:
         use_worktrees: bool = True,
         prebuild_team: bool = False,
         allow_unisolated_shell: bool | None = None,
+        max_steps: int = SESSION_MAX_STEPS,
     ) -> RunResult[str]:
         """Run one scheduler-controlled team turn.
 
@@ -243,6 +245,13 @@ class OpenCollab:
         ever given ``ask_user``, but an unattended experiment may still need its
         agents to run ``git`` in their worktrees. ``None`` leaves the shell
         answer where it has always been for an SDK run — off.
+
+        ``max_steps`` is the step ceiling every seat gets, entry agent and
+        teammates alike. A comparison between a team and a solo agent can hold
+        their tokens equal or their steps equal but not both, and this run holds
+        tokens; the ceiling is only here to stop a runaway, so set it above what
+        the token budget can pay for and read the realized step counts out of
+        the trajectory.
         """
         _non_empty(prompt, "prompt")
         if self._environment is not None:
@@ -253,6 +262,7 @@ class OpenCollab:
             raise ValueError("prebuild_team must be a boolean")
         if allow_unisolated_shell is not None and not isinstance(allow_unisolated_shell, bool):
             raise ValueError("allow_unisolated_shell must be a boolean or None")
+        resolved_team_max_steps = _positive_int(max_steps, "max_steps")
         team_path = _path(config, "config")
         try:
             result = await run_team(
@@ -274,6 +284,7 @@ class OpenCollab:
                 use_worktrees=use_worktrees,
                 prebuild_team=prebuild_team,
                 allow_unisolated_shell=allow_unisolated_shell,
+                max_steps=resolved_team_max_steps,
             )
         except ProgrammaticLifecycleError as exc:
             raise RunError(str(exc)) from exc

--- a/tests/test_prebuilt_team_topology.py
+++ b/tests/test_prebuilt_team_topology.py
@@ -38,7 +38,7 @@ from opencollab.application.scheduler_types import TeamPrebuiltError
 from opencollab.application.tool_execution import ToolRuntime
 from opencollab.bootstrap import build_runtime_context, build_scheduler
 from opencollab.bootstrap.context_builder import SpawnConfig
-from opencollab.bootstrap.session_factory import DefaultSessionFactory
+from opencollab.bootstrap.session_factory import SESSION_MAX_STEPS, DefaultSessionFactory
 from opencollab.bootstrap.team_config import (
     ANALYST_TOOL_NAMES,
     CODER_TOOL_NAMES,
@@ -772,3 +772,56 @@ async def test_the_shipped_team_still_starts_with_the_switch_off(tmp_path):
     finally:
         tracer.close()
         await scheduler.cleanup()
+
+
+async def test_every_seat_gets_the_same_step_ceiling(tmp_path):
+    """One run, one ceiling — for the entry agent and its teammates alike.
+
+    A team and a solo agent can be held to equal tokens or to equal steps, not
+    both: the solo agent carries one long history and pays more per step than a
+    teammate carrying a short one. These arms hold tokens equal, which makes the
+    step ceiling a runaway guard rather than an allowance — and a guard that
+    hands the entry agent twice what a teammate gets is neither.
+
+    Before this, the two seat paths took two different hard-coded defaults (100
+    for the entry agent, 50 for every teammate) and no caller could set either.
+    """
+    scheduler, tracer = _scheduler(
+        tmp_path,
+        prebuild_team=True,
+        team_config_path=str(HANDOFF_TEAM_FILE),
+        max_steps=777,
+    )
+    try:
+        await scheduler.ensure_team_prebuilt()
+        ceilings = {
+            scb.agent.name: scheduler._sessions[aid].max_steps
+            for aid, scb in sorted(scheduler.table.entries.items())
+        }
+    finally:
+        tracer.close()
+        await scheduler.cleanup()
+
+    assert ceilings == {"analyst": 777, "coder": 777, "tester": 777}
+
+
+async def test_the_default_ceiling_is_one_number_not_a_privilege(tmp_path):
+    """Unset, every seat still lands on the same figure — the asymmetry is gone
+    from the default, not merely overridable."""
+    scheduler, tracer = _scheduler(
+        tmp_path,
+        prebuild_team=True,
+        team_config_path=str(HANDOFF_TEAM_FILE),
+    )
+    try:
+        await scheduler.ensure_team_prebuilt()
+        ceilings = {
+            scheduler._sessions[aid].max_steps
+            for aid in scheduler.table.entries
+        }
+    finally:
+        tracer.close()
+        await scheduler.cleanup()
+
+    assert ceilings == {SESSION_MAX_STEPS}
+

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -79,6 +79,11 @@ def test_public_class_and_method_shapes_stay_lean() -> None:
             # seated before the first model call, and a seat whose shell runs.
             "prebuild_team",
             "allow_unisolated_shell",
+            # And the ceiling that must not become a third one: a team run holds
+            # tokens equal to a solo run's, so its step ceiling has to sit above
+            # what those tokens can pay for. ``agent`` and ``workflow`` already
+            # took this; ``team`` is where it could not be set at all.
+            "max_steps",
         ),
         sdk.OpenCollab.workflow: (
             "self",

--- a/tests/test_session_characterization.py
+++ b/tests/test_session_characterization.py
@@ -383,7 +383,11 @@ def test_no_tool_calls_marks_done_and_emits_text_delta():
     assert session.messages[-1] == {"role": "assistant", "content": "plain answer"}
     assert [event.type for event in events] == ["step_start", "text_delta", "step_end"]
     assert fake_llm.calls[0]["tools"] is None
-    assert [step["step_type"] for step in tracer.steps] == ["context_shaping", "llm_call"]
+    assert [step["step_type"] for step in tracer.steps] == [
+        "context_shaping",
+        "llm_call",
+        "session_terminal",
+    ]
     assert tracer.steps[1]["payload"]["content"] == "plain answer"
 
 def test_session_accepts_explicit_llm_client():
@@ -498,6 +502,7 @@ def test_tool_calls_execute_append_tool_result_and_continue():
         "tool_exec",
         "context_shaping",
         "llm_call",
+        "session_terminal",
     ]
     assert fake_llm.calls[0]["tools"][0]["function"]["name"] == "fake_tool"
 

--- a/tests/test_session_run_loop.py
+++ b/tests/test_session_run_loop.py
@@ -323,7 +323,13 @@ def test_actual_usage_overrun_is_traced_and_response_is_discarded():
         "error",
         "step_end",
     ]
-    assert [step["step_type"] for step in tracer.steps] == ["context_shaping", "llm_call"]
+    # Closing row: how the session ended, beside both counters (see
+    # ``_trace_session_terminal``).
+    assert [step["step_type"] for step in tracer.steps] == [
+        "context_shaping",
+        "llm_call",
+        "session_terminal",
+    ]
     assert tracer.steps[1]["tokens"] == reserved_input_tokens + 101
     assert tracer.steps[1]["payload"]["usage"]["input_tokens"] == (
         reserved_input_tokens + 100
@@ -576,6 +582,7 @@ def test_run_loop_llm_step_events_trace_and_message_shape():
         "llm_call",
         "context_shaping",
         "llm_call",
+        "session_terminal",
     ]
     assert events[2][1]["latency"] == tracer.steps[1]["latency"]
     assert tracer.steps[1] == {
@@ -878,3 +885,86 @@ def test_shaper_bounds_model_view_but_leaves_state_messages_full():
     assert "re-read a narrower range" in sent_tool["content"]
     # ...while the persisted history kept the full result.
     assert state.messages[1]["content"] == big
+
+
+def test_a_session_stopped_by_its_step_ceiling_says_so_on_disk():
+    """The ceiling is a guard, so a run has to be able to prove it never fired.
+
+    Tokens are the resource these arms are held to; steps vary and are counted.
+    A session stopped at its step ceiling with budget still unspent is that
+    story falling apart, and before this record it looked identical to a session
+    that simply finished: one STOPPED phase, a reason string that lived only in
+    memory, nothing in the trajectory.
+    """
+    tracer = FakeTracer()
+    calls = [tool_call()]
+    runner = build_runner(
+        agent=FakeAgent([{"type": "function", "function": {"name": "fake_tool"}}]),
+        # Never finishes on its own: every turn asks for another tool call, so
+        # the only thing that can stop it is a ceiling.
+        llm=FakeLLM(
+            [
+                llm_response(
+                    content="still working",
+                    tool_calls=calls,
+                    total_tokens=5,
+                    finish_reason="tool_calls",
+                )
+            ]
+            * 6
+        ),
+        tool_execution=FakeToolExecution(
+            ToolProcessingResult(
+                messages_to_append=[
+                    {"role": "tool", "tool_call_id": "call-1", "content": "ok"}
+                ]
+            )
+        ),
+        tracer=tracer,
+        max_steps=2,
+        max_budget_tokens=1_000_000,
+    )
+
+    run(runner.run_loop())
+
+    terminal = [step for step in tracer.steps if step["step_type"] == "session_terminal"]
+    assert len(terminal) == 1
+    payload = terminal[0]["payload"]
+    assert payload["step_ceiling_reached"] is True
+    assert payload["terminal_reason"] == "step limit reached: 2 steps"
+    # The other resource was nowhere near spent, which is what makes the stop a
+    # limit acting rather than a run finishing.
+    assert payload["used_tokens"] < payload["max_budget_tokens"]
+
+
+def test_a_session_that_finishes_on_its_own_reports_an_unreached_ceiling():
+    """The control. Without it the field above proves nothing: a record that
+    said "reached" for every session would pass the test above unchanged."""
+    tracer = FakeTracer()
+    runner = build_runner(
+        llm=FakeLLM([llm_response(content="done", total_tokens=5)]),
+        tracer=tracer,
+        max_steps=50,
+    )
+
+    run(runner.run_loop())
+
+    payload = [s for s in tracer.steps if s["step_type"] == "session_terminal"][0]["payload"]
+    assert payload["step_ceiling_reached"] is False
+    assert payload["step_count"] < payload["max_steps"]
+
+
+def test_a_finished_session_re_entered_for_its_answer_does_not_sign_off_twice():
+    """``run_loop`` doubles as a read-only query on a DONE session. One session
+    is one disposition; a second row would double-count it."""
+    tracer = FakeTracer()
+    runner = build_runner(
+        llm=FakeLLM([llm_response(content="done", total_tokens=5)]),
+        tracer=tracer,
+    )
+
+    run(runner.run_loop())
+    run(runner.run_loop())
+
+    assert len([s for s in tracer.steps if s["step_type"] == "session_terminal"]) == 1
+


### PR DESCRIPTION
Two things can stop a session: the tokens it was given and the steps it was
allowed. Across differently organized runs these cannot both be held equal. A
solo agent carries one long history and pays more per step; a team's members
each carry a short one and pay less. So holding the token pool equal makes the
team's step count higher, and holding the step count equal makes its token spend
lower. Exactly one of the two can be the aligned resource.

It is tokens. That is the cost, the thing the provider bills, and the thing a
budget claim is about. Steps become a result to report rather than a control.

## The ceiling was acting as an allowance

That only holds if the step ceiling never actually stops anyone, and it was
stopping people. The two seat paths carried two different hard-coded defaults —
`build_session`'s 100 for the entry agent, `build_spawn_session`'s 50 for every
teammate — and no caller could reach either. `client.agent()` and
`client.workflow()` both take `max_steps`; `client.team()` and `build_scheduler`
did not, so on the scheduler path the value could not be set at all.

Measured on this repository's own configurations, with a 1,000,000-token pool:

| | step ceiling, before | total |
|---|---|---|
| one agent | 100 | 100 |
| three-role team | 100 / 50 / 50 | 200 |

A teammate could be cut off at 50 steps holding most of its budget, and a
teammate is not twice as likely to run away as the agent that started the run.

## One number, reachable

`SESSION_MAX_STEPS` is defined once and reaches every seat. `build_scheduler`,
`run_team` and `client.team()` take `max_steps` and pass it to the entry agent
and each teammate alike. The standalone `build_spawn_session` helper keeps its
own documented default, so a caller that names a number still gets it.

Where the number belongs is measurable rather than a matter of taste. Every step
must send the system prompt and the tool schemas, and compaction cannot remove
either, so the cheapest possible step has a floor and the pool divided by that
floor bounds the steps a run can reach:

| | cheapest step | steps the pool can fund |
|---|---|---|
| solo agent | 2,218 | ≤ 450 |
| analyst / coder / tester | 3,881 / 3,561 / 3,367 | ≤ 257 / 280 / 297 |

## A guard nobody could check

Nothing recorded whether the ceiling had fired. The terminal reason lived in
memory, the phase collapsed to STOPPED, and a session cut off at its step
ceiling with tokens unspent was indistinguishable on disk from one that
finished. "Steps were counted, never enforced" was unfalsifiable.

Each session now writes one `session_terminal` row at its terminal transition,
carrying `terminal_reason`, `step_count`, `max_steps`, `step_ceiling_reached`,
`used_tokens` and `max_budget_tokens`. It fires once per session — `run_loop`
doubles as a read-only query on a finished session, and a second row would
double-count it. `step_ceiling_reached` is derivable from the two step fields
and is written anyway: it is the question the row exists to answer, and a reader
should not have to re-derive the rule to ask it.

A seated agent that never ran writes no row, which stays distinct from one that
ran and stopped.

## Verification

- `pytest`: 2498 passed, 2 skipped — 2493 before, plus the five tests here
- `lint-imports`: 4 contracts kept, 0 broken; interface-width gate silent
- Negative controls, each seen failing before it was seen passing: restoring the
  hard-coded 50 for teammates fails both seat tests; removing the
  `session_terminal` emission fails both record tests.
