### PR TITLE
fix(llm): include tools in Responses usage estimates

### DIFF
--- a/opencollab/adapters/llm/responses_provider.py
+++ b/opencollab/adapters/llm/responses_provider.py
@@ -526,6 +526,7 @@ def _parse_stream(
     messages: list[dict[str, Any]],
     expected_model: str | None = None,
     forced_text_tool: ForcedTextTool | None = None,
+    tools: list[dict[str, Any]] | None = None,
 ) -> LLMResponse:
     actual_model, finish_reason = _validate_terminal_response(
         state.completed_response,
@@ -588,6 +589,7 @@ def _parse_stream(
             messages,
             content,
             tool_calls,
+            tools,
         ),
         finish_reason=("tool_calls" if tool_calls and finish_reason == "stop" else finish_reason),
         reasoning=reasoning,
@@ -602,6 +604,7 @@ def parse_responses_response(
     *,
     expected_model: str,
     forced_text_tool: ForcedTextTool | None = None,
+    tools: list[dict[str, Any]] | None = None,
 ) -> LLMResponse:
     """Parse one completed non-streaming Responses object."""
     _validate_terminal_response(response, expected_model)
@@ -612,7 +615,13 @@ def parse_responses_response(
     for item in output:
         event = type("OutputItemEvent", (), {"item": item, "output_index": len(state.output_items)})()
         _accept_output_item(event, state)
-    return _parse_stream(state, messages, expected_model, forced_text_tool)
+    return _parse_stream(
+        state,
+        messages,
+        expected_model,
+        forced_text_tool,
+        tools,
+    )
 
 
 async def complete_responses(
@@ -662,6 +671,7 @@ async def complete_responses(
                 messages,
                 expected_model=model,
                 forced_text_tool=forced_text_tool,
+                tools=converted_tools,
             )
 
         state = await _create_and_consume_stream(
@@ -671,7 +681,13 @@ async def complete_responses(
             stream_idle_timeout,
             model,
         )
-        return _parse_stream(state, messages, model, forced_text_tool)
+        return _parse_stream(
+            state,
+            messages,
+            model,
+            forced_text_tool,
+            converted_tools,
+        )
 
     if provider_error_time_budget is not None:
 

--- a/opencollab/adapters/llm/responses_usage.py
+++ b/opencollab/adapters/llm/responses_usage.py
@@ -34,8 +34,15 @@ def parse_responses_usage(
     messages: list[dict[str, Any]],
     content: str | None,
     tool_calls: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
 ) -> Usage:
-    """Build normalized usage while retaining provider-native counters."""
+    """Build normalized usage while retaining provider-native counters.
+
+    ``input_tokens`` is estimated when a Responses endpoint omits its usage
+    counters.  The request's registered tool schemas are part of that input,
+    so callers must pass the provider-shaped tool list through to the
+    estimator as well as the conversational messages.
+    """
     raw = usage_to_dict(getattr(response, "usage", None))
     input_tokens = _positive_usage_int(raw, "input_tokens")
     output_tokens = _positive_usage_int(raw, "output_tokens")
@@ -46,7 +53,7 @@ def parse_responses_usage(
         cache_creation_tokens = _optional_usage_int(raw, "cache_write_tokens")
     estimated = input_tokens is None or output_tokens is None
     if input_tokens is None:
-        input_tokens = estimate_messages_tokens(messages)
+        input_tokens = estimate_messages_tokens(messages, tools)
     if output_tokens is None:
         text = content or ""
         for call in tool_calls:

--- a/tests/test_responses_non_streaming.py
+++ b/tests/test_responses_non_streaming.py
@@ -1,12 +1,15 @@
 """Non-streaming response parsing tests for the Responses adapter."""
 
 import pytest
-from responses_provider_test_support import completed_response, message_item
+from responses_provider_test_support import completed_response, message_item, ns
 
 from opencollab.adapters.llm.responses_provider import (
     ResponsesProtocolError,
+    _responses_tools,
+    complete_responses,
     parse_responses_response,
 )
+from opencollab.adapters.llm.types import estimate_messages_tokens
 
 
 def test_non_streaming_text_and_missing_usage_are_supported():
@@ -28,6 +31,47 @@ def test_non_streaming_text_and_missing_usage_are_supported():
     assert estimated.usage.estimated is True
     assert estimated.usage.cache_read_tokens is None
     assert estimated.usage.reasoning_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_estimate_includes_responses_tool_schemas():
+    messages = [{"role": "user", "content": "use the tool"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup_record",
+                "description": "d" * 1_200,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"key": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    response = completed_response(output=[message_item("done")])
+    response.usage = None
+    captured: dict[str, object] = {}
+
+    class Responses:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return response
+
+    result = await complete_responses(
+        ns(responses=Responses()),
+        "gpt-fake",
+        messages,
+        tools,
+        1.0,
+        0,
+        stream=False,
+    )
+
+    converted_tools = _responses_tools(tools)
+    assert captured["tools"] == converted_tools
+    assert result.usage.input_tokens == estimate_messages_tokens(messages, converted_tools)
+    assert result.usage.input_tokens > estimate_messages_tokens(messages)
 
 
 def test_non_streaming_usage_accepts_top_level_cache_write_fallback():


### PR DESCRIPTION
## Summary

Fix a P2 (Medium) token-accounting bug in the OpenAI Responses adapter. When a Responses endpoint omitted usage counters, the fallback estimate ignored the request's tool schemas.

## Impact

Tool-heavy requests could be charged fewer input tokens than they actually contain. That can make context-window and workflow-budget decisions inconsistent with the request sent to the provider.

## Change

Thread the provider-shaped Responses tool list through streaming and non-streaming response parsing, and include it in the fallback input-token estimate. Provider-reported usage remains authoritative when present.

## Clean Architecture scope

- Domain: unchanged.
- Application: unchanged.
- Adapters: `opencollab/adapters/llm/responses_usage.py` and `responses_provider.py`.
- Bootstrap: unchanged.
- Tests: non-streaming missing-usage regression plus existing Responses parser coverage.

The omission was introduced with the Responses transport on 2026-08-12 (before this fix); it is a provider-accounting correctness issue, not a sandbox or RL defense.

## Verification

- 41 focused Responses tests passed.
- Ruff and `git diff --check` passed.
- No real provider, remote, paid, GPU, or Docker execution was used.

