### PR TITLE
refactor(session): extract precheck stop conditions into guards

### DIFF
--- a/opencollab/application/ports.py
+++ b/opencollab/application/ports.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from opencollab.domain.hooks import HookOutcome
+from opencollab.domain.precheck import PrecheckContext, StopDecision
 from opencollab.domain.skill import SkillManifest
 
 if TYPE_CHECKING:
@@ -151,6 +152,20 @@ class ShaperPort(Protocol):
     """
 
     def shape(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        ...
+
+
+class PrecheckGuardPort(Protocol):
+    """One stop condition evaluated before each model call.
+
+    A guard is a pure read of ``PrecheckContext``: it returns a ``StopDecision``
+    to halt the session (``reason`` becomes the terminal reason and the emitted
+    error; ``message`` overrides the visible system message) or ``None`` to let
+    the next guard run. ``SessionRunUseCase.precheck`` runs them in order and
+    the first decision wins, the way shapers compose left-to-right.
+    """
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
         ...
 
 

--- a/opencollab/application/precheck_guards.py
+++ b/opencollab/application/precheck_guards.py
@@ -1,0 +1,113 @@
+"""Precheck guards — the stop conditions run before each model call.
+
+Each guard is one ``PrecheckGuardPort`` implementation replacing one branch of
+the former inline ``SessionRunUseCase.precheck``: a pure read of a
+``PrecheckContext`` that answers with a ``StopDecision`` or ``None``. The runner
+walks them in order and the first decision wins, so no guard needs to know
+about the ones before it.
+
+``default_precheck_guards`` gives the built-in order as two tuples, split
+around the enforcement gate the runner still applies inline: the first tuple
+runs before the gate, the second after it (the gate may choose the next phase
+itself, in which case the second tuple is skipped).
+"""
+
+from __future__ import annotations
+
+from opencollab.application._session_run_shared import DEFAULT_LOOP_BLOCKED_LIMIT
+from opencollab.application.ports import PrecheckGuardPort
+from opencollab.domain.precheck import PrecheckContext, StopDecision
+
+
+class CancelGuard:
+    """Stop when the caller's cancellation event is set.
+
+    Replaces the ``cancel_event.is_set()`` branch; keeps its dedicated visible
+    message instead of the derived ``[Reason. Session stopped.]`` form.
+    """
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
+        if ctx.cancel_requested:
+            return StopDecision("interrupted by user", message="[Session interrupted by user]")
+        return None
+
+
+class LoopBlockGuard:
+    """Stop once repeated short-circuited tool calls reach ``limit``.
+
+    Replaces the ``loop_blocked_since_progress`` branch. ``limit`` defaults to
+    ``DEFAULT_LOOP_BLOCKED_LIMIT``, which stays in ``_session_run_shared``.
+    """
+
+    def __init__(self, limit: int = DEFAULT_LOOP_BLOCKED_LIMIT):
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        self.limit = limit
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
+        if ctx.loop_blocked_since_progress >= self.limit:
+            return StopDecision(f"loop block limit reached: {ctx.loop_blocked_since_progress} repeated tool calls")
+        return None
+
+
+class SessionBudgetGuard:
+    """Stop once this session's own token spend reaches its cap.
+
+    Replaces the ``used_tokens >= max_budget_tokens`` branch.
+    """
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
+        if ctx.used_tokens >= ctx.max_budget_tokens:
+            return StopDecision(f"budget exceeded: {ctx.used_tokens} tokens used")
+        return None
+
+
+class TeamBudgetGuard:
+    """Stop when the team's aggregate spend has reached the global cap.
+
+    Replaces the ``_team_budget_exhausted()`` branch. Defense in depth: even a
+    session under its own cap stops here, since a single overshooting turn or
+    fan-out could otherwise spend past the pool that reserve-at-allocation is
+    meant to protect.
+    """
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
+        if ctx.team_budget_exhausted:
+            return StopDecision("team budget exceeded: aggregate spend reached the global cap")
+        return None
+
+
+class StepLimitGuard:
+    """Stop once the step count reaches the session's step cap.
+
+    Replaces the ``step_count >= max_steps`` branch. It runs after the
+    enforcement gate, which is why it sits in the second tuple below.
+    """
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
+        if ctx.step_count >= ctx.max_steps:
+            return StopDecision(f"step limit reached: {ctx.step_count} steps")
+        return None
+
+
+def default_precheck_guards() -> tuple[tuple[PrecheckGuardPort, ...], tuple[PrecheckGuardPort, ...]]:
+    """The built-in guards in their original order, split around the enforcement gate.
+
+    Returns ``(before_enforcement, after_enforcement)``: cancel, loop block,
+    session budget, and team budget run before the gate; the step limit runs
+    after it.
+    """
+    return (
+        (CancelGuard(), LoopBlockGuard(), SessionBudgetGuard(), TeamBudgetGuard()),
+        (StepLimitGuard(),),
+    )
+
+
+__all__ = [
+    "CancelGuard",
+    "LoopBlockGuard",
+    "SessionBudgetGuard",
+    "TeamBudgetGuard",
+    "StepLimitGuard",
+    "default_precheck_guards",
+]

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -33,11 +33,14 @@ from opencollab.application.events import SessionEventFactory, default_session_e
 from opencollab.application.ports import (
     EventPublisherPort,
     LLMPort,
+    PrecheckGuardPort,
     ShaperPort,
     TracePort,
 )
+from opencollab.application.precheck_guards import default_precheck_guards
 from opencollab.application.tool_execution import ToolExecutionUseCase
 from opencollab.domain.events import SessionRuntimeEvent
+from opencollab.domain.precheck import PrecheckContext
 from opencollab.domain.session import SessionPhase, SessionState
 
 logger = logging.getLogger(__name__)
@@ -83,6 +86,7 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         max_steps: int = 100,
         deferrable_tool_names: frozenset[str] = DEFAULT_DEFERRABLE_TOOLS,
         shaper: ShaperPort | None = None,
+        precheck_guards: tuple[tuple[PrecheckGuardPort, ...], tuple[PrecheckGuardPort, ...]] | None = None,
         team_budget_exhausted: Callable[[], bool] | None = None,
         is_context_overflow: Callable[[Exception], bool] | None = None,
         per_call_timeout: float | None = None,
@@ -110,6 +114,13 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         self.max_steps = max_steps
         self.deferrable_tool_names = deferrable_tool_names
         self.shaper = shaper
+        # Stop conditions run before each model call, in two runs around the
+        # enforcement gate: the first tuple before it, the second after it (a
+        # gate that picks the next phase itself skips the second). ``None``
+        # resolves to the built-in five, as ``event_factory`` resolves above.
+        self._guards_before_enforcement, self._guards_after_enforcement = (
+            precheck_guards if precheck_guards is not None else default_precheck_guards()
+        )
         # Defense-in-depth aggregate ceiling. An injected zero-arg predicate that
         # reports whether the *team total* spend has reached the global cap.
         # Passed as a plain callable (resolved in bootstrap/the factory) so the
@@ -587,45 +598,56 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
         self.state.transition_to(SessionPhase.CALLING_LLM)
         return True
 
-    async def precheck(self, cancel_event: asyncio.Event | None) -> None:
-        """Gate the next LLM call: cancellation, loop-block, token budget, step limit.
+    def _precheck_context(self, cancel_event: asyncio.Event | None) -> PrecheckContext:
+        """Snapshot what the precheck guards read, once per pass.
 
-        Each guard appends a visible system message, emits an error event, and
-        stops the session via ``_stop_precheck`` (STOPPED with a reason string);
-        otherwise proceed to CALLING_LLM.
+        The caps are read live rather than captured at construction: the
+        scheduler's lease and the ``Session`` facade both rewrite them while
+        the session runs. The team predicate is evaluated here so a guard sees
+        a plain flag (``False`` when no team cap is wired).
         """
