### PR TITLE
fix(workflow): validate per-call token budgets

### DIFF
--- a/opencollab/application/workflow.py
+++ b/opencollab/application/workflow.py
@@ -100,6 +100,13 @@ def _positive_concurrency(value: object, name: str) -> int:
     return parsed
 
 
+def _positive_budget(value: object, name: str = "budget") -> int | None:
+    """Normalize an optional per-call budget to a strictly positive integer."""
+    if value is None:
+        return None
+    return _positive_concurrency(value, name)
+
+
 class WorkflowContext(
     WorkflowAgentsMixin,
     WorkflowStructuredMixin,
@@ -748,6 +755,7 @@ class WorkflowContext(
         ``label`` is carried for the trace record only — it names the caller in
         ``budget_refusal`` / ``budget_escape`` and changes no allocation.
         """
+        cap = _positive_budget(cap)
         self._budget_waiters += 1
         try:
             # Let sibling tasks launched by one gather register as contenders

--- a/tests/test_workflow_context.py
+++ b/tests/test_workflow_context.py
@@ -53,6 +53,22 @@ async def test_agent_returns_final_text_and_seeds_prompt():
     assert session.prompt == "solve it"
     assert factory.builds[0]["prompt"] == "solve it"
 
+
+@pytest.mark.parametrize(
+    "budget",
+    [0, -1, 1.5, True, False, "2", float("nan"), float("inf")],
+)
+@pytest.mark.asyncio
+async def test_agent_rejects_invalid_per_call_budget_before_building_session(budget):
+    factory = FakeFactory([])
+    ctx = WorkflowContext(factory)
+
+    with pytest.raises(ValueError, match="budget must be a positive integer"):
+        await ctx.agent("must not start", budget=budget)
+
+    assert factory.builds == []
+
+
 @pytest.mark.parametrize("timeout", [0, -1, float("nan"), True, "bad"])
 @pytest.mark.asyncio
 async def test_agent_rejects_invalid_timeout_before_building_session(timeout):


### PR DESCRIPTION
## Summary

Fix a P2 (Medium) Application API contract bug in per-call workflow budgets.

## Root cause

`WorkflowContext.agent(budget=...)` accepted zero, negative, boolean, float, and other non-integer values. Those values could be silently clamped or truncated into a zero/incorrect session allocation, while the public SDK already requires a positive integer budget.

## Change

Validate every non-None per-call budget as a positive integer before acquiring a lease or building a session. The shared `budget_total=0` plus `over_budget_ok=True` forced-write behavior remains unchanged; this patch only validates the optional per-call cap.

## Clean Architecture scope

- Domain: unchanged.
- Application: `opencollab/application/workflow.py` budget validation.
- Adapters and Bootstrap: unchanged.
- Tests: invalid-budget rejection before session construction.

This is a pre-existing workflow contract inconsistency, not a shell/path/Git security defense and not an RL threat-model change.

## Verification

- 106 focused workflow budget/concurrency tests passed.
- Ruff and `git diff --check` passed.
- No remote, paid, GPU, Docker, or sandbox-policy behavior is changed.

