### PR TITLE
chore(release): prepare OpenCollab 0.5.1 maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-09-05
+
+### Fixed
+- Normalized the whitespace-padded byte count emitted by BSD/macOS `wc -c`,
+  so verified Docker container writes use the same cross-platform contract as
+  GNU `wc`.
+
 ## [0.5.0] - 2026-08-13
 
 ### Added
@@ -124,7 +131,8 @@ clean architecture where everything but the model sits behind swappable ports.
 - Trimmed the GLM SWE-bench experiment archive to the final report and prediction files.
 - Moved Chinese working notes into `docs/archive/`.
 
-[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/RISE-X-Lab/OpenCollab/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/RISE-X-Lab/OpenCollab/compare/563027175e2cc2540d19324def73010a7e436dcc...v0.4.1
 [0.1.0]: https://github.com/RISE-X-Lab/OpenCollab/tree/563027175e2cc2540d19324def73010a7e436dcc

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,7 +60,7 @@ distribution just as CI does:
 
 ```bash
 set -euo pipefail
-release_version=0.5.0
+release_version=0.5.1
 artifact_root="$(mktemp -d -t "opencollab-${release_version}.XXXXXX")"
 mkdir -p "$artifact_root/sdist" "$artifact_root/wheel" "$artifact_root/assets"
 

--- a/opencollab/__init__.py
+++ b/opencollab/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from opencollab.sdk import OpenCollab, RunError, RunResult, workflow
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = ["OpenCollab", "RunError", "RunResult", "workflow"]
 _PUBLIC_MODULES = {

--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -531,7 +531,10 @@ class DockerEnvironment(Environment):
             'mkdir -p -- "$(dirname -- "$target")" && '
             '(umask 077; set -C; : > "$temporary") && '
             'cat > "$temporary" && '
-            'bytes=$(wc -c < "$temporary") && '
+            # BSD ``wc`` pads its count with leading spaces while GNU ``wc``
+            # does not. Normalize the portable command's text output before
+            # comparing it with the byte count calculated by the caller.
+            'bytes=$(wc -c < "$temporary" | tr -d \'[:space:]\') && '
             'digest=$(sha256sum -- "$temporary" 2>/dev/null | awk \'{print $1}\' || '
             'shasum -a 256 -- "$temporary" | awk \'{print $1}\') && '
             '[ "$bytes" = "$expected_bytes" ] && [ "$digest" = "$expected_digest" ] && '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencollab"
-version = "0.5.0"
+version = "0.5.1"
 description = "Minimal multi-agent software development framework for explicit team and workflow orchestration."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_docker_env.py
+++ b/tests/test_docker_env.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 from collections.abc import Callable
 
 import pytest
 
 from opencollab.adapters import _env_docker as docker_module
+from opencollab.adapters._env_base import ExecResult
 from opencollab.adapters._env_local import LOCAL_FILE_WRITE_LIMIT_BYTES
 from opencollab.adapters._env_process import ProcessCleanupError, ProcessResult
 from opencollab.adapters.env import DockerEnvironment, LocalEnvironment
@@ -562,6 +564,44 @@ async def test_verified_write_threads_stdin_and_digest(monkeypatch) -> None:
     env = DockerEnvironment()
     await env.setup()
     await env.write_file("/workspace/result.txt", "hello")
+
+
+async def test_verified_write_accepts_bsd_wc_padding(monkeypatch, tmp_path) -> None:
+    """A BSD-style padded ``wc -c`` count still verifies the write."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_wc = fake_bin / "wc"
+    fake_wc.write_text("#!/bin/sh\nprintf '      5\\n'\n", encoding="utf-8")
+    fake_wc.chmod(0o755)
+    child_env = {"PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}"}
+
+    async def run_locally(command, *, timeout, input_bytes=None):
+        completed = subprocess.run(
+            ["bash", "-c", command],
+            input=input_bytes,
+            capture_output=True,
+            cwd=workspace,
+            env=child_env,
+            check=False,
+        )
+        return ExecResult(
+            completed.returncode,
+            completed.stdout.decode(),
+            completed.stderr.decode(),
+        )
+
+    async def discard_temporary(_temporary):
+        return None
+
+    env = DockerEnvironment(workspace=str(workspace), container_id=CONTAINER_ID)
+    env._attached_bound = True
+    monkeypatch.setattr(env, "_exec", run_locally)
+    monkeypatch.setattr(env, "_discard_write_temporary", discard_temporary)
+
+    await env.write_file(str(workspace / "padded.txt"), "hello")
+    assert (workspace / "padded.txt").read_text(encoding="utf-8") == "hello"
 
 
 async def test_write_half_input_failure_keeps_old_target_and_cleans_temp(monkeypatch) -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -17,11 +17,13 @@ _MULAN_PSL_2_SHA256 = "eb7a1d713eb919b146787629e22e4c975cb701f529a65d4d7e0fcd417
 def test_release_metadata_keeps_versions_aligned_and_includes_license() -> None:
     pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     changelog = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    lockfile = (_REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
     license_bytes = (_REPO_ROOT / "LICENSE").read_bytes()
 
     assert opencollab.__version__
     assert f'version = "{opencollab.__version__}"' in pyproject
     assert f"## [{opencollab.__version__}]" in changelog
+    assert f'name = "opencollab"\nversion = "{opencollab.__version__}"' in lockfile
     assert 'license = "MulanPSL-2.0"' in pyproject
     assert 'license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]' in pyproject
     assert license_bytes.startswith(_COPYRIGHT_NOTICE)

--- a/tests/test_sdk_api.py
+++ b/tests/test_sdk_api.py
@@ -24,7 +24,7 @@ from opencollab.workflows import WorkflowContext
 
 def test_root_and_sdk_export_one_small_surface() -> None:
     expected = ["OpenCollab", "RunError", "RunResult", "workflow"]
-    assert opencollab.__version__ == "0.5.0"
+    assert opencollab.__version__ == "0.5.1"
     assert opencollab.__all__ == expected
     assert sdk.__all__ == expected
     assert all(getattr(opencollab, name) is getattr(sdk, name) for name in expected)

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "opencollab"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# OpenCollab 0.5.1

OpenCollab 0.5.1 is a maintenance prerelease from the OpenCollab v0.5.x
line. It is intentionally based on the published v0.5.0 commit rather than
the separate 0.6.x main line, so it remains compatible with
OpenCollab-Eval 0.5.1.

## Exact release identity

- Tag: `v0.5.1`
- Release commit: `7ab5e9accbb56d67da62ba09b35526932fe8f324`
- Base: OpenCollab v0.5.0, peeled commit
  `963585611ad2a1d0c1fc7f4ba0043af5a3d860bb`
- Maintenance branch: `codex/release-0.5.1-maintenance`

## Fix

- Normalize the whitespace-padded byte count emitted by BSD/macOS `wc -c` so
  verified Docker container writes work on both BSD and GNU environments.

The failure was reproduced against the v0.5.0 baseline with a BSD-style
`wc -c` result; the corrected path and regression test pass.

## Artifacts

The source distribution and wheel were built from the exact release commit,
passed Twine validation, and passed an isolated Python 3.13 installation and
CLI probe.

```text
4c06f08fd873e5492045828506885a87e851a990b8831ca4b829a812970698d7  opencollab-0.5.1.tar.gz
0220d847c024caf4aa950008df3a240b77c68acc920e706275be5bb720fa82d4  opencollab-0.5.1-py3-none-any.whl
```

Local full-suite evidence: `2282 passed, 1 skipped`; focused Docker,
release-metadata, and SDK tests: `53 passed`.

## Signing and publication note

Per the maintainer's explicit authorization for this correction, this release
uses an annotated unsigned tag because no local GPG or configured SSH signing
key was available. The tag is not lightweight and must not be moved or
replaced. This maintenance release is separate from the 0.6.x main line.