-        if cancel_event and cancel_event.is_set():
-            await self._stop_precheck(
-                "interrupted by user",
-                message="[Session interrupted by user]",
-            )
+        return PrecheckContext(
+            cancel_requested=bool(cancel_event and cancel_event.is_set()),
+            loop_blocked_since_progress=self.state.turn.loop_blocked_since_progress,
+            used_tokens=self.state.used_tokens,
+            max_budget_tokens=self.max_budget_tokens,
+            team_budget_exhausted=(
+                self._team_budget_exhausted is not None and self._team_budget_exhausted()
+            ),
+            step_count=self.state.step_count,
+            max_steps=self.max_steps,
+        )
+
+    async def _stop_on_first_guard(
+        self,
+        guards: tuple[PrecheckGuardPort, ...],
+        ctx: PrecheckContext,
+    ) -> bool:
+        """Run ``guards`` in order, stopping on the first decision; True if one fired."""
+        for guard in guards:
+            decision = guard.check(ctx)
+            if decision is not None:
+                await self._stop_precheck(decision.reason, message=decision.message)
+                return True
+        return False
+
+    async def precheck(self, cancel_event: asyncio.Event | None) -> None:
+        """Gate the next LLM call: the guards, the enforcement gate, then the rest.
+
+        A stopping guard halts the session via ``_stop_precheck``; otherwise
+        proceed to CALLING_LLM. Built-ins live in ``application/precheck_guards.py``.
+        """
+        ctx = self._precheck_context(cancel_event)
+        if await self._stop_on_first_guard(self._guards_before_enforcement, ctx):
             return
 
