### PR TITLE
fix: give the timing tests deadlines their implementations can meet

### DIFF
--- a/tests/test_async_timeout.py
+++ b/tests/test_async_timeout.py
@@ -169,7 +169,11 @@ print("RESULT:" + repr(value))
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        timeout=1,
+        # Starting an interpreter and importing opencollab measures 0.37-0.52s
+        # on an idle machine here and more under load, so a one-second budget
+        # was bounding Python's startup, not the shutdown being tested. This
+        # only has to fail a subprocess that never exits.
+        timeout=60,
         env=env,
         check=False,
     )

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -125,12 +125,13 @@ def test_autosave_coalesces_generations_not_yet_started():
 def test_autosave_coalesces_pending_generations_without_blocking_emit():
     current = {"value": ""}
     saved: list[str] = []
+    release = threading.Event()
 
     def prepare():
         frozen = current["value"]
 
         def save():
-            time.sleep(0.02)
+            release.wait(10.0)
             saved.append(frozen)
 
         return save
@@ -138,17 +139,18 @@ def test_autosave_coalesces_pending_generations_without_blocking_emit():
     subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
 
     async def scenario():
-        started = time.monotonic()
         for index in range(10):
             current["value"] = str(index)
             await subscriber.emit(SessionEvent(type="step_end"))
-        emit_elapsed = time.monotonic() - started
+            # The first save is parked in the sink and nothing has released it,
+            # so an emit that waited for its save could not have returned here.
+            # Not blocking is proved by what has been saved, not by a stopwatch.
+            assert saved == []
+        release.set()
         await asyncio.gather(*subscriber.pending_tasks)
-        return emit_elapsed
 
-    elapsed = asyncio.run(scenario())
+    asyncio.run(scenario())
 
-    assert elapsed < 0.05
     assert saved == ["0", "9"]
 
 

--- a/tests/test_autosave_subscriber.py
+++ b/tests/test_autosave_subscriber.py
@@ -122,6 +122,16 @@ def test_autosave_coalesces_generations_not_yet_started():
     assert subscriber.pending_tasks == ()
 
 
+# The sink is released on its own timer rather than by the loop under test: an
+# ``emit`` that waited for its save would otherwise be holding the release it
+# needs, and the block would only surface after the sink's own 10s cap.
+SINK_HELD_SECONDS = 2.0
+
+# Ten hand-offs cost microseconds; an ``emit`` that waited pays the whole hold
+# above on the first one. This bound sits between the two with room to spare.
+NON_BLOCKING_EMIT_SECONDS = 0.5
+
+
 def test_autosave_coalesces_pending_generations_without_blocking_emit():
     current = {"value": ""}
     saved: list[str] = []
@@ -139,14 +149,22 @@ def test_autosave_coalesces_pending_generations_without_blocking_emit():
     subscriber = AutoSaveSubscriber(lambda: None, prepare_fn=prepare)
 
     async def scenario():
-        for index in range(10):
-            current["value"] = str(index)
-            await subscriber.emit(SessionEvent(type="step_end"))
-            # The first save is parked in the sink and nothing has released it,
-            # so an emit that waited for its save could not have returned here.
-            # Not blocking is proved by what has been saved, not by a stopwatch.
-            assert saved == []
-        release.set()
+        releaser = threading.Timer(SINK_HELD_SECONDS, release.set)
+        releaser.start()
+        try:
+            started_at = time.monotonic()
+            for index in range(10):
+                current["value"] = str(index)
+                await subscriber.emit(SessionEvent(type="step_end"))
+                # The first save is parked in the sink and the sink is still
+                # held, so an emit that waited for its save could not have
+                # returned here.
+                assert saved == []
+            # And the hand-offs did not merely decline to wait — they came back.
+            assert time.monotonic() - started_at < NON_BLOCKING_EMIT_SECONDS
+        finally:
+            releaser.cancel()
+            release.set()
         await asyncio.gather(*subscriber.pending_tasks)
 
     asyncio.run(scenario())

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -17,6 +17,10 @@ from types import SimpleNamespace
 import pytest
 
 from opencollab.adapters import hooks as hooks_adapter
+from opencollab.adapters._env_process import (
+    PROCESS_KILL_GRACE_SECONDS,
+    PROCESS_TERM_GRACE_SECONDS,
+)
 from opencollab.adapters.hooks import ShellHookRunner
 from opencollab.application.hooks import HookEventSubscriber
 from opencollab.bootstrap import build_runtime_context, build_scheduler
@@ -167,12 +171,25 @@ def test_runner_swallows_nonzero_exit():
     assert outcome.allow is True
 
 
+# Killing one hook may cost the hook's own timeout, then a SIGTERM grace, then
+# two kill graces reaping the group. A test deadline below that sum reports a
+# kill that worked as a failure on any machine slow enough to need the graces.
+HOOK_KILL_WORST_CASE_SECONDS = PROCESS_TERM_GRACE_SECONDS + 2 * PROCESS_KILL_GRACE_SECONDS
+
+
 def test_runner_kills_on_timeout_without_raising():
-    spec = HookSpec(event="Stop", action_type="command", command="sleep 5", timeout=0.2)
+    hook_timeout = 0.2
+    # The command outlives the deadline by an order of magnitude, so a hook that
+    # was waited out instead of killed trips the deadline rather than passing.
+    spec = HookSpec(event="Stop", action_type="command", command="sleep 60", timeout=hook_timeout)
     runner = ShellHookRunner((spec,))
