### PR TITLE
refactor(session): isolate trace construction into a mixin

### DIFF
--- a/opencollab/application/_session_run_completion.py
+++ b/opencollab/application/_session_run_completion.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import time
 from dataclasses import replace
 from typing import Any
@@ -13,14 +12,14 @@ from opencollab.application._session_run_shared import (
     _WRITE_TOOLS,
     GenerationTimeoutError,
     _ContextOverflowStop,
+    _is_tool_choice_rejection,
     _submit_tool_choice,
     _TokenBudgetStop,
 )
 from opencollab.application.async_timeout import CallerTimeoutError, abandon_on_timeout
 from opencollab.application.ports import CompletionResponse
-from opencollab.application.shaping import ShaperPipeline, forced_shape
+from opencollab.application.shaping import forced_shape
 from opencollab.application.steering import (
-    READS_NUDGE_SOFT,
     build_steering_block,
     fold_steering,
 )
@@ -32,66 +31,6 @@ from opencollab.domain.token_estimation import estimate_request_tokens
 from opencollab.domain.tools import ToolProcessingResult
 
 logger = logging.getLogger(__name__)
-
-
-def _selector_names_tool_choice(selector: Any) -> bool:
-    """Return whether a structured error selector targets ``tool_choice``."""
-    values = selector if isinstance(selector, (list, tuple)) else [selector]
-    for value in values:
-        if not isinstance(value, str):
-            continue
-        normalized = re.sub(r"[\s-]+", "_", value.strip().lower())
-        segments = re.split(r"[.\[\]/]+", normalized)
-        if "tool_choice" in segments:
-            return True
-    return False
-
-
-def _selector_has_named_segment(selector: Any) -> bool:
-    """Return whether a structured selector contains an authoritative name."""
-    values = selector if isinstance(selector, (list, tuple)) else [selector]
-    return any(isinstance(value, str) and bool(value.strip()) for value in values)
-
-
-def _is_tool_choice_rejection(exc: Exception) -> bool:
-    """Return whether a provider validation error specifically rejects choice."""
-    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
-    if status is not None and status not in {400, 422}:
-        return False
-
-    body = getattr(exc, "body", None)
-    if isinstance(body, dict):
-        detail = body.get("error", body)
-        if isinstance(detail, dict):
-            selector_keys = ("param", "field", "path")
-            selectors = [
-                detail[key]
-                for key in selector_keys
-                if key in detail and _selector_has_named_segment(detail[key])
-            ]
-            if selectors:
-                return any(_selector_names_tool_choice(value) for value in selectors)
-            code = detail.get("code")
-            if code in {"invalid_tool_choice", "unsupported_tool_choice"}:
-                return True
-
-    message = str(exc).lower()
-    choice = r"tool(?:_| )choice"
-    rejection = (
-        r"invalid|unsupported|not\s+supported|not\s+allowed|unknown|"
-        r"unrecognized|unexpected|rejected"
-    )
-    return any(
-        re.search(pattern, message)
-        for pattern in (
-            rf"\b(?:{rejection})\s+(?:(?:value\s+for|parameter|field)\s*:?\s+)?"
-            rf"{choice}\b",
-            rf"\b{choice}\b(?:\s+(?:parameter|field|value))?"
-            rf"\s+(?:(?:is|was)\s+)?(?:{rejection})\b",
-            rf"\b(?:does\s+not\s+support|doesn't\s+support|rejects?|rejected)"
-            rf"\s+(?:the\s+)?{choice}\b",
-        )
-    )
 
 
 class _SessionRunCompletionMixin:
@@ -610,152 +549,6 @@ class _SessionRunCompletionMixin:
         await self.event_publisher.emit(self.event_factory.error(reason))
         self.clear_pending_step()
         self.state.transition_to(SessionPhase.STOPPED, reason=reason)
