### PR TITLE
fix(application): restore session state after direct cancellation

### DIFF
--- a/opencollab/application/session.py
+++ b/opencollab/application/session.py
@@ -290,6 +290,17 @@ class Session:
             primary_error: BaseException | None = None
             try:
                 return await self.runner.run_loop(cancel_event)
+            except asyncio.CancelledError as exc:
+                # A public caller may cancel the task directly instead of
+                # setting ``cancel_event``.  The runner intentionally lets that
+                # cancellation propagate, but leaving an in-flight phase in
+                # place would make the facade permanently reject the next user
+                # turn as busy.  Record the same terminal state used by the
+                # scheduler's out-of-band cancellation path before re-raising.
+                primary_error = exc
+                if not self.state.phase.is_terminal():
+                    self.state.cancel()
+                raise
             except BaseException as exc:
                 primary_error = exc
                 raise

--- a/tests/test_session_characterization.py
+++ b/tests/test_session_characterization.py
@@ -239,6 +239,39 @@ async def test_session_rejects_user_message_while_provider_turn_is_active():
         await run_task
 
 
+@pytest.mark.asyncio
+async def test_direct_run_loop_cancellation_leaves_session_reusable():
+    class GatedLLM:
+        def __init__(self):
+            self.calls = 0
+            self.started = asyncio.Event()
+
+        async def complete(self, messages, tools=None, temperature=0.0):
+            del messages, tools, temperature
+            self.calls += 1
+            if self.calls == 1:
+                self.started.set()
+                await asyncio.Event().wait()
+            return llm_response(content="fresh answer")
+
+    llm = GatedLLM()
+    session = Session(agent=FakeAgent(), llm=llm)
+    cancelled = asyncio.create_task(session.run_loop())
+    await asyncio.wait_for(llm.started.wait(), timeout=0.5)
+
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(cancelled, timeout=0.5)
+
+    assert session.state.phase is SessionPhase.STOPPED
+    assert session.state.terminal_reason == "cancelled"
+
+    await session.add_user_message("retry after cancellation")
+    assert await asyncio.wait_for(session.run_loop(), timeout=0.5) == "fresh answer"
+    assert session.state.phase is SessionPhase.DONE
+    assert llm.calls == 2
+
+
 def test_session_rejects_user_message_for_a_suspended_turn():
     session = Session(agent=FakeAgent(), llm=FakeLLMClient())
     session.phase = SessionPhase.AWAITING_EVENTS


### PR DESCRIPTION
## Summary

Fix a P2 (Medium) application-lifecycle bug in the public `Session.run_loop()` facade. Cancelling a caller-owned run task could leave the session in `CALLING_LLM` with no terminal reason, so every subsequent turn was rejected as busy.

## Root cause

The runner correctly propagated `asyncio.CancelledError`, but the facade only checkpointed terminal state in its `finally` block. A direct caller cancellation therefore never crossed the out-of-band cancellation transition.

## Change

When the facade observes direct task cancellation, it marks any non-terminal session `STOPPED` with reason `cancelled`, then re-raises the original cancellation. Existing scheduler cancellation and cleanup ownership are unchanged.

## Clean Architecture scope

- Domain: unchanged.
- Application: `opencollab/application/session.py` cancellation/state transition.
- Adapters and Bootstrap: unchanged.
- Tests: direct-cancellation/reusability regression.

The faulty behavior predates this PR and is not claimed as a regression introduced by PR #85.

## Verification

- 111 focused session/state/autosave tests passed.
- Ruff and `git diff --check` passed.
- No remote, paid, GPU, Docker, or sandbox-policy behavior is changed.