+    deadline = hook_timeout + HOOK_KILL_WORST_CASE_SECONDS + 1.0
 
     async def _run():
-        return await asyncio.wait_for(runner.fire("Stop", {"hook_event_name": "Stop"}), timeout=2.0)
+        return await asyncio.wait_for(
+            runner.fire("Stop", {"hook_event_name": "Stop"}),
+            timeout=deadline,
+        )
 
     # Returns well under the sleep duration and does not raise.
     outcome = asyncio.run(_run())
@@ -180,14 +197,19 @@ def test_runner_kills_on_timeout_without_raising():
 
 
 def _delayed_sentinel_command(started, finished) -> str:
-    code = (
-        "import pathlib,time; "
-        f"pathlib.Path({str(started)!r}).touch(); "
-        "time.sleep(0.6); "
-        f"pathlib.Path({str(finished)!r}).touch()"
+    """A backgrounded descendant that marks its start, waits, then marks its end.
+
+    Both marks are shell redirections rather than a launched program: the callers
+    below kill this group on a sub-second timeout, and an interpreter's startup
+    does not reliably fit inside one — measured at 0.04-0.35s on the machines
+    this suite runs on, against a 0.2s hook timeout.
+    """
+    child = (
+        f": > {shlex.quote(str(started))}; "
+        "sleep 0.6; "
+        f": > {shlex.quote(str(finished))}"
     )
-    child = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
-    return f"{child} & wait"
+    return f"{{ {child}; }} & wait"
 
 
 def test_runner_timeout_kills_descendant_process_group(tmp_path):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shlex
 import sys
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -196,20 +198,63 @@ def test_runner_kills_on_timeout_without_raising():
     assert outcome.allow is True
 
 
-def _delayed_sentinel_command(started, finished) -> str:
-    """A backgrounded descendant that marks its start, waits, then marks its end.
+# The descendant must still be sleeping when a *slow but correct* cleanup gets
+# round to killing it. Cleanup is allowed the whole kill window, so a descendant
+# that wakes inside it writes ``finished`` on cleanup that worked — the same
+# mismatch this module fixes elsewhere, pointing the other way.
+DESCENDANT_OUTLIVES_CLEANUP_SECONDS = HOOK_KILL_WORST_CASE_SECONDS + 5.0
 
-    Both marks are shell redirections rather than a launched program: the callers
+
+def _delayed_sentinel_command(started, finished) -> str:
+    """A backgrounded descendant that records its pid, sleeps, then marks its end.
+
+    The marks are shell builtins rather than a launched program: the callers
     below kill this group on a sub-second timeout, and an interpreter's startup
     does not reliably fit inside one — measured at 0.04-0.35s on the machines
     this suite runs on, against a 0.2s hook timeout.
+
+    ``started`` carries the sleeping descendant's pid, so a caller asks whether
+    that process is gone rather than waiting out a wall-clock window. ``finished``
+    is written only when the sleep runs to completion (``&&`` drops it when a
+    signal ends the wait), and the sleep outlasts every grace the cleanup path
+    may spend, so a cleanup that worked cannot lose a race to it.
     """
     child = (
-        f": > {shlex.quote(str(started))}; "
-        "sleep 0.6; "
-        f": > {shlex.quote(str(finished))}"
+        f"sleep {DESCENDANT_OUTLIVES_CLEANUP_SECONDS} & "
+        f"echo $! > {shlex.quote(str(started))}; "
+        f"wait $! && : > {shlex.quote(str(finished))}"
     )
     return f"{{ {child}; }} & wait"
+
+
+async def _await_descendant_reaped(started) -> None:
+    """Wait, on the loop, until the recorded descendant is gone.
+
+    Bounded by what ``terminate_process`` permits itself rather than by a fixed
+    sleep, so a loaded machine buys time instead of a false failure. The wait
+    has to happen *on the running loop*: the cancellation path finishes its
+    cleanup there, so a caller that closed the loop first would be asking about
+    a descendant nobody is left to kill.
+    """
+    deadline = time.monotonic() + HOOK_KILL_WORST_CASE_SECONDS + 1.0
+    # ``started`` exists as soon as the redirection opens it, which can be a
+    # moment before the pid lands in it.
+    while True:
+        recorded = started.read_text().strip() if started.exists() else ""
+        if recorded:
+            break
+        if time.monotonic() >= deadline:
+            pytest.fail("descendant never recorded its pid")
+        await asyncio.sleep(0.01)
+    descendant = int(recorded)
+    while True:
+        try:
+            os.kill(descendant, 0)
+        except ProcessLookupError:
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(f"descendant {descendant} outlived the cleanup path")
+        await asyncio.sleep(0.01)
 
 
 def test_runner_timeout_kills_descendant_process_group(tmp_path):
@@ -222,10 +267,12 @@ def test_runner_timeout_kills_descendant_process_group(tmp_path):
         timeout=0.2,
     )
 
-    asyncio.run(ShellHookRunner((spec,)).fire("Stop", {"hook_event_name": "Stop"}))
+    async def _run() -> None:
+        await ShellHookRunner((spec,)).fire("Stop", {"hook_event_name": "Stop"})
+        assert started.exists()
+        await _await_descendant_reaped(started)
 
-    assert started.exists()
-    asyncio.run(asyncio.sleep(0.7))
+    asyncio.run(_run())
     assert not finished.exists()
 
 
@@ -274,7 +321,7 @@ def test_runner_caller_cancellation_kills_descendant_process_group(tmp_path):
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        await asyncio.sleep(0.7)
+        await _await_descendant_reaped(started)
 
     asyncio.run(_run())
     assert not finished.exists()

--- a/tests/test_local_env_processes.py
+++ b/tests/test_local_env_processes.py
@@ -326,6 +326,20 @@ async def test_process_timeout_covers_blocked_stdin_writer(tmp_path) -> None:
         )
 
 
+# ``terminate_process`` may spend a SIGTERM grace and then two kill graces
+# reaping the group, so a deadline below that sum reports a cleanup that worked
+# as a hang. The two spawn tests below wait on cleanup that really runs, so they
+# have to allow what the implementation allows itself.
+CLEANUP_WORST_CASE_SECONDS = (
+    process_module.PROCESS_TERM_GRACE_SECONDS + 2 * process_module.PROCESS_KILL_GRACE_SECONDS
+)
+
+# The gated spawn never completes while the gate is held, so a task that failed
+# to give up would miss any deadline at all; this one only has to sit above a
+# loaded machine's scheduling jitter.
+GATED_TASK_SETTLES_SECONDS = 2.0
+
+
 async def test_process_timeout_covers_subprocess_spawn(monkeypatch, tmp_path) -> None:
     gate = asyncio.Event()
     terminated = asyncio.Event()
@@ -357,7 +371,7 @@ async def test_process_timeout_covers_subprocess_spawn(monkeypatch, tmp_path) ->
     )
 
     try:
-        done, _pending = await asyncio.wait({task}, timeout=0.1)
+        done, _pending = await asyncio.wait({task}, timeout=GATED_TASK_SETTLES_SECONDS)
         assert task in done
         with pytest.raises(asyncio.TimeoutError):
             task.result()
@@ -366,7 +380,7 @@ async def test_process_timeout_covers_subprocess_spawn(monkeypatch, tmp_path) ->
         if not task.done():
             with pytest.raises(asyncio.TimeoutError):
                 await task
-        await asyncio.wait_for(terminated.wait(), timeout=1)
+        await asyncio.wait_for(terminated.wait(), timeout=CLEANUP_WORST_CASE_SECONDS + 1)
 
 
 async def test_process_cancellation_during_spawn_is_bounded(
@@ -405,7 +419,7 @@ async def test_process_cancellation_during_spawn_is_bounded(
     task.cancel()
 
     try:
-        done, _pending = await asyncio.wait({task}, timeout=0.1)
+        done, _pending = await asyncio.wait({task}, timeout=GATED_TASK_SETTLES_SECONDS)
         assert task in done
         with pytest.raises(asyncio.CancelledError):
             task.result()
@@ -414,7 +428,7 @@ async def test_process_cancellation_during_spawn_is_bounded(
         if not task.done():
             with pytest.raises(asyncio.CancelledError):
                 await task
-        await asyncio.wait_for(terminated.wait(), timeout=1)
+        await asyncio.wait_for(terminated.wait(), timeout=CLEANUP_WORST_CASE_SECONDS + 1)
 
 
 async def test_registry_abort_bounds_unfinished_spawn_handoff(monkeypatch) -> None:

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -139,6 +140,17 @@ def test_tracer_write_failure_is_sticky(tmp_path, monkeypatch) -> None:
     assert tracer.dropped_steps == 2
 
 
+# The sink is released on its own timer rather than by the caller under test: a
+# ``log_step`` that waited for the write would otherwise be holding the release
+# it needs, and the block would only surface after the sink's own 10s cap.
+SINK_HELD_SECONDS = 2.0
+
+# A ``log_step`` that waited for the sink pays the whole hold above. This bound
+# sits an order of magnitude above the hand-off and well below that hold, so it
+# fails a caller that waited without failing a merely loaded machine.
+NON_BLOCKING_HANDOFF_SECONDS = 0.5
+
+
 def test_tracer_slow_write_does_not_block_log_step(tmp_path, monkeypatch) -> None:
     started = threading.Event()
     release = threading.Event()
@@ -151,14 +163,20 @@ def test_tracer_slow_write_does_not_block_log_step(tmp_path, monkeypatch) -> Non
 
     monkeypatch.setattr("opencollab.adapters.trace.write_locked_text", slow_write)
     tracer = Tracer("run", output_dir=str(tmp_path))
+    releaser = threading.Timer(SINK_HELD_SECONDS, release.set)
+    releaser.start()
     try:
+        handed_off_at = time.monotonic()
         tracer.log_step("slow", {})
-        # The writer really is inside the slow sink, and nothing has released it
-        # yet — so a log_step that waited for the write could not have returned.
-        # Handing off is proved by which events are set, not by how long it took.
+        elapsed = time.monotonic() - handed_off_at
+        # The writer really is inside the slow sink and the sink is still held,
+        # so a log_step that waited for the write could not have returned.
         assert started.wait(10.0)
         assert not left_sink.is_set()
+        # And it did not merely decline to wait for the sink — it came back.
+        assert elapsed < NON_BLOCKING_HANDOFF_SECONDS
     finally:
+        releaser.cancel()
         release.set()
         tracer.close()
 

--- a/tests/test_observability_file_safety.py
+++ b/tests/test_observability_file_safety.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import os
 import threading
-import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -143,23 +142,24 @@ def test_tracer_write_failure_is_sticky(tmp_path, monkeypatch) -> None:
 def test_tracer_slow_write_does_not_block_log_step(tmp_path, monkeypatch) -> None:
     started = threading.Event()
     release = threading.Event()
+    left_sink = threading.Event()
 
     def slow_write(*_args, **_kwargs) -> None:
         started.set()
-        assert release.wait(1.0)
+        release.wait(10.0)
+        left_sink.set()
 
     monkeypatch.setattr("opencollab.adapters.trace.write_locked_text", slow_write)
     tracer = Tracer("run", output_dir=str(tmp_path))
-    timer = threading.Timer(0.15, release.set)
-    timer.start()
     try:
-        before = time.monotonic()
         tracer.log_step("slow", {})
-        elapsed = time.monotonic() - before
-        assert elapsed < 0.05
+        # The writer really is inside the slow sink, and nothing has released it
+        # yet — so a log_step that waited for the write could not have returned.
+        # Handing off is proved by which events are set, not by how long it took.
+        assert started.wait(10.0)
+        assert not left_sink.is_set()
     finally:
         release.set()
-        timer.cancel()
         tracer.close()
 
 

--- a/tests/test_responses_http_contract.py
+++ b/tests/test_responses_http_contract.py
@@ -67,6 +67,14 @@ def _completed_event(
     }
 
 
+# These tests assert what the client puts on the wire and what it makes of the
+# reply, never how fast a local server answers. The timeouts are here to fail a
+# hang, so they sit far above the round trip: a five-second round deadline is
+# reachable on a loaded single-core runner, and reports a correct request as a
+# protocol error.
+HANG_GUARD_SECONDS = 60
+
+
 @contextmanager
 def fake_responses_server(
     scripts: list[list[dict[str, Any]]],
@@ -155,9 +163,9 @@ async def test_real_http_stream_replays_reasoning_function_call_and_output(monke
             base_url=base_url,
             wire_protocol="responses",
             max_retries=0,
-            request_timeout=5,
-            first_event_timeout=2,
-            stream_idle_timeout=2,
+            request_timeout=HANG_GUARD_SECONDS,
+            first_event_timeout=HANG_GUARD_SECONDS,
+            stream_idle_timeout=HANG_GUARD_SECONDS,
         )
         first = await client.complete(
             [{"role": "system", "content": "Use tools."}, {"role": "user", "content": "Get it."}],
@@ -255,9 +263,9 @@ async def test_real_http_deepseek_named_tool_uses_json_schema_text_binding():
             base_url=base_url,
             wire_protocol="responses",
             max_retries=0,
-            request_timeout=5,
-            first_event_timeout=2,
-            stream_idle_timeout=2,
+            request_timeout=HANG_GUARD_SECONDS,
+            first_event_timeout=HANG_GUARD_SECONDS,
+            stream_idle_timeout=HANG_GUARD_SECONDS,
         )
         result = await client.complete(
             [{"role": "user", "content": "Return findings."}],

--- a/tests/test_responses_provider.py
+++ b/tests/test_responses_provider.py
@@ -520,15 +520,29 @@ async def test_first_event_timeout_includes_waiting_for_response_headers():
 
 
 @pytest.mark.asyncio
-async def test_response_header_timeout_retries_the_same_request():
+async def test_response_header_timeout_retries_the_same_request(monkeypatch):
     calls = 0
+
+    # The first-event budget is spent by attempt 1 *and* re-imposed on attempt 2,
+    # which has to create its stream and yield its first event inside whatever is
+    # left of it. Keep the budget far above the microseconds that costs: a value
+    # small enough to be interesting on attempt 1 is a coin flip on attempt 2.
+    first_event_timeout = 0.25
+
+    async def skip_delay(_seconds):
+        return None
+
+    # Patching ``retry.asyncio.sleep`` mutates the one shared ``asyncio`` module,
+    # so the stalled attempt below must hang on something other than a sleep.
+    monkeypatch.setattr("opencollab.adapters.llm.retry.asyncio.sleep", skip_delay)
+    never = asyncio.Event()
 
     class Responses:
         async def create(self, **_kwargs):
             nonlocal calls
             calls += 1
             if calls == 1:
-                await asyncio.sleep(10)
+                await never.wait()
             item = message_item("OK")
             return FakeStream(
                 [
@@ -545,9 +559,9 @@ async def test_response_header_timeout_retries_the_same_request():
         None,
         0,
         1,
-        first_event_timeout=0.001,
+        first_event_timeout=first_event_timeout,
         stream_idle_timeout=1,
-        round_timeout=2,
+        round_timeout=5,
     )
 
     assert calls == 2

--- a/tests/test_workflow_context_budget.py
+++ b/tests/test_workflow_context_budget.py
@@ -29,11 +29,22 @@ from opencollab.application.workflow_runtime import (
 # waits meant to EXPIRE keep their own small timeouts.
 MUST_SETTLE_SECONDS = 10.0
 
-# test_dead_scout_synth_respects_the_callers_deadline separates two outcomes:
-# the caller's deadline was honoured (milliseconds) or it was not, in which case
-# the internal commit cap runs instead. Any value between them tells them apart,
-# so sit far from the fast one rather than a tenth of a second away from it.
-CALLER_DEADLINE_HONOURED_SECONDS = 10.0
+# The deadline test below hands the synth a caller deadline and checks that the
+# synth is bounded by it. A millisecond deadline cannot do that: it can expire
+# while the synth session is still being built, and ``_remaining_timeout`` then
+# raises before ``run_loop`` is ever called — the synth never starts, and the
+# test reads that as a cancellation failure. Half a second is far above the
+# scheduling jitter that costs, so the synth is certain to have started.
+DEAD_SCOUT_CALLER_TIMEOUT_SECONDS = 0.5
+
+# The bound the deadline is *checked* against is a separate number from the
+# hang guard: a guard sized to tell a honoured deadline from the internal commit
+# cap would also pass an implementation that overran the caller by a second.
+# This one is generous against a loaded machine — half a second of slack on top
+# of the deadline, against the scheduling jitter actually measured here (a 10 ms
+# deadline was missed once in fifteen runs on a machine held busy) — while still
+# failing an overrun long before the internal cap could explain it.
+CALLER_DEADLINE_HONOURED_SECONDS = DEAD_SCOUT_CALLER_TIMEOUT_SECONDS + 0.5
 assert CALLER_DEADLINE_HONOURED_SECONDS < DEFAULT_INTERNAL_COMMIT_TIMEOUT_SECONDS
 
 
@@ -371,9 +382,11 @@ async def test_dead_scout_synth_respects_the_callers_deadline():
     class BlockingSynth(FakeSession):
         def __init__(self) -> None:
             super().__init__()
+            self.started = asyncio.Event()
             self.cancelled = asyncio.Event()
 
         async def run_loop(self, cancel_event=None):
+            self.started.set()
             try:
                 await asyncio.Event().wait()
             except asyncio.CancelledError:
@@ -396,15 +409,20 @@ async def test_dead_scout_synth_respects_the_callers_deadline():
         result = await asyncio.wait_for(
             ctx.agent(
                 "scout",
-                timeout=0.01,
+                timeout=DEAD_SCOUT_CALLER_TIMEOUT_SECONDS,
                 enforcement_strength=ENFORCEMENT_ON,
             ),
-            timeout=CALLER_DEADLINE_HONOURED_SECONDS,
+            # A hang guard, nothing more — the elapsed bound below is what
+            # actually holds the implementation to the caller's deadline.
+            timeout=MUST_SETTLE_SECONDS,
         )
     finally:
         await ctx.wait_for_pending_cleanup()
 
     assert result is not None and "evidence cards" in result
+    # Separate "the synth never ran" from "the synth ran and the deadline
+    # cancelled it": only the second says the deadline reached the synth.
+    assert synth.started.is_set()
     assert synth.cancelled.is_set()
     assert asyncio.get_running_loop().time() - started_at < CALLER_DEADLINE_HONOURED_SECONDS
 

--- a/tests/test_workflow_context_budget.py
+++ b/tests/test_workflow_context_budget.py
@@ -19,6 +19,22 @@ from opencollab.application.workflow import (
     WorkflowBudgetExceeded,
     WorkflowContext,
 )
+from opencollab.application.workflow_runtime import (
+    DEFAULT_INTERNAL_COMMIT_TIMEOUT_SECONDS,
+)
+
+# Waits on work that must SUCCEED. It is event-loop bookkeeping with no
+# intrinsic duration, so a sub-second budget bounds how starved the machine is
+# rather than the code, and reports work that finished as a red build. The
+# waits meant to EXPIRE keep their own small timeouts.
+MUST_SETTLE_SECONDS = 10.0
+
+# test_dead_scout_synth_respects_the_callers_deadline separates two outcomes:
+# the caller's deadline was honoured (milliseconds) or it was not, in which case
+# the internal commit cap runs instead. Any value between them tells them apart,
+# so sit far from the fast one rather than a tenth of a second away from it.
+CALLER_DEADLINE_HONOURED_SECONDS = 10.0
+assert CALLER_DEADLINE_HONOURED_SECONDS < DEFAULT_INTERNAL_COMMIT_TIMEOUT_SECONDS
 
 
 @pytest.mark.asyncio
@@ -258,7 +274,7 @@ async def test_timeout_keeps_concurrency_slot_until_cancel_cleanup_finishes():
     ctx = WorkflowContext(factory, max_concurrency=1)
 
     assert await ctx.agent("slow", timeout=0.05) is None
-    await asyncio.wait_for(timed_out.cancel_seen.wait(), timeout=0.5)
+    await asyncio.wait_for(timed_out.cancel_seen.wait(), timeout=MUST_SETTLE_SECONDS)
 
     second_task = asyncio.create_task(ctx.agent("second"))
     for _ in range(20):
@@ -267,7 +283,7 @@ async def test_timeout_keeps_concurrency_slot_until_cancel_cleanup_finishes():
     assert second_task.done() is False
 
     timed_out.release_cancel.set()
-    assert await asyncio.wait_for(second_task, timeout=0.5) == "second"
+    assert await asyncio.wait_for(second_task, timeout=MUST_SETTLE_SECONDS) == "second"
     assert overlapped is False
 
 @pytest.mark.asyncio
@@ -282,11 +298,11 @@ async def test_active_background_agent_is_visible_to_boundary_owner():
     ctx = WorkflowContext(FakeFactory([session]))
     agent_task = asyncio.create_task(ctx.agent("background"))
 
-    await asyncio.wait_for(started.wait(), timeout=0.5)
+    await asyncio.wait_for(started.wait(), timeout=MUST_SETTLE_SECONDS)
     assert agent_task in ctx.pending_cleanup_tasks
 
     release.set()
-    assert await asyncio.wait_for(agent_task, timeout=0.5) == "done"
+    assert await asyncio.wait_for(agent_task, timeout=MUST_SETTLE_SECONDS) == "done"
     await asyncio.sleep(0)
     assert ctx.pending_cleanup_tasks == ()
 
@@ -307,9 +323,9 @@ async def test_pending_cleanup_callback_consumes_late_exception():
     ctx = WorkflowContext(FakeFactory([session]))
     try:
         assert await ctx.agent("slow", timeout=0.05) is None
-        await asyncio.wait_for(session.cancel_seen.wait(), timeout=0.5)
+        await asyncio.wait_for(session.cancel_seen.wait(), timeout=MUST_SETTLE_SECONDS)
         session.release_cancel.set()
-        await asyncio.wait_for(ctx.wait_for_pending_cleanup(), timeout=0.5)
+        await asyncio.wait_for(ctx.wait_for_pending_cleanup(), timeout=MUST_SETTLE_SECONDS)
         for _ in range(3):
             await asyncio.sleep(0)
         gc.collect()
@@ -341,9 +357,9 @@ async def test_enforced_timeout_does_not_start_synth_while_scout_cleans_up():
 
     assert result is not None and "evidence cards" in result
     assert len(factory.builds) == 1
-    await asyncio.wait_for(timed_out.cancel_seen.wait(), timeout=0.5)
+    await asyncio.wait_for(timed_out.cancel_seen.wait(), timeout=MUST_SETTLE_SECONDS)
     timed_out.release_cancel.set()
-    await asyncio.wait_for(ctx.wait_for_pending_cleanup(), timeout=0.5)
+    await asyncio.wait_for(ctx.wait_for_pending_cleanup(), timeout=MUST_SETTLE_SECONDS)
 
 
 @pytest.mark.asyncio
@@ -383,14 +399,14 @@ async def test_dead_scout_synth_respects_the_callers_deadline():
                 timeout=0.01,
                 enforcement_strength=ENFORCEMENT_ON,
             ),
-            timeout=0.2,
+            timeout=CALLER_DEADLINE_HONOURED_SECONDS,
         )
     finally:
         await ctx.wait_for_pending_cleanup()
 
     assert result is not None and "evidence cards" in result
     assert synth.cancelled.is_set()
-    assert asyncio.get_running_loop().time() - started_at < 0.1
+    assert asyncio.get_running_loop().time() - started_at < CALLER_DEADLINE_HONOURED_SECONDS
 
 
 @pytest.mark.asyncio
@@ -478,14 +494,14 @@ async def test_budget_lease_release_cannot_be_cancelled_while_lock_is_held():
     )
 
     first_task = asyncio.create_task(ctx.agent("first", budget=80))
-    await asyncio.wait_for(first_started.wait(), timeout=0.5)
+    await asyncio.wait_for(first_started.wait(), timeout=MUST_SETTLE_SECONDS)
     await ctx._budget_lock.acquire()
     try:
         release_first.set()
         for _ in range(5):
             await asyncio.sleep(0)
         first_task.cancel()
-        assert await asyncio.wait_for(first_task, timeout=0.5) == "first"
+        assert await asyncio.wait_for(first_task, timeout=MUST_SETTLE_SECONDS) == "first"
         assert ctx.budget._leases == []
     finally:
         ctx._budget_lock.release()

--- a/tests/test_workflow_runtime_cleanup.py
+++ b/tests/test_workflow_runtime_cleanup.py
@@ -30,6 +30,18 @@ from opencollab.bootstrap.session_factory import build_session
 from opencollab.domain.agent import Agent
 from opencollab.domain.events import SessionRuntimeEvent
 
+# Deadlines on cleanup that must SUCCEED. Every wait below is on pure
+# event-loop bookkeeping with no intrinsic duration, so a sub-second budget
+# does not bound the code — it bounds how starved the machine is, and reports a
+# cleanup that worked as a red build. These exist to fail a genuine hang; the
+# waits that are supposed to EXPIRE keep their own small timeouts, because the
+# cleanup path spends them in full on every run before it escalates: the
+# quiesce in test_cleanup_cancels_tasks_without_aborting_caller_environment
+# before it cancels, and the cleanup_timeout in
+# test_run_workflow_quiesces_late_session_before_manifest_and_tracer_close
+# before it aborts the environment.
+MUST_SETTLE_SECONDS = 10.0
+
 
 @pytest.mark.asyncio
 async def test_cleanup_cancels_tasks_without_aborting_caller_environment():
@@ -91,7 +103,7 @@ async def test_workflow_finalization_closes_session_resources():
     quiesced, succeeded, lingering = (
         await workflow_cleanup._quiesce_and_finalize_workflow_context(
             ctx,
-            timeout=0.1,
+            timeout=MUST_SETTLE_SECONDS,
         )
     )
 
@@ -205,7 +217,7 @@ async def test_run_workflow_quiesces_late_session_before_manifest_and_tracer_clo
 
     async def fn(ctx, args):
         assert await ctx.agent("slow", timeout=0.001) is None
-        await asyncio.wait_for(holder["session"].cancel_seen.wait(), timeout=0.5)
+        await asyncio.wait_for(holder["session"].cancel_seen.wait(), timeout=MUST_SETTLE_SECONDS)
         return "ok"
 
     save_dir = str(tmp_path / "run")
@@ -283,7 +295,7 @@ async def test_workflow_cleanup_marks_cancelled_blocking_autosave_nonquiescent()
     cleanup = asyncio.create_task(
         workflow_cleanup._quiesce_workflow_context(ctx, timeout=0.02)
     )
-    deadline = asyncio.get_running_loop().time() + 0.5
+    deadline = asyncio.get_running_loop().time() + MUST_SETTLE_SECONDS
     while not (
         cleanup.done()
         or all(owner.cancelled() or owner.done() for owner in owners)
@@ -295,7 +307,7 @@ async def test_workflow_cleanup_marks_cancelled_blocking_autosave_nonquiescent()
 
     try:
         release_first.set()
-        assert await asyncio.to_thread(second_started.wait, 0.5)
+        assert await asyncio.to_thread(second_started.wait, MUST_SETTLE_SECONDS)
         quiesced, succeeded, _lingering = await cleanup
         assert quiesced is False
         assert succeeded is False
@@ -306,7 +318,7 @@ async def test_workflow_cleanup_marks_cancelled_blocking_autosave_nonquiescent()
         await asyncio.gather(*owners, return_exceptions=True)
 
     assert calls == ["start-1", "end-1", "start-2", "end-2"]
-    assert await workflow_cleanup._wait_for_context_cleanup(ctx, timeout=0.2)
+    assert await workflow_cleanup._wait_for_context_cleanup(ctx, timeout=MUST_SETTLE_SECONDS)
 
 @pytest.mark.asyncio
 async def test_workflow_cleanup_reports_completed_autosave_failure():
@@ -337,7 +349,7 @@ async def test_workflow_cleanup_reports_completed_autosave_failure():
 
     quiesced, succeeded, _lingering = await workflow_cleanup._quiesce_workflow_context(
         ctx,
-        timeout=0.1,
+        timeout=MUST_SETTLE_SECONDS,
     )
     assert quiesced is True
     assert succeeded is False
@@ -395,7 +407,7 @@ async def test_workflow_cleanup_tracks_abandoned_provider_task_until_exit():
 
     llm.release.set()
     await asyncio.gather(*pending, return_exceptions=True)
-    assert await workflow_cleanup._wait_for_context_cleanup(ctx, timeout=0.2)
+    assert await workflow_cleanup._wait_for_context_cleanup(ctx, timeout=MUST_SETTLE_SECONDS)
 
 @pytest.mark.asyncio
 async def test_run_workflow_reports_technical_cleanup_failure_after_quiescence(
@@ -479,11 +491,11 @@ async def test_run_workflow_cleanup_failure_is_note_on_primary_cancel(monkeypatc
         await asyncio.Event().wait()
 
     run_task = asyncio.create_task(workflow_runtime.run_workflow(fn, {}, cfg=_cfg()))
-    await asyncio.wait_for(started.wait(), timeout=0.5)
+    await asyncio.wait_for(started.wait(), timeout=MUST_SETTLE_SECONDS)
     run_task.cancel("primary cancellation")
 
     with pytest.raises(asyncio.CancelledError) as caught:
-        await asyncio.wait_for(run_task, timeout=0.5)
+        await asyncio.wait_for(run_task, timeout=MUST_SETTLE_SECONDS)
     assert_cancel_reason(caught.value, "primary cancellation")
     assert_cancel_note(
         caught.value,
@@ -528,7 +540,7 @@ async def test_run_workflow_reports_manifest_failure(
             {},
             cfg=_cfg(),
             save_dir=str(tmp_path / "run"),
-            cleanup_timeout=0.2,
+            cleanup_timeout=MUST_SETTLE_SECONDS,
         )
 
 @pytest.mark.asyncio
@@ -570,15 +582,15 @@ async def test_run_workflow_waits_for_orphaned_background_agent(monkeypatch):
             fn,
             {},
             cfg=_cfg(),
-            cleanup_timeout=0.2,
+            cleanup_timeout=MUST_SETTLE_SECONDS,
         )
     )
-    await asyncio.wait_for(started.wait(), timeout=0.5)
+    await asyncio.wait_for(started.wait(), timeout=MUST_SETTLE_SECONDS)
     await asyncio.sleep(0)
     assert run_task.done() is False
 
     release.set()
-    assert await asyncio.wait_for(run_task, timeout=0.5) == "workflow-returned"
+    assert await asyncio.wait_for(run_task, timeout=MUST_SETTLE_SECONDS) == "workflow-returned"
 
 @pytest.mark.asyncio
 async def test_owned_tracer_closes_when_cleanup_fails(
@@ -662,7 +674,7 @@ async def test_owned_tracer_closes_when_cleanup_fails(
 
     async def fn(ctx, args):
         assert await ctx.agent("slow", timeout=0.001) is None
-        await asyncio.wait_for(holder["session"].cancel_seen.wait(), timeout=0.5)
+        await asyncio.wait_for(holder["session"].cancel_seen.wait(), timeout=MUST_SETTLE_SECONDS)
         return "workflow-returned"
 
     with pytest.raises(RuntimeError, match="technical workflow cleanup failed"):
@@ -678,5 +690,5 @@ async def test_owned_tracer_closes_when_cleanup_fails(
     assert tracer.closed is True
     pending = holder["context"].pending_cleanup_tasks
     holder["session"].release.set()
-    await asyncio.wait_for(asyncio.gather(*pending, return_exceptions=True), timeout=0.5)
+    await asyncio.wait_for(asyncio.gather(*pending, return_exceptions=True), timeout=MUST_SETTLE_SECONDS)
     assert order.index("tracer-close") < order.index("session-finished")


### PR DESCRIPTION
## What this fixes

Seven tests asserted that an operation finished inside a wall-clock budget **that the code under test is allowed to exceed**. They pass on an idle machine and go red on a loaded one — a report about the runner, not about the code. One of them (`test (3.14)` on #83) did exactly that yesterday while 3.10–3.13 stayed green.

The criterion used to decide what to touch: *is the test's deadline bigger than the worst case the implementation permits itself?*

| test | deadline | what the implementation permits / costs | ratio |
|---|---|---|---|
| `test_runner_kills_on_timeout_without_raising` | 2.0s | `0.2` hook timeout + `PROCESS_TERM_GRACE_SECONDS` + 2×`PROCESS_KILL_GRACE_SECONDS` = **4.25s** | **0.47×** |
| `test_process_timeout_covers_subprocess_spawn` | 1.0s | same cleanup path, **4.05s** | **0.25×** |
| `test_process_cancellation_during_spawn_is_bounded` | 1.0s | same cleanup path, **4.05s** | **0.25×** |
| `test_runner_timeout_kills_descendant_process_group` | 0.2s hook timeout | Python interpreter startup, measured **0.04–0.11s idle, 0.35s loaded** | **0.6× loaded** |
| `test_response_header_timeout_retries_the_same_request` | 1ms first-event budget | attempt 2's stream, measured **0.36ms under 6× load** | 2.8× |
| `test_tracer_slow_write_does_not_block_log_step` | `elapsed < 0.05s` | blocking alternative 0.15s | 3× |
| `test_autosave_coalesces_..._without_blocking_emit` | `elapsed < 0.05s` | blocking alternative 0.2s | 4× |

## What changed

**Deadlines are now derived from the constants they bound.** `tests/test_hooks.py` and `tests/test_local_env_processes.py` compute their guards from `PROCESS_TERM_GRACE_SECONDS` / `PROCESS_KILL_GRACE_SECONDS`, so changing a grace cannot silently re-create the mismatch. The hook's command went `sleep 5` → `sleep 60` so a hook that was *waited out* rather than killed still trips the guard.

**The descendant sentinel no longer launches an interpreter.** `_delayed_sentinel_command` marks its start with a shell redirection instead of `python -c`: measured **6.5ms** worst of 15 runs, against the same 0.2s budget. Verified that the command still writes *both* marks when nobody kills it, so `assert not finished.exists()` remains a real assertion.

**The Responses retry test stops racing itself.** Its first-event budget was spent by the stalled attempt *and* re-imposed on the successful one, which had to create its stream and yield an event inside whatever was left. Budget is now 0.25s, and the retry backoff is patched out the way the four neighbouring tests in that file already do — which also removes 1.1s of real sleeping (`0.25s` call, was `1.15s`). The stalled attempt now hangs on an `Event` rather than `asyncio.sleep`, because patching `retry.asyncio.sleep` mutates the one shared `asyncio` module.

**Two stopwatch assertions became clock-free ones.** They asked whether a hand-off was *fast*; they now ask whether it *happened* — the sink is parked on an event nobody has released, so a caller that waited for it could not have reached the assertion. Both were mutation-checked: making `log_step` and `emit` block does make them fail.

## What was deliberately left alone

`test_stubborn_timed_out_tool_cannot_write_after_execute_returns` and `test_stubborn_environment_abort_is_bounded_and_exposed` keep `assert elapsed < 0.2`: measured at 0.02–0.05s under 5× load, and the only constant that could surprise them (`TOOL_EXECUTION_TIMEOUT_GRACE`) is one they patch themselves.

`test_registry_abort_bounds_unfinished_spawn_handoff` keeps its 0.1s deadline: it patches `PROCESS_KILL_GRACE_SECONDS` to 0.01 first, so its deadline already sits 10× above what the implementation permits.

## Verification

- `2498 passed, 2 skipped` — unchanged from `main`.
- Mutation check on the two rewritten assertions: both fail when the property breaks.
- import-linter: 4 contracts kept. `check_interface_width`, `check_added_files`, `check_secret_history`, `check_conventional_title`: all pass.
- No test lost an assertion.

---

## Second commit: three more, this time reproduced

The first commit was found by reading budgets against constants. To catch what
that misses, the full suite was then run three times on a machine held busy.
**Every round went red, and differently each time:**

| round | failed |
|---|---|
| 1 | `test_real_http_stream_replays_reasoning_function_call_and_output`<br>`test_run_workflow_quiesces_late_session_before_manifest_and_tracer_close` |
| 2 | `test_real_http_stream_replays_reasoning_function_call_and_output` |
| 3 | `test_real_http_stream_replays_reasoning_function_call_and_output`<br>`test_bounded_shutdown_preserves_result_despite_cancellation_resistant_task` |

**The HTTP-contract test failed 3/3**, with `Responses round deadline exceeded after 5s` — the *round* timeout, not the `first_event_timeout` it had been filed under. These tests assert what the client puts on the wire and what it makes of the reply, never how fast a local server answers, so all three timeouts are hang guards and now sit far above the round trip.

**The bounded-shutdown test gave a subprocess one second** to start an interpreter and import `opencollab`. Measured here: **0.37–0.52s idle**, and the interpreter alone costs 0.35s under load. That budget was bounding Python's startup, not the shutdown under test.

**`test_workflow_runtime_cleanup.py` had the same defect in fifteen places** — deadlines on cleanup that must *succeed*, each bounding pure event-loop bookkeeping with no intrinsic duration. They are one named constant now.

Two waits in that file were deliberately **left alone**: the quiesce that then cancels, and the `cleanup_timeout` that then aborts the environment. The cleanup path is *supposed* to spend those in full before escalating, so raising them only makes the suite sit still — measured at a flat 10s each when they were raised by mistake, which is how they were identified.

Suite unchanged: `2498 passed, 2 skipped`.