-        if self.state.turn.loop_blocked_since_progress >= DEFAULT_LOOP_BLOCKED_LIMIT:
-            reason = f"loop block limit reached: {self.state.turn.loop_blocked_since_progress} repeated tool calls"
-            await self._stop_precheck(reason)
-            return
-
-        if self.state.used_tokens >= self.max_budget_tokens:
-            reason = f"budget exceeded: {self.state.used_tokens} tokens used"
-            await self._stop_precheck(reason)
-            return
-
-        # Aggregate ceiling (defense-in-depth): even when this session is under
-        # its own cap, stop if the *team total* has reached the global cap. A
-        # single overshooting turn or fan-out could otherwise spend past the
-        # global pool that reserve-at-allocation is meant to protect.
-        if self._team_budget_exhausted is not None and self._team_budget_exhausted():
-            reason = "team budget exceeded: aggregate spend reached the global cap"
-            await self._stop_precheck(reason)
-            return
-
+        # Kept inline, not a guard: it can pick the next phase itself (wind-down
+        # -> CALLING_LLM), which ``StopDecision`` cannot express. Extracting it
+        # is the follow-up. Its no-op returns touch nothing the later guards read.
         if await self._apply_enforcement_gate():
             return
 
-        if self.state.step_count >= self.max_steps:
-            reason = f"step limit reached: {self.state.step_count} steps"
-            await self._stop_precheck(reason)
+        if await self._stop_on_first_guard(self._guards_after_enforcement, ctx):
             return
 
         self.state.transition_to(SessionPhase.CALLING_LLM)

