### PR TITLE
fix: tighten workflow budgets and test-result reporting

### DIFF
--- a/opencollab/adapters/llm/responses_provider.py
+++ b/opencollab/adapters/llm/responses_provider.py
@@ -43,6 +43,7 @@ from opencollab.adapters.llm.tool_contracts import (
 )
 from opencollab.adapters.llm.types import (
     LLMResponse,
+    ModelCapabilities,
     model_capabilities,
     rescue_empty_turn,
     to_plain_data,
@@ -129,15 +130,18 @@ def _forced_text_tool(
     model: str,
     converted_tools: list[dict[str, Any]],
     tool_choice: Any,
+    *,
+    capabilities: ModelCapabilities | None = None,
 ) -> ForcedTextTool | None:
     """Bind one named tool through ``text.format`` when forcing is unsupported."""
     choice = _responses_tool_choice(tool_choice, converted_tools)
+    capabilities = capabilities or model_capabilities(model)
     try:
         return forced_text_tool(
             converted_tools,
             choice,
-            supports_forced_tool_choice=(model_capabilities(model).supports_forced_tool_choice),
-            supports_json_schema=model_capabilities(model).supports_responses_json_schema,
+            supports_forced_tool_choice=capabilities.supports_forced_tool_choice,
+            supports_json_schema=capabilities.supports_responses_json_schema,
         )
     except ValueError as exc:
         raise ResponsesProtocolError(str(exc)) from exc
@@ -159,13 +163,13 @@ def _build_request_kwargs(
     instructions, input_items = _messages_to_input(messages)
     if not input_items:
         raise ResponsesProtocolError("Responses request has no input items")
+    capabilities = model_capabilities(model)
     kwargs: dict[str, Any] = {
         "model": model,
         "input": input_items,
         "store": False,
-        "stream": model_capabilities(model).supports_responses_streaming,
+        "stream": capabilities.supports_responses_streaming,
     }
-    capabilities = model_capabilities(model)
     if capabilities.supports_responses_reasoning:
         kwargs["include"] = ["reasoning.encrypted_content"]
     if capabilities.supports_responses_sampling:
@@ -181,12 +185,17 @@ def _build_request_kwargs(
         raise ResponsesProtocolError(f"model {model!r} does not support function tools")
     choice = _responses_tool_choice(tool_choice, converted_tools)
     if converted_tools:
-        text_tool = _forced_text_tool(model, converted_tools, tool_choice)
+        text_tool = _forced_text_tool(
+            model,
+            converted_tools,
+            tool_choice,
+            capabilities=capabilities,
+        )
         if text_tool is not None:
             kwargs["text"] = forced_text_format(text_tool)
         else:
             kwargs["tools"] = converted_tools
-            if not model_capabilities(model).supports_forced_tool_choice and choice is not None and choice != "auto":
+            if not capabilities.supports_forced_tool_choice and choice is not None and choice != "auto":
                 choice = "auto"
             kwargs["tool_choice"] = choice
     if top_p is not None:

--- a/opencollab/adapters/llm/types.py
+++ b/opencollab/adapters/llm/types.py
@@ -203,6 +203,11 @@ _EXACT_MODEL_CAPABILITIES: dict[str, ModelCapabilities] = {
     ),
 }
 
+# These provider identifiers describe one bounded model spelling, rather than
+# an open-ended family.  Unknown gateway aliases must not inherit capabilities
+# that have not been verified for them.
+_BOUNDED_CAPABILITY_FAMILIES = frozenset({"k3", "kimi-for-coding"})
+
 # Conservative default output reservation when a model is recognised.
 DEFAULT_MAX_OUTPUT_TOKENS = DEFAULT_MAX_TOKENS_PER_STEP
 
@@ -213,6 +218,8 @@ def model_matches_family(model: str | None, family: str) -> bool:
         return False
     normalized = model.strip().lower().rsplit("/", 1)[-1]
     normalized_family = family.strip().lower()
+    if normalized_family in _BOUNDED_CAPABILITY_FAMILIES:
+        return _canonical_model_id(normalized) == normalized_family
     return normalized == normalized_family or normalized.startswith(
         f"{normalized_family}-"
     )

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -282,6 +282,10 @@ class RunTestsTool(Tool):
             combined,
             runner=runner,
             target=target,
+            output_truncated=bool(
+                getattr(result, "stdout_truncated", False)
+                or getattr(result, "stderr_truncated", False)
+            ),
         )
         if target:
             if green:
@@ -510,8 +514,6 @@ def _pytest_missing(returncode: int, output: str) -> bool:
     """Whether the run failed because pytest itself is absent."""
     if returncode == 0:
         return False
-    if returncode == 127:
-        return True
     lines = [line.strip() for line in output.splitlines() if line.strip()]
     return len(lines) == 1 and _PYTEST_MISSING_RE.fullmatch(lines[0]) is not None
 
@@ -569,6 +571,13 @@ def _target_has_pass_proof(target: str, passed_lines: list[str]) -> bool:
     for line in passed_lines:
         node_id = line.removeprefix("PASSED ").strip()
         candidate = node_id.removeprefix("./")
+        if has_selector and not target_path:
+            candidate_selector = candidate.partition("::")[2]
+            if candidate_selector == _selector or candidate_selector.startswith(
+                _selector + "["
+            ):
+                return True
+            continue
         if candidate == normalized or candidate.startswith(normalized + "::"):
             return True
         if has_selector and candidate.startswith(normalized + "["):
@@ -589,6 +598,7 @@ def _is_green(
     *,
     runner: str = DEFAULT_RUNNER,
     target: str = "",
+    output_truncated: bool = False,
 ) -> bool:
     """The GREEN verdict's positive-proof specification.
 
@@ -599,6 +609,10 @@ def _is_green(
     pass proof; go: parsed ``PASS`` lines); a runner with no parser-backed
     adapter cannot authorize GREEN and returns ``False`` by construction.
     """
+    if output_truncated:
+        # A bounded capture may have dropped the only pass/failure evidence;
+        # a retained summary cannot certify the complete run.
+        return False
     summaries = _summary_lines(output)
     if _is_pytest_runner(runner) and len(summaries) != 1:
         # One tool invocation represents one pytest session. Multiple result

--- a/opencollab/application/workflow.py
+++ b/opencollab/application/workflow.py
@@ -158,6 +158,10 @@ class WorkflowContext(
         self.budget = WorkflowBudget(budget_total, self._sessions)
         self._budget_lock = asyncio.Lock()
         self._budget_waiters = 0
+        # ``over_budget_ok`` is a one-shot escape for a forced final write.
+        # Claiming it under the budget lock prevents concurrent callers from
+        # turning the escape hatch into an unbounded tail.
+        self._over_budget_escape_used = False
         self._active_budget_lease: contextvars.ContextVar[_BudgetLease | None] = (
             contextvars.ContextVar("workflow_budget_lease", default=None)
         )
@@ -772,6 +776,22 @@ class WorkflowContext(
                         f"of {self.budget.total}"
                     )
                 if over_budget_ok and available <= 0:
+                    if self._over_budget_escape_used:
+                        self._trace_budget_decision(
+                            "budget_refusal",
+                            cap=cap,
+                            remaining=remaining,
+                            label=label,
+                            over_budget_ok=True,
+                        )
+                        raise WorkflowBudgetExceeded(
+                            f"workflow budget exhausted: spent {self.budget.spent()} "
+                            f"of {self.budget.total}; the one over-budget escape "
+                            "has already been used"
+                        )
+                    # Claim before tracing/building so failures cannot turn the
+                    # one-shot escape into a retry loop.
+                    self._over_budget_escape_used = True
                     self._trace_budget_decision(
                         "budget_escape",
                         cap=cap,

--- a/opencollab/bootstrap/programmatic.py
+++ b/opencollab/bootstrap/programmatic.py
@@ -141,8 +141,13 @@ def attach_container(
     """Attach to a caller-owned container workspace."""
     container_id = _trimmed(container_id, "container_id")
     workspace = _trimmed(workspace, "workspace")
-    if not posixpath.isabs(workspace) or posixpath.normpath(workspace) != workspace:
-        raise ValueError("workspace must be a normalized absolute container path")
+    if (
+        workspace.startswith("//")
+        or not posixpath.isabs(workspace)
+        or posixpath.normpath(workspace) != workspace
+        or workspace == "/"
+    ):
+        raise ValueError("workspace must be a normalized absolute non-root container path")
     if isinstance(timeout_returncode, bool) or not isinstance(timeout_returncode, int):
         raise ValueError("timeout_returncode must be an integer")
     return DockerWorkspaceEnvironment(

--- a/tests/test_llm_provider_requests.py
+++ b/tests/test_llm_provider_requests.py
@@ -12,7 +12,7 @@ from opencollab.adapters.llm.anthropic_provider import _build_request_kwargs as 
 from opencollab.adapters.llm.anthropic_provider import convert_to_anthropic_messages
 from opencollab.adapters.llm.openai_provider import _build_request_kwargs as build_openai_kwargs
 from opencollab.adapters.llm.openai_provider import _parse_response as parse_openai_response
-from opencollab.adapters.llm.types import model_capabilities
+from opencollab.adapters.llm.types import model_capabilities, model_matches_family
 
 # ---------------------------------------------------------------------------
 # Thinking passthrough — OpenAI-compatible extra_body (DashScope compatible mode)
@@ -229,6 +229,18 @@ def test_known_model_capabilities_reject_prefixed_near_misses(model):
 
     assert capabilities.context_window is None
     assert capabilities.supports_forced_tool_choice is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gateway/kimi-for-coding-20260807",
+        "gateway/kimi-for-coding-2026-8-07",
+        "gateway/kimi-for-coding-2026-08-07-preview",
+    ],
+)
+def test_model_family_matching_rejects_unbounded_kimi_aliases(model):
+    assert not model_matches_family(model, "kimi-for-coding")
 
 
 def test_unknown_model_capabilities_use_neutral_defaults():

--- a/tests/test_run_tests_runner_selection.py
+++ b/tests/test_run_tests_runner_selection.py
@@ -114,6 +114,34 @@ def test_run_tests_falls_back_to_native_runner_when_pytest_missing():
     assert "without an executed-target proof parser" in result
 
 
+def test_run_tests_does_not_treat_generic_127_as_missing_pytest():
+    """A real pytest failure with status 127 must not switch runners."""
+    env = ScriptedEnv(
+        [
+            ("python -m pytest", 127, "pytest runtime failed"),
+            ("test -f go.mod", 0, ""),
+            (
+                "go test -json",
+                0,
+                '{"Action":"pass","Package":"module/internal/server",'
+                '"Test":"TestEvaluate"}',
+            ),
+        ]
+    )
+    runtime = runtime_for(env)
+
+    result = run(
+        RunTestsTool().execute_with_runtime(
+            {"target": "internal/server"},
+            runtime,
+        )
+    )
+
+    assert "Verdict: GREEN" not in result
+    assert len(env.exec_calls) == 1
+    assert not any(command.startswith("test -f") for command, _ in env.exec_calls)
+
+
 def test_run_tests_does_not_fallback_from_a_green_pytest_message():
     env = FakeEnv(
         stdout=PLAIN_PASS_OUTPUT + "\nNo module named pytest\n",
@@ -130,6 +158,15 @@ def test_run_tests_does_not_fallback_from_a_green_pytest_message():
 
     assert "Verdict: GREEN" in result
     assert len(env.exec_calls) == 1
+
+
+def test_root_level_pytest_selector_accepts_matching_node_from_any_file():
+    from opencollab.adapters.tools.run_tests import _is_green
+
+    output = "PASSED tests/test_x.py::test_one\n1 passed in 0.01s\n"
+
+    assert _is_green(0, output, target="::test_one")
+    assert not _is_green(0, output, target="::test_other")
 
 
 def test_run_tests_does_not_fallback_from_failed_test_output_text():

--- a/tests/test_run_tests_tool.py
+++ b/tests/test_run_tests_tool.py
@@ -55,7 +55,7 @@ def test_run_tests_accepts_plain_pytest_q_summary():
     assert "Verdict: GREEN" in result
 
 
-def test_run_tests_accepts_pass_proof_from_retained_capture_tail():
+def test_run_tests_rejects_pass_proof_from_truncated_capture():
     class TruncatedOutputEnv(FakeEnv):
         async def exec_cmd(self, cmd: str, timeout: float = 120.0):
             self.exec_calls.append((cmd, timeout))
@@ -79,7 +79,7 @@ def test_run_tests_accepts_pass_proof_from_retained_capture_tail():
     )
 
     assert "passed=1" in result
-    assert "Verdict: GREEN" in result
+    assert "Verdict: RED" in result
 
 
 def test_run_tests_directory_target_requires_a_descendant_pass():

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -245,6 +245,8 @@ def test_attach_container_validates_non_owning_workspace() -> None:
         attach_container(container_id="container-1", workspace="/tmp/../testbed")
     with pytest.raises(ValueError, match="container_id"):
         attach_container(container_id=" container-1 ", workspace="/testbed")
+    with pytest.raises(ValueError, match="non-root"):
+        attach_container(container_id="container-1", workspace="/")
 
 
 def test_builtin_tools_are_fresh_ordered_and_headless_safe() -> None:

--- a/tests/test_workflow_context_budget.py
+++ b/tests/test_workflow_context_budget.py
@@ -234,6 +234,48 @@ async def test_pending_cleanup_wait_covers_unreserved_over_budget_lease():
     timed_out.release_cancel.set()
     await waiter
 
+
+@pytest.mark.asyncio
+async def test_over_budget_escape_is_single_use():
+    """Only one exhausted-pool call may use the forced-write escape."""
+    factory = FakeFactory(
+        [FakeSession(reply="forced"), FakeSession(reply="must not run")]
+    )
+    ctx = WorkflowContext(factory, budget_total=0)
+
+    assert await ctx.agent("forced write", over_budget_ok=True) == "forced"
+    with pytest.raises(WorkflowBudgetExceeded):
+        await ctx.agent("second forced write", over_budget_ok=True)
+
+    assert len(factory.builds) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_over_budget_escapes_allow_only_one_call():
+    """The one-shot escape is claimed atomically when calls race."""
+    release = asyncio.Event()
+    factory = FakeFactory([FakeSession(reply="forced", gate=release)])
+    ctx = WorkflowContext(factory, budget_total=0, max_concurrency=2)
+
+    tasks = [
+        asyncio.create_task(ctx.agent(f"forced-{index}", over_budget_ok=True))
+        for index in range(2)
+    ]
+    try:
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if len(factory.builds) == 1:
+                break
+        release.set()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+    finally:
+        release.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert sum(isinstance(result, WorkflowBudgetExceeded) for result in results) == 1
+    assert sum(isinstance(result, str) and result == "forced" for result in results) == 1
+
+
 @pytest.mark.asyncio
 async def test_timeout_keeps_concurrency_slot_until_cancel_cleanup_finishes():
     active = 0


### PR DESCRIPTION
## Summary

This revision narrows PR #85 to a small set of product-facing correctness fixes raised in review. The previous broad shell/path/Git hardening has been removed. This PR does not assume that an RL agent or an adversarial model will attack its own runtime, and it does not try to turn the trusted low-level environment API into a general sandbox.

## What changed

- **Bootstrap / public API** (`opencollab/bootstrap/programmatic.py`): `attach_container` rejects `/` (and non-canonical `//...`) as a container workspace while retaining the existing normalized absolute-path contract.
- **Application** (`opencollab/application/workflow.py`): the `over_budget_ok` escape is claimed under the budget lock and can be consumed only once, including under concurrent requests.
- **Adapters / LLM** (`opencollab/adapters/llm/types.py`, `responses_provider.py`): capability-family matching uses canonical bounded identifiers, and a single capability record is reused while building a Responses request.
- **Adapters / test runner** (`opencollab/adapters/tools/run_tests.py`): truncated stdout/stderr can never certify `GREEN`; a generic exit code 127 is not treated as “pytest missing”; and root-level pytest selectors are matched against the reported node IDs.

## Clean Architecture scope

| Layer | Status |
| --- | --- |
| Domain | Unchanged |
| Application | Workflow budget lease semantics |
| Adapters | LLM capability handling and `run_tests` evidence handling |
| Frameworks & Drivers / Bootstrap | Public `attach_container` workspace validation |

The Python 3.10 `-I` anti-shadowing proposal from the review is intentionally not included: it is a model/workspace attack defense and can also break source-checkout test runs. Likewise, shell parser/blacklist changes, Git metadata and hardlink/TOCTOU checks, PATH ownership checks, dynamic-evaluator/container-hook defenses, Go path hardening, and other RL/model-adversarial changes are explicitly out of scope and are not present in this revision.

## Verification

- Focused product suites: **134 passed**.
- Full feasible local suite: **2586 passed, 7 failed, 1 skipped**. The seven failures reproduce unchanged on a clean `origin/main` checkout in `tests/test_container_worktree_env.py` (local Docker-shim write tests); this revision changes no Docker/container implementation.
- `python -m ruff check` on all changed Python files: passed.
- `python -m compileall -q opencollab tests`: passed.
- `git diff --check`: passed.

No real Docker daemon, remote execution, GPU, paid API, or local server was used.

The earlier NEW-017..NEW-044 security-hardening claims are withdrawn from this PR; their code and tests are not part of the current head.