-
-    def _shape_and_trace(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Shape the model's view, recording which compaction rung really fired.
-
-        The shapers reshape a COPY (the transcript keeps the full history), so
-        nothing on disk would otherwise say which of the five rungs ran on a
-        given turn. This emits one ``context_shaping`` record per fired rung —
-        and exactly one ``rung="none"`` record when the turn passed through
-        untouched, so a reader can tell "nothing fired" from "nothing was
-        recorded". The rung labels are the shapers' own frozen names, which is
-        what lets a run be compared turn-by-turn against its assigned policy.
-
-        The pipeline stays a pure transform: it only reports, and the sink
-        lives here, where ``tracer``/``aid``/``step_count`` are already at hand.
-        """
-        if self.tracer is None:
-            return self.shaper.shape(messages) if self.shaper is not None else messages
-        # A ShaperPipeline names its own rungs; wrap anything else (a single
-        # shaper, or nothing wired at all) so every turn still reports.
-        pipeline = (
-            self.shaper
-            if isinstance(self.shaper, ShaperPipeline)
-            else ShaperPipeline(() if self.shaper is None else (self.shaper,))
-        )
-        shaped, reports = pipeline.shape_with_report(messages)
-        for report in reports:
-            self.tracer.log_step(
-                step_type="context_shaping",
-                payload={
-                    "seq": self.state.step_count,
-                    "aid": self.state.aid,
-                    **report,
-                },
-            )
-        return shaped
-
-    def _maybe_trace_steering(self, level: str | None) -> None:
-        """Emit a ``steering_nudge`` trace step on an UPWARD level crossing.
-
-        ``reads_since_last_edit`` can jump past 8/16 in one batch, so the high-
-        water mark (``_last_steering_level``), not equality, decides whether this
-        is a new escalation. A genuine write reset re-arms so a later re-escalation
-        traces again. The mark advances even when no tracer is wired, so the next
-        escalation still computes correctly.
-        """
-        rank = {None: 0, "soft": 1, "hard": 2}
-        if level is None:
-            # ``level is None`` means no active write nudge this turn. Re-arm the
-            # high-water mark only when a write reset actually dropped reads below
-            # the soft rung; if reads is still high (e.g. a read-only session that
-            # never escalates), the escalation has NOT de-escalated, so leave the
-            # mark intact (re-arming would let a later still-high turn re-fire a
-            # duplicate steering_nudge).
-            if self.state.turn.reads_since_last_edit < READS_NUDGE_SOFT:
-                self._last_steering_level = None
-            return
-        if rank[level] > rank[self._last_steering_level] and self.tracer is not None:
-            self.tracer.log_step(
-                step_type="steering_nudge",
-                payload={
-                    "aid": self.state.aid,
-                    "agent": getattr(self.agent, "role", None)
-                    or getattr(self.agent, "label", None)
-                    or self.agent.model,
-                    "reads_since_last_edit": self.state.turn.reads_since_last_edit,
-                    "level": level,
-                    "tool_choice_override": level == "hard",
-                    "step": self.state.step_count,
-                },
-            )
-        self._last_steering_level = level  # update high-water mark even with no tracer
-
-    def record_llm_trace(self, response: CompletionResponse, latency: float) -> None:
-        if self.tracer:
-            tool_calls_log = None
-            if response.tool_calls:
-                tool_calls_log = [
-                    {
-                        "id": tc.get("id"),
-                        "name": tc.get("function", {}).get("name"),
-                        "arguments": tc.get("function", {}).get("arguments", ""),
-                    }
-                    for tc in response.tool_calls
-                ]
-            usage = response.usage
-            input_tokens = getattr(usage, "input_tokens", 0)
-            total_tokens = getattr(usage, "total_tokens", input_tokens)
-            payload = {
-                # Agent attribution: the same ``aid`` steering_nudge/commit_brake
-                # stamp, so every record in a multi-agent trajectory file joins
-                # on one field.
-                "aid": self.state.aid,
-                "model": self.agent.model,
-                "finish_reason": response.finish_reason,
-                "content": response.content,
-                "tool_calls": tool_calls_log,
-            }
-            if usage is not None:
-                output_tokens = getattr(usage, "output_tokens", max(total_tokens - input_tokens, 0))
-                cache_read_tokens = getattr(usage, "cache_read_tokens", 0)
-                cache_creation_tokens = getattr(usage, "cache_creation_tokens", 0)
-                payload["usage"] = {
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens,
-                    "total_tokens": total_tokens,
-                    "cache_read_tokens": cache_read_tokens,
-                    "cache_creation_tokens": cache_creation_tokens,
-                    "uncached_input_tokens": (
-                        max(input_tokens - cache_read_tokens - cache_creation_tokens, 0)
-                        if cache_read_tokens is not None and cache_creation_tokens is not None
-                        else None
-                    ),
-                    "estimated": getattr(usage, "estimated", False),
-                }
-                reasoning_tokens = getattr(usage, "reasoning_tokens", None)
-                if reasoning_tokens is not None:
-                    payload["usage"]["reasoning_tokens"] = reasoning_tokens
-                raw_usage = getattr(usage, "raw_usage", None)
-                if raw_usage:
-                    payload["usage"]["raw_usage"] = raw_usage
-            # Record provider chain-of-thought to the trajectory when present
-            # (omitted otherwise, so non-thinking traces keep their prior shape).
-            reasoning = getattr(response, "reasoning", None)
-            if reasoning:
-                payload["reasoning"] = reasoning
-            payload["thinking"] = bool(getattr(self.agent, "thinking", False))
-            wire_protocol = getattr(self.agent, "wire_protocol", "chat_completions")
-            if wire_protocol != "chat_completions":
-                payload["wire_protocol"] = wire_protocol
-            reasoning_effort = getattr(self.agent, "reasoning_effort", None)
-            if reasoning_effort is not None:
-                payload["reasoning_effort"] = reasoning_effort
-            payload["reasoning_effort_policy"] = getattr(
-                self.agent,
-                "reasoning_effort_policy",
-                "configured",
-            )
-            provider_model = getattr(response, "provider_model", None)
-            if provider_model is not None:
-                payload["provider_model"] = provider_model
-            self.tracer.log_step(
-                step_type="llm_call",
-                payload=payload,
-                tokens=total_tokens,
-                latency=latency,
-            )
 
     def append_assistant_message(self, response: CompletionResponse) -> None:
         has_content = (

--- a/opencollab/application/_session_run_shared.py
+++ b/opencollab/application/_session_run_shared.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -143,3 +144,63 @@ def _submit_tool_choice(name: str) -> dict[str, Any]:
     submit-only toolset) is the remaining guarantee.
     """
     return {"type": "function", "function": {"name": name}}
+
+
+def _selector_names_tool_choice(selector: Any) -> bool:
+    """Return whether a structured error selector targets ``tool_choice``."""
+    values = selector if isinstance(selector, (list, tuple)) else [selector]
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        normalized = re.sub(r"[\s-]+", "_", value.strip().lower())
+        segments = re.split(r"[.\[\]/]+", normalized)
+        if "tool_choice" in segments:
+            return True
+    return False
+
+
+def _selector_has_named_segment(selector: Any) -> bool:
+    """Return whether a structured selector contains an authoritative name."""
+    values = selector if isinstance(selector, (list, tuple)) else [selector]
+    return any(isinstance(value, str) and bool(value.strip()) for value in values)
+
+
+def _is_tool_choice_rejection(exc: Exception) -> bool:
+    """Return whether a provider validation error specifically rejects choice."""
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if status is not None and status not in {400, 422}:
+        return False
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        detail = body.get("error", body)
+        if isinstance(detail, dict):
+            selector_keys = ("param", "field", "path")
+            selectors = [
+                detail[key]
+                for key in selector_keys
+                if key in detail and _selector_has_named_segment(detail[key])
+            ]
+            if selectors:
+                return any(_selector_names_tool_choice(value) for value in selectors)
+            code = detail.get("code")
+            if code in {"invalid_tool_choice", "unsupported_tool_choice"}:
+                return True
+
+    message = str(exc).lower()
+    choice = r"tool(?:_| )choice"
+    rejection = (
+        r"invalid|unsupported|not\s+supported|not\s+allowed|unknown|"
+        r"unrecognized|unexpected|rejected"
+    )
+    return any(
+        re.search(pattern, message)
+        for pattern in (
+            rf"\b(?:{rejection})\s+(?:(?:value\s+for|parameter|field)\s*:?\s+)?"
+            rf"{choice}\b",
+            rf"\b{choice}\b(?:\s+(?:parameter|field|value))?"
+            rf"\s+(?:(?:is|was)\s+)?(?:{rejection})\b",
+            rf"\b(?:does\s+not\s+support|doesn't\s+support|rejects?|rejected)"
+            rf"\s+(?:the\s+)?{choice}\b",
+        )
+    )

--- a/opencollab/application/_session_run_trace.py
+++ b/opencollab/application/_session_run_trace.py
@@ -1,0 +1,240 @@
+"""Trace construction for session execution.
+
+Every method here reads session state and writes the tracer; none decides
+what the session does next. Kept apart from the run loop and the completion
+helpers so the trajectory a run leaves behind can be read from one place:
+``context_shaping`` (which compaction rung fired), ``steering_nudge`` (an
+upward read-without-write escalation), ``llm_call`` (one model call), and
+``session_terminal`` (how the session ended). The ``commit_brake`` row stays
+with the enforcement gate that trips it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opencollab.application.ports import CompletionResponse, ShaperPort, TracePort
+from opencollab.application.shaping import ShaperPipeline
+from opencollab.application.steering import READS_NUDGE_SOFT
+from opencollab.domain.session import SessionState
+
+logger = logging.getLogger(__name__)
+
+
+class _SessionRunTraceMixin:
+    """Trace rows composed into ``SessionRunUseCase``.
+
+    The two private marks below belong to the host as well: it initialises
+    them in ``__init__`` and clears them in ``reset_for_restore``; this mixin
+    only advances them.
+    """
+
+    # Host attributes read here. Bare annotations: they create no runtime
+    # attribute, they only name what ``SessionRunUseCase.__init__`` assigns.
+    tracer: TracePort | None
+    shaper: ShaperPort | None
+    state: SessionState
+    # ``Any`` because the host takes a duck-typed agent (tests pass stubs
+    # without ``role``/``label``/``thinking``), so every read below goes through
+    # ``getattr`` with a default.
+    agent: Any
+    max_steps: int
+    max_budget_tokens: int
+    _last_steering_level: str | None
+    _session_terminal_traced: bool
+
+    def _shape_and_trace(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Shape the model's view, recording which compaction rung really fired.
+
+        The shapers reshape a COPY (the transcript keeps the full history), so
+        nothing on disk would otherwise say which of the five rungs ran on a
+        given turn. This emits one ``context_shaping`` record per fired rung —
+        and exactly one ``rung="none"`` record when the turn passed through
+        untouched, so a reader can tell "nothing fired" from "nothing was
+        recorded". The rung labels are the shapers' own frozen names, which is
+        what lets a run be compared turn-by-turn against its assigned policy.
+
+        The pipeline stays a pure transform: it only reports, and the sink
+        lives here, where ``tracer``/``aid``/``step_count`` are already at hand.
+        """
+        if self.tracer is None:
+            return self.shaper.shape(messages) if self.shaper is not None else messages
+        # A ShaperPipeline names its own rungs; wrap anything else (a single
+        # shaper, or nothing wired at all) so every turn still reports.
+        pipeline = (
+            self.shaper
+            if isinstance(self.shaper, ShaperPipeline)
+            else ShaperPipeline(() if self.shaper is None else (self.shaper,))
+        )
+        shaped, reports = pipeline.shape_with_report(messages)
+        for report in reports:
+            self.tracer.log_step(
+                step_type="context_shaping",
+                payload={
+                    "seq": self.state.step_count,
+                    "aid": self.state.aid,
+                    **report,
+                },
+            )
+        return shaped
+
+    def _maybe_trace_steering(self, level: str | None) -> None:
+        """Emit a ``steering_nudge`` trace step on an UPWARD level crossing.
+
+        ``reads_since_last_edit`` can jump past 8/16 in one batch, so the high-
+        water mark (``_last_steering_level``), not equality, decides whether this
+        is a new escalation. A genuine write reset re-arms so a later re-escalation
+        traces again. The mark advances even when no tracer is wired, so the next
+        escalation still computes correctly.
+        """
+        rank = {None: 0, "soft": 1, "hard": 2}
+        if level is None:
+            # ``level is None`` means no active write nudge this turn. Re-arm the
+            # high-water mark only when a write reset actually dropped reads below
+            # the soft rung; if reads is still high (e.g. a read-only session that
+            # never escalates), the escalation has NOT de-escalated, so leave the
+            # mark intact (re-arming would let a later still-high turn re-fire a
+            # duplicate steering_nudge).
+            if self.state.turn.reads_since_last_edit < READS_NUDGE_SOFT:
+                self._last_steering_level = None
+            return
+        if rank[level] > rank[self._last_steering_level] and self.tracer is not None:
+            self.tracer.log_step(
+                step_type="steering_nudge",
+                payload={
+                    "aid": self.state.aid,
+                    "agent": getattr(self.agent, "role", None)
+                    or getattr(self.agent, "label", None)
+                    or self.agent.model,
+                    "reads_since_last_edit": self.state.turn.reads_since_last_edit,
+                    "level": level,
+                    "tool_choice_override": level == "hard",
+                    "step": self.state.step_count,
+                },
+            )
+        self._last_steering_level = level  # update high-water mark even with no tracer
+
+    def record_llm_trace(self, response: CompletionResponse, latency: float) -> None:
+        if self.tracer:
+            tool_calls_log = None
+            if response.tool_calls:
+                tool_calls_log = [
+                    {
+                        "id": tc.get("id"),
+                        "name": tc.get("function", {}).get("name"),
+                        "arguments": tc.get("function", {}).get("arguments", ""),
+                    }
+                    for tc in response.tool_calls
+                ]
+            usage = response.usage
+            input_tokens = getattr(usage, "input_tokens", 0)
+            total_tokens = getattr(usage, "total_tokens", input_tokens)
+            payload = {
+                # Agent attribution: the same ``aid`` steering_nudge/commit_brake
+                # stamp, so every record in a multi-agent trajectory file joins
+                # on one field.
+                "aid": self.state.aid,
+                "model": self.agent.model,
+                "finish_reason": response.finish_reason,
+                "content": response.content,
+                "tool_calls": tool_calls_log,
+            }
+            if usage is not None:
+                output_tokens = getattr(usage, "output_tokens", max(total_tokens - input_tokens, 0))
+                cache_read_tokens = getattr(usage, "cache_read_tokens", 0)
+                cache_creation_tokens = getattr(usage, "cache_creation_tokens", 0)
+                payload["usage"] = {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": total_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_creation_tokens": cache_creation_tokens,
+                    "uncached_input_tokens": (
+                        max(input_tokens - cache_read_tokens - cache_creation_tokens, 0)
+                        if cache_read_tokens is not None and cache_creation_tokens is not None
+                        else None
+                    ),
+                    "estimated": getattr(usage, "estimated", False),
+                }
+                reasoning_tokens = getattr(usage, "reasoning_tokens", None)
+                if reasoning_tokens is not None:
+                    payload["usage"]["reasoning_tokens"] = reasoning_tokens
+                raw_usage = getattr(usage, "raw_usage", None)
+                if raw_usage:
+                    payload["usage"]["raw_usage"] = raw_usage
+            # Record provider chain-of-thought to the trajectory when present
+            # (omitted otherwise, so non-thinking traces keep their prior shape).
+            reasoning = getattr(response, "reasoning", None)
+            if reasoning:
+                payload["reasoning"] = reasoning
+            payload["thinking"] = bool(getattr(self.agent, "thinking", False))
+            wire_protocol = getattr(self.agent, "wire_protocol", "chat_completions")
+            if wire_protocol != "chat_completions":
+                payload["wire_protocol"] = wire_protocol
+            reasoning_effort = getattr(self.agent, "reasoning_effort", None)
+            if reasoning_effort is not None:
+                payload["reasoning_effort"] = reasoning_effort
+            payload["reasoning_effort_policy"] = getattr(
+                self.agent,
+                "reasoning_effort_policy",
+                "configured",
+            )
+            provider_model = getattr(response, "provider_model", None)
+            if provider_model is not None:
+                payload["provider_model"] = provider_model
+            self.tracer.log_step(
+                step_type="llm_call",
+                payload=payload,
+                tokens=total_tokens,
+                latency=latency,
+            )
+
+    def _trace_session_terminal(self) -> None:
+        """Record how this session ended, and what it had left when it did.
+
+        Two resources can stop a session: the tokens it was given and the steps
+        it was allowed. They cannot both be equalized across differently
+        organized runs — a solo agent carries one long history and pays more per
+        step than a teammate carrying a short one — so a comparison holds one of
+        them equal and lets the other vary. This repository holds tokens equal.
+
+        That makes the step ceiling a runaway guard rather than an allowance,
+        and a guard is only honest if it never actually fires. Nothing recorded
+        that. A session stopped at its step ceiling with tokens still unspent
+        looked exactly like a session that finished: the phase collapsed to
+        STOPPED, the reason string lived only in memory, and the trajectory —
+        the file the run is read from afterwards — said nothing at all. The
+        claim "steps were counted, never enforced" was unfalsifiable.
+
+        So each session writes one row naming its disposition beside both
+        counters and both ceilings. ``step_ceiling_reached`` is derivable from
+        the two step fields and is written anyway: it is the exact question this
+        record exists to answer, and a reader should not have to re-derive the
+        rule to ask it.
+
+        Observation only, and guarded: a record that cannot be built must not
+        change how the session ended.
+        """
+        if self._session_terminal_traced or self.tracer is None:
+            return
+        self._session_terminal_traced = True
+        try:
+            step_count = int(self.state.step_count)
+            max_steps = int(self.max_steps)
+            self.tracer.log_step(
+                step_type="session_terminal",
+                payload={
+                    "aid": self.state.aid,
+                    "role": getattr(self.agent, "name", None),
+                    "phase": self.state.phase.value,
+                    "terminal_reason": self.state.terminal_reason,
+                    "step_count": step_count,
+                    "max_steps": max_steps,
+                    "step_ceiling_reached": step_count >= max_steps,
+                    "used_tokens": int(self.state.used_tokens),
+                    "max_budget_tokens": int(self.max_budget_tokens),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — observability is non-authoritative
+            logger.error("session terminal trace failed: %s", exc)

--- a/opencollab/application/session_run.py
+++ b/opencollab/application/session_run.py
@@ -28,6 +28,7 @@ from opencollab.application._session_run_shared import (
     _submit_tool_choice,
     _TokenBudgetStop,
 )
+from opencollab.application._session_run_trace import _SessionRunTraceMixin
 from opencollab.application._session_run_usage import _normalize_completion_usage
 from opencollab.application.events import SessionEventFactory, default_session_event_factory
 from opencollab.application.ports import (
@@ -61,7 +62,7 @@ __all__ = [
 ]
 
 
-class SessionRunUseCase(_SessionRunCompletionMixin):
+class SessionRunUseCase(_SessionRunCompletionMixin, _SessionRunTraceMixin):
     """Application use case for the session run loop.
 
     The LLM response is structural (``CompletionResponse`` in
@@ -323,55 +324,6 @@ class SessionRunUseCase(_SessionRunCompletionMixin):
     def is_terminal_phase(self) -> bool:
         """Whether the session has finished its turn (done/failed/limits)."""
         return self.state.phase.is_terminal()
-
-    def _trace_session_terminal(self) -> None:
-        """Record how this session ended, and what it had left when it did.
-
-        Two resources can stop a session: the tokens it was given and the steps
-        it was allowed. They cannot both be equalized across differently
-        organized runs — a solo agent carries one long history and pays more per
-        step than a teammate carrying a short one — so a comparison holds one of
-        them equal and lets the other vary. This repository holds tokens equal.
-
-        That makes the step ceiling a runaway guard rather than an allowance,
-        and a guard is only honest if it never actually fires. Nothing recorded
-        that. A session stopped at its step ceiling with tokens still unspent
-        looked exactly like a session that finished: the phase collapsed to
-        STOPPED, the reason string lived only in memory, and the trajectory —
-        the file the run is read from afterwards — said nothing at all. The
-        claim "steps were counted, never enforced" was unfalsifiable.
-
-        So each session writes one row naming its disposition beside both
-        counters and both ceilings. ``step_ceiling_reached`` is derivable from
-        the two step fields and is written anyway: it is the exact question this
-        record exists to answer, and a reader should not have to re-derive the
-        rule to ask it.
-
-        Observation only, and guarded: a record that cannot be built must not
-        change how the session ended.
-        """
-        if self._session_terminal_traced or self.tracer is None:
-            return
-        self._session_terminal_traced = True
-        try:
-            step_count = int(self.state.step_count)
-            max_steps = int(self.max_steps)
-            self.tracer.log_step(
-                step_type="session_terminal",
-                payload={
-                    "aid": self.state.aid,
-                    "role": getattr(self.agent, "name", None),
-                    "phase": self.state.phase.value,
-                    "terminal_reason": self.state.terminal_reason,
-                    "step_count": step_count,
-                    "max_steps": max_steps,
-                    "step_ceiling_reached": step_count >= max_steps,
-                    "used_tokens": int(self.state.used_tokens),
-                    "max_budget_tokens": int(self.max_budget_tokens),
-                },
-            )
-        except Exception as exc:  # noqa: BLE001 — observability is non-authoritative
-            logger.error("session terminal trace failed: %s", exc)
 
     def _should_suspend(self) -> bool:
         """The loop stops on a terminal phase (turn finished) OR on the


### PR DESCRIPTION
## Problem

`session_run.py` (762 lines) and `_session_run_completion.py` (797 lines) each mix the run loop with trace construction: four methods that only read state and write tracer rows sit inline next to phase transitions and tool dispatch. `_session_run_completion.py` is 3 lines under the 800-line ceiling, so nothing can be added to it without first moving something out. Reading how a trajectory row is built means finding four methods across two files.

## Change

Move the four trace methods into one mixin, `_SessionRunTraceMixin` (`application/_session_run_trace.py`), and the pure-function `tool_choice` rejection classifier into `_session_run_shared.py` beside `_submit_tool_choice`. Bodies are byte-identical; no signature or `self` access changed. The mixin declares the host attributes it reads as bare annotations so pyright can check it standalone — no other mixin does this yet; happy to drop them for uniformity.

| Symbol | From | To |
|---|---|---|
| `_shape_and_trace` | `_session_run_completion.py` | `_session_run_trace.py` |
| `_maybe_trace_steering` | `_session_run_completion.py` | `_session_run_trace.py` |
| `record_llm_trace` | `_session_run_completion.py` | `_session_run_trace.py` |
| `_trace_session_terminal` | `session_run.py` | `_session_run_trace.py` |
| `_is_tool_choice_rejection` + 2 helpers | `_session_run_completion.py` | `_session_run_shared.py` |

`_trace_brake_trip` stays with the enforcement gate it serves. Attribute initialisation and reset stay in the host.

## Effect

Now: `session_run.py` 762→714, `_session_run_completion.py` 797→590 (210 lines of headroom under the ceiling), `_session_run_shared.py` 145→206, new `_session_run_trace.py` 240. Net across the package: a move, not a reduction. One observable difference: the logger name on the "session terminal trace failed" error line.

Later: trace rows have one home; anyone adding a row edits one file. This PR does not change what the loop does or make anything pluggable — it is file organisation only. It touches `session_run.py`, which the iclr-2027 ↔ main merge will also touch; if that merge is imminent, this can wait behind it.

## Verification

Full suite: 2631 passed (main 2606 + #94's 25). `ruff check .`, `lint-imports` (4 contracts kept), `deptry .` clean. pyright on the new module: 0 errors. No test imported a moved name.
