### PR TITLE
fix(sdk): forward solo agent LLM configuration

### DIFF
--- a/opencollab/bootstrap/programmatic.py
+++ b/opencollab/bootstrap/programmatic.py
@@ -354,13 +354,21 @@ async def run_agent(
         tools=list(resolved_tools),
         model=config["model"],
         provider=config["provider"],
+        wire_protocol=config.get("wire_protocol", "chat_completions"),
         api_key=config.get("api_key"),
         base_url=config.get("base_url"),
+        context_window=config.get("context_window"),
         max_tokens_per_step=config.get("max_output_tokens", 8_192),
         temperature=config.get("temperature", 0.2),
         top_p=config.get("top_p"),
         thinking=config.get("thinking", False),
         thinking_params=resolve_thinking_params(config.get("thinking_params")),
+        reasoning_effort=config.get("reasoning_effort"),
+        llm_connect_timeout=config.get("llm_connect_timeout", 30.0),
+        llm_first_event_timeout=config.get("llm_first_event_timeout", 180.0),
+        llm_stream_idle_timeout=config.get("llm_stream_idle_timeout", 180.0),
+        llm_max_retries=config.get("llm_max_retries", 3),
+        provider_error_time_budget=config.get("provider_error_time_budget", 0.0),
     )
     _claim_artifacts(artifacts)
     owned_environment = environment is None

--- a/tests/test_sdk_runtime.py
+++ b/tests/test_sdk_runtime.py
@@ -104,6 +104,58 @@ async def test_client_resolves_config_once_and_delegates_plain_arguments(
     assert captured["max_steps"] == 4
 
 
+async def test_agent_forwards_all_llm_configuration_to_runtime_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured = {}
+
+    async def fake_runtime(**kwargs):
+        captured["agent"] = kwargs["agent"]
+        raise RuntimeError("stop after composition")
+
+    monkeypatch.setattr(programmatic, "_run_agent", fake_runtime)
+    client = OpenCollab(
+        tmp_path,
+        config={
+            "model": "unit-model",
+            "provider": "openai",
+            "wire_protocol": "responses",
+            "context_window": 12_345,
+            "max_output_tokens": 777,
+            "temperature": 0.4,
+            "top_p": 0.6,
+            "thinking": True,
+            "thinking_params": {"budget_tokens": 256},
+            "reasoning_effort": "high",
+            "llm_max_retries": 0,
+            "llm_connect_timeout": 1.25,
+            "llm_first_event_timeout": 2.5,
+            "llm_stream_idle_timeout": 3.75,
+            "provider_error_time_budget": 9.0,
+        },
+        environment=object(),
+    )
+
+    with pytest.raises(RuntimeError, match="stop after composition"):
+        await client.agent("compose only", tools=(), trace=False)
+
+    agent = captured["agent"]
+    assert agent.wire_protocol == "responses"
+    assert agent.context_window == 12_345
+    assert agent.max_tokens_per_step == 777
+    assert agent.temperature == 0.4
+    assert agent.top_p == 0.6
+    assert agent.thinking is True
+    assert agent.thinking_params == {"budget_tokens": 256}
+    assert agent.reasoning_effort == "high"
+    assert agent.llm_max_retries == 0
+    assert agent.llm_connect_timeout == 1.25
+    assert agent.llm_first_event_timeout == 2.5
+    assert agent.llm_stream_idle_timeout == 3.75
+    assert agent.provider_error_time_budget == 9.0
+
+
 def _completed_agent_metrics() -> dict[str, object]:
     return {
         "steps": 1,


### PR DESCRIPTION
## Summary

Fix a P2 (Medium) public SDK configuration contract bug: the solo `OpenCollab.agent()` path silently dropped several validated LLM settings while the workflow/team path honored them.

## Root cause

The Bootstrap composition root created the domain `Agent` with only the original subset of configuration fields. A caller could request a Responses wire protocol, reasoning effort, context window, retry policy, or timeout values and receive default behavior without an error.

## Change

Forward the validated configuration through `run_agent()` for:

- `wire_protocol`, `context_window`, and `reasoning_effort`
- `llm_max_retries`
- `llm_connect_timeout`, `llm_first_event_timeout`, and `llm_stream_idle_timeout`
- `provider_error_time_budget`

Existing model, provider, key, URL, token, sampling, thinking, and thinking-parameter forwarding is preserved.

## Clean Architecture scope

- Domain: unchanged.
- Application: unchanged.
- Adapters: unchanged.
- Bootstrap: `opencollab/bootstrap/programmatic.py` composition/wiring.
- Tests: SDK runtime forwarding regression.

This is a pre-existing wiring omission in the public solo API, not a PR #85 security change and not an RL threat-model change.

## Verification

- 114 SDK/config tests passed.
- Ruff and `git diff --check` passed.
- No remote, paid, GPU, Docker, or sandbox-policy behavior is changed.

