### PR TITLE
chore(release): prepare OpenCollab 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-04
+
+### Added
+- Added public team and workflow controls for prebuilt rosters, turn
+  serialization, per-seat step limits, caller-supplied environments, and
+  declared team-role inspection.
+- Added public handoff and submit tools, worktree-backed teammate execution,
+  structured worktree and trace evidence, and the handoff experiment example.
+- Added provider capability contracts, Responses non-streaming support, richer
+  usage accounting, and explicit model/provider request validation.
+
+### Changed
+- Expanded the SDK and workflow-authoring contracts with explicit agent
+  identity, isolation, budgets, deadlines, cancellation, cleanup, and
+  lifecycle results. Teams now use the caller's environment when supplied and
+  keep their declared topology and resource decisions in the run evidence.
+- Hardened scheduler, session, storage, repository-map, and environment
+  boundaries so ownership, snapshots, path containment, terminal state, and
+  partial work remain explicit across retries and restored runs.
+- Reworked the CLI/TUI turn queue and display lifecycle, and split the runtime
+  into narrower architecture-bound modules with import-layer checks.
+
+### Fixed
+- Fixed per-call budget validation, one-shot budget escapes, cancellation-state
+  reset, complete test-run evidence checks, command-safety checks, and
+  provider usage estimates. Normalized BSD/macOS `wc -c` output so verified
+  container file writes work across host and image shells.
+- Fixed handoff accounting, shell-output traversal, container git identity,
+  worktree diff bases, stale history sizing, and team/workflow resource
+  attribution.
+
+### Removed
+- Removed the legacy toolbar and keyboard modules superseded by the current
+  CLI/TUI turn-queue implementation.
+
 ## [0.5.0] - 2026-08-13
 
 ### Added
@@ -124,7 +159,8 @@ clean architecture where everything but the model sits behind swappable ports.
 - Trimmed the GLM SWE-bench experiment archive to the final report and prediction files.
 - Moved Chinese working notes into `docs/archive/`.
 