--- a/opencollab/bootstrap/container.py
+++ b/opencollab/bootstrap/container.py
@@ -39,6 +39,7 @@ from opencollab.application.ports import (
     EventPublisherPort,
     LLMPort,
     PermissionPort,
+    PrecheckGuardPort,
     SafetyPolicyPort,
     SessionStorePort,
     ShaperPort,
@@ -308,6 +309,7 @@ def build_session_runtime(
     seed_system_messages: list[dict[str, Any]] | None = None,
     shaper: ShaperPort | None = None,
     team_budget_exhausted: Callable[[], bool] | None = None,
+    precheck_guards: tuple[tuple[PrecheckGuardPort, ...], tuple[PrecheckGuardPort, ...]] | None = None,
 ) -> SessionRuntime:
     """Build a ``SessionRuntime`` with the same construction order
     ``Session.__init__`` used to perform inline.
@@ -318,7 +320,9 @@ def build_session_runtime(
     ``seed_system_messages`` retain source-level provenance for layered system
     context; ``seed_user_messages`` are startup user-context messages appended
     after them (e.g. a spawned agent's task);
-    ``shaper`` reshapes the message list before each model call.
+    ``shaper`` reshapes the message list before each model call;
+    ``precheck_guards`` replaces the stop conditions run before each model
+    call (``None`` keeps the built-in five).
     """
     resolved_env = env if env is not None else LocalEnvironment()
     resolved_store: SessionStorePort = store if store is not None else SessionStore()
@@ -373,6 +377,7 @@ def build_session_runtime(
         max_steps=max_steps,
         shaper=resolved_shaper,
         team_budget_exhausted=team_budget_exhausted,
+        precheck_guards=precheck_guards,
         # The context-overflow classifier lives in the adapter layer; injected
         # as a plain callable so the application use case never imports it (same
         # boundary pattern as the team-budget predicate). Enables the

--- a/opencollab/domain/precheck.py
+++ b/opencollab/domain/precheck.py
@@ -1,0 +1,53 @@
+"""Precheck vocabulary — what a stop condition reads and what it answers.
+
+``PrecheckContext`` is the snapshot a session run takes of itself before each
+model call: the counters and caps its stop conditions compare. ``StopDecision``
+is one condition's verdict to halt. Both are plain values, so a condition can
+be exercised against a literal context with no session behind it.
+
+This module is data only — no I/O, no outer-layer imports — so it sits at the
+center of the dependency graph alongside the other ``domain`` modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrecheckContext:
+    """The quantities the precheck stop conditions read, taken once per pass.
+
+    Field names follow the session attributes they mirror. ``cancel_requested``
+    is the cancellation event's set flag; ``team_budget_exhausted`` is the
+    aggregate-cap predicate already evaluated (``False`` when no team cap is
+    wired). The caps travel here rather than inside a condition because both
+    can be raised or lowered while the session runs.
+    """
+
+    cancel_requested: bool
+    loop_blocked_since_progress: int
+    used_tokens: int
+    max_budget_tokens: int
+    team_budget_exhausted: bool
+    step_count: int
+    max_steps: int
+
+
+@dataclass(frozen=True)
+class StopDecision:
+    """A stop condition's verdict to halt the session.
+
+    ``reason`` is the single disposition detail: it becomes the terminal reason
+    and the emitted error. ``message`` overrides the visible system message the
+    runner otherwise derives from ``reason``.
+    """
+
+    reason: str
+    message: str | None = None
+
+
+__all__ = [
+    "PrecheckContext",
+    "StopDecision",
+]

--- a/tests/test_precheck_guards.py
+++ b/tests/test_precheck_guards.py
@@ -1,0 +1,293 @@
+"""Unit tests for the precheck guards and their wiring into the session run."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from session_run_loop_test_support import (
+    FakeLLM,
+    build_runner,
+    collect_events,
+    llm_response,
+    run,
+)
+
+from opencollab.application.precheck_guards import (
+    CancelGuard,
+    LoopBlockGuard,
+    SessionBudgetGuard,
+    StepLimitGuard,
+    TeamBudgetGuard,
+    default_precheck_guards,
+)
+from opencollab.application.session_run import DEFAULT_LOOP_BLOCKED_LIMIT, ENFORCEMENT_ON
+from opencollab.domain.precheck import PrecheckContext, StopDecision
+from opencollab.domain.session import SessionPhase, SessionState, TurnEnforcementState
+
+
+def _ctx(**overrides) -> PrecheckContext:
+    fields = {
+        "cancel_requested": False,
+        "loop_blocked_since_progress": 0,
+        "used_tokens": 0,
+        "max_budget_tokens": 1_000,
+        "team_budget_exhausted": False,
+        "step_count": 0,
+        "max_steps": 100,
+    }
+    fields.update(overrides)
+    return PrecheckContext(**fields)
+
+
+class _RecordingGuard:
+    """A guard that remembers every context it saw and answers a fixed decision."""
+
+    def __init__(self, decision: StopDecision | None = None):
+        self.decision = decision
+        self.seen: list[PrecheckContext] = []
+
+    def check(self, ctx: PrecheckContext) -> StopDecision | None:
+        self.seen.append(ctx)
+        return self.decision
+
+
+# --------------------------------------------------------------------------- #
+# The guards on a bare context.
+# --------------------------------------------------------------------------- #
+
+
+def test_quiet_context_passes_every_built_in_guard():
+    before, after = default_precheck_guards()
+    assert [guard.check(_ctx()) for guard in before + after] == [None] * 5
+
+
+@pytest.mark.parametrize(
+    ("guard", "overrides", "decision"),
+    [
+        (
+            CancelGuard(),
+            {"cancel_requested": True},
+            StopDecision("interrupted by user", message="[Session interrupted by user]"),
+        ),
+        (
+            LoopBlockGuard(),
+            {"loop_blocked_since_progress": DEFAULT_LOOP_BLOCKED_LIMIT},
+            StopDecision(f"loop block limit reached: {DEFAULT_LOOP_BLOCKED_LIMIT} repeated tool calls"),
+        ),
+        (
+            SessionBudgetGuard(),
+            {"used_tokens": 1_000, "max_budget_tokens": 1_000},
+            StopDecision("budget exceeded: 1000 tokens used"),
+        ),
+        (
+            TeamBudgetGuard(),
+            {"team_budget_exhausted": True},
+            StopDecision("team budget exceeded: aggregate spend reached the global cap"),
+        ),
+        (
+            StepLimitGuard(),
+            {"step_count": 7, "max_steps": 7},
+            StopDecision("step limit reached: 7 steps"),
+        ),
+    ],
+)
+def test_each_guard_stops_with_its_verbatim_reason(guard, overrides, decision):
+    assert guard.check(_ctx(**overrides)) == decision
+
+
+def test_thresholds_are_inclusive_and_one_below_passes():
+    assert LoopBlockGuard(limit=2).check(_ctx(loop_blocked_since_progress=1)) is None
+    assert LoopBlockGuard(limit=2).check(_ctx(loop_blocked_since_progress=2)) is not None
+    assert SessionBudgetGuard().check(_ctx(used_tokens=999, max_budget_tokens=1_000)) is None
+    assert StepLimitGuard().check(_ctx(step_count=6, max_steps=7)) is None
+
+
+@pytest.mark.parametrize("limit", [0, -1, True, 1.5])
+def test_loop_block_guard_rejects_a_non_positive_limit(limit):
+    with pytest.raises(ValueError, match="positive integer"):
+        LoopBlockGuard(limit=limit)
+
+
+def test_built_in_order_matches_the_former_inline_precheck():
+    before, after = default_precheck_guards()
+    assert [type(guard) for guard in before] == [
+        CancelGuard,
+        LoopBlockGuard,
+        SessionBudgetGuard,
+        TeamBudgetGuard,
+    ]
+    assert [type(guard) for guard in after] == [StepLimitGuard]
+    loop_guard = before[1]
+    assert isinstance(loop_guard, LoopBlockGuard)
+    assert loop_guard.limit == DEFAULT_LOOP_BLOCKED_LIMIT
+
+
+# --------------------------------------------------------------------------- #
+# Wiring into the session run.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("cancelled", "loop_blocked", "used_tokens", "team_exhausted", "reason"),
+    [
+        (True, 3, 10, True, "interrupted by user"),
+        (False, 3, 10, True, "loop block limit reached: 3 repeated tool calls"),
+        (False, 0, 10, True, "budget exceeded: 10 tokens used"),
+        (False, 0, 0, True, "team budget exceeded: aggregate spend reached the global cap"),
+        (False, 0, 0, False, "step limit reached: 5 steps"),
+    ],
+)
+def test_built_in_guards_stop_in_the_original_order(cancelled, loop_blocked, used_tokens, team_exhausted, reason):
+    """Arm every trigger at once, then disarm them one by one: that walks the order."""
+    events, bus = collect_events()
+    state = SessionState(
+        messages=[{"role": "system", "content": "sys"}],
+        used_tokens=used_tokens,
+        step_count=5,
+        turn=TurnEnforcementState(loop_blocked_since_progress=loop_blocked),
+    )
+    llm = FakeLLM()
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        event_bus=bus,
+        max_budget_tokens=10,
+        max_steps=5,
+        team_budget_exhausted=lambda: team_exhausted,
+    )
+    cancel_event = asyncio.Event()
+    if cancelled:
+        cancel_event.set()
+
+    result = run(runner.run_loop(cancel_event=cancel_event))
+
+    assert result == ""
+    assert llm.calls == []
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason == reason
+    assert events == [("error", {"reason": reason, "aid": -1})]
+
+
+def test_injected_guards_run_in_order_and_the_first_decision_wins():
+    first = _RecordingGuard()
+    second = _RecordingGuard(StopDecision("custom stop", message="[custom notice]"))
+    third = _RecordingGuard()
+    fourth = _RecordingGuard()
+    events, bus = collect_events()
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    llm = FakeLLM()
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        event_bus=bus,
+        precheck_guards=((first, second, third), (fourth,)),
+    )
+
+    result = run(runner.run_loop())
+
+    assert result == ""
+    assert llm.calls == []
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason == "custom stop"
+    assert state.messages[-1] == {"role": "system", "content": "[custom notice]"}
+    assert events == [("error", {"reason": "custom stop", "aid": -1})]
+    assert [len(guard.seen) for guard in (first, second, third, fourth)] == [1, 1, 0, 0]
+
+
+def test_a_decision_without_message_gets_the_derived_notice():
+    guard = _RecordingGuard(StopDecision("custom stop"))
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    runner = build_runner(state=state, llm=FakeLLM(), precheck_guards=((guard,), ()))
+
+    run(runner.run_loop())
+
+    assert state.messages[-1] == {"role": "system", "content": "[Custom stop. Session stopped.]"}
+
+
+def test_guards_after_the_gate_run_when_the_gate_passes():
+    before = _RecordingGuard()
+    after = _RecordingGuard(StopDecision("late stop"))
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    runner = build_runner(state=state, llm=FakeLLM(), precheck_guards=((before,), (after,)))
+
+    run(runner.run_loop())
+
+    assert state.terminal_reason == "late stop"
+    assert [len(before.seen), len(after.seen)] == [1, 1]
+
+
+def test_guards_after_the_gate_are_skipped_when_the_gate_takes_the_turn():
+    """The split exists for this: a gate that settles the turn ends the pass."""
+    before = _RecordingGuard()
+    after = _RecordingGuard(StopDecision("late stop"))
+    state = SessionState(
+        messages=[{"role": "system", "content": "sys"}],
+        wind_down_done=True,
+        wind_down_attempts=2,
+    )
+    llm = FakeLLM()
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        enforcement_strength=ENFORCEMENT_ON,
+        precheck_guards=((before,), (after,)),
+    )
+
+    run(runner.run_loop())
+
+    assert llm.calls == []
+    assert state.phase is SessionPhase.STOPPED
+    assert state.terminal_reason == "wind-down complete: forced commit within reserve"
+    assert [len(before.seen), len(after.seen)] == [1, 0]
+
+
+def test_context_snapshots_live_state_and_caps_each_pass():
+    spy = _RecordingGuard()
+    state = SessionState(
+        messages=[{"role": "system", "content": "sys"}],
+        used_tokens=42,
+        step_count=3,
+        turn=TurnEnforcementState(loop_blocked_since_progress=1),
+    )
+    llm = FakeLLM([llm_response(content="done")])
+    runner = build_runner(
+        state=state,
+        llm=llm,
+        max_budget_tokens=500,
+        max_steps=9,
+        team_budget_exhausted=lambda: False,
+        precheck_guards=((spy,), ()),
+    )
+
+    run(runner.run_loop(cancel_event=asyncio.Event()))
+
+    assert len(llm.calls) == 1
+    assert spy.seen[0] == PrecheckContext(
+        cancel_requested=False,
+        loop_blocked_since_progress=1,
+        used_tokens=42,
+        max_budget_tokens=500,
+        team_budget_exhausted=False,
+        step_count=3,
+        max_steps=9,
+    )
+
+
+def test_caps_changed_after_construction_reach_the_guards():
+    """The scheduler's lease and the ``Session`` facade rewrite the caps mid-run."""
+    spy = _RecordingGuard()
+    state = SessionState(messages=[{"role": "system", "content": "sys"}])
+    runner = build_runner(
+        state=state,
+        llm=FakeLLM([llm_response(content="done")]),
+        max_budget_tokens=500,
+        max_steps=9,
+        precheck_guards=((spy,), ()),
+    )
+    runner.max_budget_tokens = 700
+    runner.max_steps = 4
+
+    run(runner.run_loop())
+
+    assert (spy.seen[0].max_budget_tokens, spy.seen[0].max_steps) == (700, 4)