-[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/RISE-X-Lab/OpenCollab/compare/563027175e2cc2540d19324def73010a7e436dcc...v0.4.1
 [0.1.0]: https://github.com/RISE-X-Lab/OpenCollab/tree/563027175e2cc2540d19324def73010a7e436dcc

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,7 +60,7 @@ distribution just as CI does:
 
 ```bash
 set -euo pipefail
-release_version=0.5.0
+release_version=0.6.0
 artifact_root="$(mktemp -d -t "opencollab-${release_version}.XXXXXX")"
 mkdir -p "$artifact_root/sdist" "$artifact_root/wheel" "$artifact_root/assets"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,10 @@ interfaces. The [configuration guide](../configs/README.md) covers providers,
 models, and team files. The [skills guide](../skills/README.md) explains
 on-demand agent skills. Contribution checks and vulnerability reporting are in
 [CONTRIBUTING.md](../CONTRIBUTING.md) and [SECURITY.md](../SECURITY.md).
-The [0.5.0 migration guide](migrations/0.5.0.md) lists the explicit lifecycle,
-isolation, scheduler, and workflow-contract changes currently under review.
+The [0.6.0 migration guide](migrations/0.6.0.md) lists the public API,
+team/workflow, evidence, lifecycle, and budget-contract changes in the current
+release candidate. The [0.5.0 migration guide](migrations/0.5.0.md) remains
+available for upgrades from the previous release.
 
 ## Design records
 

--- a/docs/migrations/0.6.0.md
+++ b/docs/migrations/0.6.0.md
@@ -1,0 +1,62 @@
+# OpenCollab 0.6.0 migration guide
+
+OpenCollab 0.6.0 is a feature release for the compact SDK and the runtime
+behind teams and workflows. It follows the 0.5.0 release and includes public
+API additions as well as stricter lifecycle and evidence contracts. Review the
+individual signatures in the package guide before upgrading an integration.
+
+## Team construction and execution
+
+`OpenCollab.team()` now accepts an optional caller-supplied environment and
+controls for prebuilding a declared roster, allowing or denying an unisolated
+shell, limiting per-seat steps, and serializing turns. A prebuilt team seats
+all declared roles before the first model call and does not permit later
+`spawn_agent` calls. `serialize_turns=True` makes a teammate message wait for
+the active turn instead of running beside it.
+
+The new `opencollab.teams.declared_role_names()` helper lets an integration
+size a team budget from its configuration before starting a run. Team runs
+record topology and resource decisions in their evidence; inspect the returned
+`RunResult` rather than inferring success from printed output.
+
+## Workflow and tool contracts
+
+Workflow contexts expose an explicit `isolation` choice for agent calls.
+`opencollab.tools` includes the public `submit` built-in and a structural
+`VerificationTool` contract. Handoff-capable workflows can use the public
+`opencollab.teams` and submit surfaces together with the worktree/evidence
+helpers. Custom tools and environments should implement the public protocols,
+not import removed adapter internals.
+
+## Lifecycle and compatibility changes
+
+- Terminal `STOPPED` and `ERROR` states, cancellation, cleanup failures, and
+  scheduler stalls remain failures; a completed process or empty output is not
+  a successful run.
+- Snapshot and isolation requests require an independently forkable
+  environment. Shared or root-container workspaces are rejected instead of
+  silently weakening the boundary.
+- Session and scheduler records now preserve agent identity, budgets,
+  deadlines, worktree changes, tool outcomes, and provider usage. Integrations
+  that deserialize these records should tolerate the added fields and retain
+  unknown fields when forwarding evidence.
+- The legacy `opencollab.adapters.cli.toolbar` and
+  `opencollab.adapters.tui.keyboard` modules are removed. Use the current CLI
+  and TUI entry points instead.
+- Container file writes now normalize the whitespace-padded count emitted by
+  BSD/macOS `wc`; images and host-side test shims can use either BSD or GNU
+  coreutils without changing the verification contract.
+
+## Upgrade checklist
+
+1. Pin and test against `opencollab==0.6.0`; do not assume that a 0.5.x
+   integration accepts the expanded team/workflow surface.
+2. Pass an environment that supports `fork_snapshot()` whenever isolated team
+   or workflow execution is requested.
+3. Handle explicit `RunResult` status and lifecycle errors at the integration
+   boundary; do not convert `STOPPED`, `ERROR`, or an empty output to success.
+4. Replace imports of removed CLI/TUI helper modules with the public surfaces
+   documented in `README.md` and `opencollab/README.md`.
+5. If using OpenCollab-Eval 0.5.x, keep the existing OpenCollab 0.5.x pairing
+   until an Eval 0.6.x compatibility audit is complete; the 0.6.0 SDK is not
+   declared compatible by the 0.5.x dependency range.

--- a/opencollab/__init__.py
+++ b/opencollab/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from opencollab.sdk import OpenCollab, RunError, RunResult, workflow
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = ["OpenCollab", "RunError", "RunResult", "workflow"]
 _PUBLIC_MODULES = {

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -577,7 +577,10 @@ class DockerEnvironment(Environment):
             'mkdir -p -- "$(dirname -- "$target")" && '
             '(umask 077; set -C; : > "$temporary") && '
             'cat > "$temporary" && '
-            'bytes=$(wc -c < "$temporary") && '
+            # BSD ``wc`` pads its count with leading spaces while GNU ``wc``
+            # does not. Normalize the portable command's text output before
+            # comparing it with the byte count calculated by the caller.
+            'bytes=$(wc -c < "$temporary" | tr -d \'[:space:]\') && '
             'digest=$(sha256sum -- "$temporary" 2>/dev/null | awk \'{print $1}\' || '
             'shasum -a 256 -- "$temporary" | awk \'{print $1}\') && '
             '[ "$bytes" = "$expected_bytes" ] && [ "$digest" = "$expected_digest" ] && '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencollab"
-version = "0.5.0"
+version = "0.6.0"
 description = "Minimal multi-agent software development framework for explicit team and workflow orchestration."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_container_worktree_env.py
+++ b/tests/test_container_worktree_env.py
@@ -16,7 +16,9 @@ puts the worktree, and what it concludes from what Git answers.
 
 from __future__ import annotations
 
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -97,6 +99,24 @@ def _env(repo, tmp_path, branch: str) -> ContainerWorktreeEnvironment:
         worktree_root=str(tmp_path / "worktrees"),
         branch_name=branch,
     )
+
+
+async def test_verified_write_accepts_bsd_wc_padding(local_docker, monkeypatch, tmp_path):
+    """A BSD-style padded ``wc -c`` count still verifies the write."""
+    repo = _repo(tmp_path / "testbed")
+    env = _env(repo, tmp_path, "container-bsd-wc")
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_wc = fake_bin / "wc"
+    fake_wc.write_text("#!/bin/sh\nprintf '      5\\n'\n", encoding="utf-8")
+    fake_wc.chmod(0o755)
+    try:
+        await env.setup()
+        monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+        await env.write_file("padded.txt", "hello")
+        assert Path(env.workspace, "padded.txt").read_text(encoding="utf-8") == "hello"
+    finally:
+        await env.cleanup()
 
 
 async def test_an_agents_own_commits_stay_in_its_own_diff(local_docker, tmp_path):

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -17,11 +17,15 @@ _MULAN_PSL_2_SHA256 = "eb7a1d713eb919b146787629e22e4c975cb701f529a65d4d7e0fcd417
 def test_release_metadata_keeps_versions_aligned_and_includes_license() -> None:
     pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     changelog = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    lockfile = (_REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
     license_bytes = (_REPO_ROOT / "LICENSE").read_bytes()
 
     assert opencollab.__version__
     assert f'version = "{opencollab.__version__}"' in pyproject
     assert f"## [{opencollab.__version__}]" in changelog
+    assert (
+        f'name = "opencollab"\nversion = "{opencollab.__version__}"' in lockfile
+    )
     assert 'license = "MulanPSL-2.0"' in pyproject
     assert 'license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]' in pyproject
     assert license_bytes.startswith(_COPYRIGHT_NOTICE)

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -24,7 +24,7 @@ from opencollab.workflows import WorkflowContext
 
 def test_root_and_sdk_export_one_small_surface() -> None:
     expected = ["OpenCollab", "RunError", "RunResult", "workflow"]
-    assert opencollab.__version__ == "0.5.0"
+    assert opencollab.__version__ == "0.6.0"
     assert opencollab.__all__ == expected
     assert sdk.__all__ == expected
     assert all(getattr(opencollab, name) is getattr(sdk, name) for name in expected)

--- a/uv.lock
+++ b/uv.lock
@@ -488,7 +488,7 @@ wheels = [
 
 [[package]]
 name = "opencollab"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release candidate\n\n- Candidate commit: 62d8a9eb14c2f322581d12a175fd139d47ba6237\n- Parent is the current remote main 542fa431f9e48b5229addcc790345beb978eba22.\n- Version metadata, uv.lock, changelog, migration/release docs, and wheel metadata are aligned at 0.6.0.\n- Includes the verified BSD/macOS wc -c normalization fix for container file writes.\n- Validation: full local suite 2605 passed, 1 skipped; targeted release/container/SDK tests 65 passed; ruff, deptry, lint-imports, compileall, uv lock --check, diff check, isolated install probe, and twine check passed.\n- This is a broad 0.x minor release relative to v0.5.0; it is not a 0.5.1 patch release.\n- No model or paid calls were used.\n\nPlease run the repository CI matrix and merge only after all checks pass.