### PR DESCRIPTION
## What changed

`precheck()` carried five inline stop checks — cancellation, loop block, session budget, team budget, step limit — each an `if` that built its own reason string. They are now guards behind a port.

- `domain/precheck.py` — `PrecheckContext` (the snapshot a guard reads) and `StopDecision` (its verdict). Data only, stdlib only.
- `application/ports.py` — `PrecheckGuardPort`, next to `ShaperPort`.
- `application/precheck_guards.py` — the five built-in guards and `default_precheck_guards()`, which returns them in their original order.
- `SessionRunUseCase` and `build_session_runtime` accept an optional `precheck_guards` pair; `None` keeps the built-in five, so every existing call site behaves as before.

Reason strings, visible messages, and evaluation order are unchanged.

## Why this shape

Follows the `ShaperPort` pattern: one narrow Protocol, small implementations, composed in order. The data types live in `domain/`, the same way `HookOutcome` does, so `ports.py` stays Protocols only. Caps are read into the context on every pass rather than captured at guard construction, because the scheduler's lease and the `Session` facade rewrite them mid-run.

## Why the enforcement gate stays inline

Unlike a guard it can choose the next phase itself (wind-down → `CALLING_LLM`), which `StopDecision` cannot express. It stays in place with a comment; the guards are split into the tuple that runs before it and the one that runs after, so a gate that takes the turn still skips the step limit. Extracting it is the follow-up.

## Line count

`session_run.py` 762 → 784, `ports.py` 529 → 544, `container.py` 456 → 461, plus three new files. The run loop grows this time: `_precheck_context` and `_stop_on_first_guard` are the one-time cost of the pattern. Each guard extracted from here on removes lines from the loop and adds no new `if` branch to it.

## Verification

- `pytest -q`: 2629 passed (baseline 2606 + 23 new in `tests/test_precheck_guards.py`)
- `ruff check .`, `lint-imports` (4 contracts kept), `deptry .`: clean
- `pyright` on the three new files: 0 errors

## Follow-up

Extract the enforcement gate. `session_run.py` has 16 lines of headroom under the 800-line ceiling; that extraction should net it down.
