### PR TITLE
fix: preserve timed-out containers and support Django source tests

### DIFF
--- a/opencollab/adapters/_env_docker.py
+++ b/opencollab/adapters/_env_docker.py
@@ -158,7 +158,14 @@ def _validate_container_reference(value: str) -> str:
 
 
 class DockerEnvironment(Environment):
-    """Run commands in a new network-isolated or caller-owned container."""
+    """Run commands in a new network-isolated or caller-owned container.
+
+    A recoverable command timeout retains the running container. If cancellation
+    cannot quiesce the command, owned containers are stopped and revoked while
+    preserving their filesystem for caller recovery (for example, docker cp).
+    abort() also preserves the container and backing workspace. The owner must
+    call cleanup() after collecting artifacts to remove these resources.
+    """
 
     process_isolated = True
 
@@ -293,7 +300,6 @@ class DockerEnvironment(Environment):
         args = [
             "run",
             "-d",
-            "--rm",
             "--network",
             "none",
             "--name",
@@ -433,10 +439,18 @@ class DockerEnvironment(Environment):
         if self._attached:
             self.revoke()
             return False
-        removed = await self._remove_container_if_owned()
-        if not removed:
-            self.revoke()
-        return removed
+        # Losing the command group must not discard the caller's workspace or
+        # masquerade as a recoverable tool timeout. Retain it until cleanup().
+        self.revoke()
+        await self._stop_owned_container()
+        return False
+
+    async def _stop_owned_container(self) -> None:
+        if self._container_id is None:
+            return
+        result = await self._docker("stop", "--time", "1", "--", self._container_id)
+        if result.returncode != 0:
+            raise ProcessCleanupError("owned container could not be stopped; workspace retained")
 
     async def _exec(
         self,
@@ -696,6 +710,10 @@ class DockerEnvironment(Environment):
 
     async def cleanup(self) -> None:
         async with self._lifecycle_lock:
+            if not self._attached:
+                self.revoke()
+                await await_owned_operation(self._cleanup_resources(), propagate_cancellation=True)
+                return
             await self._abort_resources_locked()
             if self._attached:
                 await await_owned_operation(
@@ -713,7 +731,7 @@ class DockerEnvironment(Environment):
         self.revoke()
         if not self._attached:
             await await_owned_operation(
-                self._cleanup_resources(),
+                self._stop_owned_container(),
                 propagate_cancellation=True,
             )
             return

--- a/opencollab/adapters/tools/_run_tests_django.py
+++ b/opencollab/adapters/tools/_run_tests_django.py
@@ -1,0 +1,108 @@
+"""Django source-tree runner discovery and unittest execution evidence."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import shlex
+from typing import Any
+
+DJANGO_RUNNER = "python tests/runtests.py"
+_LABEL = re.compile(r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*")
+_RAN = re.compile(r"Ran (\d+) tests? in [\d.]+s")
+_RESULT = re.compile(
+    r"^(test\S*) \(([^()]+)\)(?:\n[^\n]*)? \.\.\. "
+    r"(ok|FAIL|ERROR|skipped .+|expected failure|unexpected success)$",
+    re.MULTILINE,
+)
+_OK = re.compile(r"OK(?: \((?:skipped=\d+|expected failures=\d+)(?:, (?:skipped=\d+|expected failures=\d+))*\))?")
+
+
+def is_django_runner(runner: str) -> bool:
+    try:
+        parts = shlex.split(runner)
+    except ValueError:
+        return False
+    return (
+        len(parts) == 2
+        and re.fullmatch(r"(?:python(?:\d+(?:\.\d+)*)?|pypy\d*)", parts[0].rsplit("/", 1)[-1]) is not None
+        and parts[1] in {"tests/runtests.py", "./tests/runtests.py"}
+    )
+
+
+async def detect_django_runner(env: Any) -> str | None:
+    """Prefer Django's own entry point only in its source repository."""
+    read = getattr(env, "read_text_range", None)
+    if not callable(read):
+        return None
+    try:
+        for path in ("tests/runtests.py", "django/__init__.py"):
+            await read(posixpath.join(env.workspace, path), offset=1, limit=1, max_chars=256)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    return DJANGO_RUNNER
+
+
+class InvalidDjangoTargetError(ValueError):
+    """The requested selector cannot be represented by one Django label."""
+
+
+def django_target(target: str) -> str:
+    if target in {"", ".", "./", "tests", "tests/", "./tests", "./tests/"}:
+        return ""
+    if target.startswith("/"):
+        raise InvalidDjangoTargetError("Django target must be relative to the repository")
+    label = target.removeprefix("./").removeprefix("tests/")
+    path, separator, selector = label.partition("::")
+    label = path.removesuffix(".py").strip("/").replace("/", ".")
+    if separator:
+        label += "." + selector.replace("::", ".")
+    if _LABEL.fullmatch(label) is None:
+        raise InvalidDjangoTargetError("Django target must be one dotted test label or repository test path")
+    return label
+
+
+def django_command(runner: str, target: str) -> str:
+    label = django_target(target)
+    return f"{runner} --verbosity 2 --parallel 1" + (f" {shlex.quote(label)}" if label else "")
+
+
+def django_evidence(output: str) -> tuple[dict[str, int], list[str], list[str], int | None, bool]:
+    """Require one complete unittest run, not just a successful exit status."""
+    lines = [line.strip() for line in output.splitlines()]
+    ran = [_RAN.fullmatch(line) for line in lines]
+    totals = [int(match[1]) for match in ran if match]
+    terminals = [line for line in lines if _OK.fullmatch(line) or line.startswith("FAILED (")]
+    passed, failed = [], []
+    counts = {"passed": 0, "failed": 0, "error": 0, "skipped": 0}
+    seen = set()
+    for match in _RESULT.finditer(output):
+        method, parent, status = match.groups()
+        node = parent if parent.endswith("." + method) else parent + "." + method
+        if node in seen:
+            return counts, passed, failed, None, False
+        seen.add(node)
+        if status == "ok":
+            counts["passed"] += 1
+            passed.append(node)
+        elif status.startswith("skipped") or status == "expected failure":
+            counts["skipped"] += 1
+        else:
+            counts["error" if status == "ERROR" else "failed"] += 1
+            failed.append(node)
+    total = totals[0] if len(totals) == 1 else None
+    valid = (
+        total is not None and total > 0 and total == sum(counts.values())
+        and len(terminals) == 1 and _OK.fullmatch(terminals[0]) is not None
+        and not counts["failed"] and not counts["error"]
+    )
+    return counts, passed, failed, total, valid
+
+
+def django_has_pass_proof(target: str, output: str) -> bool:
+    try:
+        label = django_target(target)
+    except ValueError:
+        return False
+    _counts, passed, _failed, _total, valid = django_evidence(output)
+    return valid and any(not label or node == label or node.startswith(label + ".") for node in passed)

--- a/opencollab/adapters/tools/run_tests.py
+++ b/opencollab/adapters/tools/run_tests.py
@@ -1,26 +1,4 @@
-"""run_tests — structured test-runner wrapper.
-
-Agents lose budget (and credibility) reading raw pytest dumps and then claiming
-"it passes" without proof. This tool wraps the project's test runner with a
-FIXED calling convention and returns a *structured* result — pass/fail/error
-counts, the failing node-ids, and the head of the first traceback — instead of
-raw stdout. That gives the model a small, reliable signal it can act on and
-makes an unverified "it passes" claim much harder to make by accident.
-
-Defaults to ``python -m pytest`` and also supports Go ``go test``. Other native
-runners are detected but rejected before execution until they have a parser that
-can prove the requested target actually ran. Output is truncated to protect the
-context.
-
-Every run ALWAYS ends with a one-line ``Verdict: GREEN|RED`` (plus, on RED, a
-missing-substring hint and — when the same failing target keeps failing — an
-escalation nudge) so a downstream gate/model gets a reliable signal even when
-the runner prints no pytest-shaped summary line.
-
-Ref:
-- bash.py: same env + safety-policy handling, same head/tail truncation idea.
-- Patch verification: a green/red signal from the requested tests beats prose.
-"""
+"""Structured pytest, Go, and Django source-runner results with executed-test proof."""
 
 from __future__ import annotations
 
@@ -30,6 +8,14 @@ import shlex
 from typing import Any
 
 from opencollab.adapters.tools._output import require_positive_int, truncate
+from opencollab.adapters.tools._run_tests_django import (
+    InvalidDjangoTargetError,
+    detect_django_runner,
+    django_command,
+    django_evidence,
+    django_has_pass_proof,
+    is_django_runner,
+)
 from opencollab.adapters.tools._run_tests_go import (
     GO_PATH_PREFIX as GO_PATH_PREFIX,
 )
@@ -145,6 +131,7 @@ class RunTestsTool(Tool):
         "guessing. Pass `target` (a path or node-id like 'tests/test_x.py::test_y') "
         "to focus the run. "
         "Go projects are auto-detected when pytest is unavailable or collects no tests. "
+        "Django source repositories use tests/runtests.py with dotted test labels. "
         "Other native runners return RED before execution until a proof parser exists. "
         "For Go, pass `target` "
         "like './internal/server' or './internal/server::TestEvaluate'. Read the "
@@ -234,14 +221,14 @@ class RunTestsTool(Tool):
             return (
                 "Error: runner override is disabled for this run_tests tool. "
                 "Omit `runner`; run_tests auto-detects pytest and project-native "
-                "runners such as Go go.mod, sympy bin/test, Django manage.py, and "
+                "runners such as Go go.mod, sympy bin/test, Django tests/runtests.py, manage.py, and "
                 "tox. For Go, pass `target` like './internal/server' or "
                 "'./internal/server::TestEvaluate'."
             )
         if extra_args and not self.allow_extra_args:
             return "Error: extra_args is disabled for this run_tests tool."
 
-        runner = pinned_runner or DEFAULT_RUNNER
+        runner = pinned_runner or await detect_django_runner(env) or DEFAULT_RUNNER
         if pinned_runner is not None and not _is_supported_runner(runner):
             return self._unsupported_runner_report(target, runner)
         try:
@@ -274,6 +261,9 @@ class RunTestsTool(Tool):
                     combined = result.stdout + (
                         "\n" + result.stderr if result.stderr else ""
                     )
+        except InvalidDjangoTargetError as exc:
+            self._record(target, False)
+            return f"Command: not executed\nError: {exc}\nVerdict: RED"
         except _InvalidGoTargetError as exc:
             return self._invalid_go_target_report(target, exc)
 
@@ -450,7 +440,7 @@ def _is_pytest_runner(runner: str) -> bool:
 
 
 def _is_supported_runner(runner: str) -> bool:
-    return _is_pytest_runner(runner) or _is_go_runner(runner)
+    return _is_pytest_runner(runner) or _is_go_runner(runner) or is_django_runner(runner)
 
 
 def _validate_go_target_before_execution(
@@ -474,6 +464,8 @@ def _build_command(runner: str, target: str, extra_args: str) -> str:
         parts = [runner, "--tb=short", "-rfE", "-rA", "-p", "no:cacheprovider", "-q"]
         if target:
             parts.append(shlex.quote(target))
+    elif is_django_runner(runner):
+        parts = [django_command(runner, target)]
     elif _is_go_runner(runner):
         parts = [_go_runner_command(runner), "-json"]
         parts.extend(_translate_go_target_args(target))
@@ -613,6 +605,8 @@ def _is_green(
         # A bounded capture may have dropped the only pass/failure evidence;
         # a retained summary cannot certify the complete run.
         return False
+    if is_django_runner(runner):
+        return returncode == 0 and django_has_pass_proof(target, output)
     summaries = _summary_lines(output)
     if _is_pytest_runner(runner) and len(summaries) != 1:
         # One tool invocation represents one pytest session. Multiple result
@@ -691,7 +685,7 @@ def _format_report(
     max_chars: int = MAX_TRACEBACK_CHARS,
 ) -> str:
     if green is None:
-        green = _is_green(returncode, output)
+        green = _is_green(returncode, output, runner=runner, target=target)
     if _is_pytest_runner(runner) and _pytest_missing(returncode, output):
         # Still emit a parseable verdict so the gate/model is never left without
         # a signal. pytest-missing is RED (the named tests could not run) and
@@ -710,6 +704,9 @@ def _format_report(
     counts, warnings = _parse_counts(summary)
     failed = _failed_tests(output)
     passed = _passed_tests(output)
+    if is_django_runner(runner):
+        counts, passed, failed, total, _valid = django_evidence(output)
+        summary = f"Django unittest runner executed {total} tests" if total is not None else None
 
     parts = [f"Command: {cmd}", f"Exit code: {returncode}"]
     if counts:

--- a/tests/test_docker_timeout_workspace.py
+++ b/tests/test_docker_timeout_workspace.py
@@ -1,0 +1,132 @@
+"""A timeout must preserve workspace ownership until explicit cleanup."""
+
+import asyncio
+
+import pytest
+from test_docker_env import CONTAINER_ID, FakeDocker, _patch, _result
+
+from opencollab.adapters._env_process import ProcessCleanupError
+from opencollab.adapters.env import DockerEnvironment
+
+
+async def test_failed_group_cancel_stops_but_retains_workspace(monkeypatch):
+    def respond(command, _kwargs):
+        if command[1] == "run":
+            assert "--rm" not in command
+            return _result(stdout=CONTAINER_ID.encode())
+        if command[1] == "exec":
+            if "opencollab-cancel" in command:
+                return _result(returncode=124)
+            return asyncio.TimeoutError()
+        if command[1] in {"stop", "rm"}:
+            return _result()
+        raise AssertionError(command)
+
+    fake = FakeDocker(respond)
+    _patch(monkeypatch, fake)
+    env = DockerEnvironment()
+    await env.setup()
+    with pytest.raises(ProcessCleanupError, match="did not quiesce"):
+        await env.exec_cmd("sleep 60", timeout=0.01)
+    assert env.revoked
+    assert env._container_id == CONTAINER_ID
+    assert [call[0][1] for call in fake.calls] == ["run", "exec", "exec", "stop"]
+    with pytest.raises(RuntimeError, match="aborted"):
+        await env.exec_cmd("git diff")
+    await env.cleanup()
+    assert fake.calls[-1][0] == ("docker", "rm", "-f", "--", CONTAINER_ID)
+
+
+async def test_abort_retains_container_and_backing_until_cleanup(monkeypatch):
+    class Backing:
+        cleaned = False
+
+        async def cleanup(self):
+            self.cleaned = True
+
+    backing = Backing()
+    fake = FakeDocker(lambda command, _kwargs: _result(stdout=CONTAINER_ID.encode()))
+    _patch(monkeypatch, fake)
+    env = DockerEnvironment(backing_environment=backing)
+    await env.setup()
+    await env.abort()
+    assert env.revoked
+    assert env._container_id == CONTAINER_ID
+    assert fake.calls[-1][0] == ("docker", "stop", "--time", "1", "--", CONTAINER_ID)
+    assert not backing.cleaned
+    assert not any(call[0][1] == "rm" for call in fake.calls)
+    await env.cleanup()
+    assert backing.cleaned
+    assert env._container_id is None
+
+
+async def test_failed_container_stop_never_claims_recovered_timeout(monkeypatch):
+    def respond(command, _kwargs):
+        if command[1] == "run":
+            return _result(stdout=CONTAINER_ID.encode())
+        if command[1] == "exec" and "opencollab-exec" in command:
+            return asyncio.TimeoutError()
+        return _result(returncode=1)
+
+    fake = FakeDocker(respond)
+    _patch(monkeypatch, fake)
+    env = DockerEnvironment()
+    await env.setup()
+    with pytest.raises(ProcessCleanupError, match="workspace retained"):
+        await env.exec_cmd("sleep 60", timeout=0.01)
+    assert env.revoked and env._container_id == CONTAINER_ID
+    assert not any(call[0][1] == "rm" for call in fake.calls)
+
+
+async def test_quiesced_command_timeout_keeps_same_container_usable(monkeypatch):
+    timed_out = False
+
+    def respond(command, _kwargs):
+        nonlocal timed_out
+        if command[1] == "run":
+            return _result(stdout=CONTAINER_ID.encode())
+        if command[1] == "exec":
+            if not timed_out:
+                timed_out = True
+                return asyncio.TimeoutError()
+            return _result(stdout=b"preserved patch")
+        raise AssertionError(command)
+
+    fake = FakeDocker(respond)
+    _patch(monkeypatch, fake)
+    env = DockerEnvironment()
+    await env.setup()
+    result = await env.exec_cmd("sleep 60", timeout=0.01)
+    assert result.returncode == -1
+    assert not env.revoked
+    assert (await env.exec_cmd("git diff")).stdout == "preserved patch"
+    assert env._container_id == CONTAINER_ID
+    assert not any(call[0][1] in {"stop", "rm"} for call in fake.calls)
+
+
+async def test_caller_cancellation_retains_owned_container(monkeypatch):
+    started = asyncio.Event()
+    env = DockerEnvironment()
+
+    async def docker(*args, **_kwargs):
+        if args[0] == "run":
+            return _result(stdout=CONTAINER_ID.encode())
+        if args[0] == "exec":
+            if "opencollab-cancel" in args:
+                return _result(returncode=125)
+            started.set()
+            await asyncio.Event().wait()
+        if args[0] == "stop":
+            return _result()
+        raise AssertionError(args)
+
+    monkeypatch.setattr(env, "_docker", docker)
+    await env.setup()
+    task = asyncio.create_task(env.exec_cmd("sleep 60"))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert env.revoked
+    assert env._container_id == CONTAINER_ID
+    assert not env._active_execs

--- a/tests/test_run_tests_django.py
+++ b/tests/test_run_tests_django.py
@@ -1,0 +1,94 @@
+"""Django source tests run without pytest and require matching verbose proof."""
+
+import sys
+
+import pytest
+from run_tests_tool_test_support import runtime_for
+
+from opencollab.adapters.env import LocalEnvironment
+from opencollab.adapters.tools._run_tests_django import DJANGO_RUNNER, django_command
+from opencollab.adapters.tools.run_tests import RunTestsTool, _is_green
+
+PASS = "test_one (admin_utils.tests.Example.test_one) ... ok\n\nRan 1 test in 0.001s\n\nOK\n"
+
+
+@pytest.mark.parametrize("target", ["admin_utils", "tests/admin_utils", "admin_utils.tests.Example.test_one",
+                                   "tests/admin_utils/tests.py::Example::test_one"])
+def test_django_accepts_matching_executed_labels(target):
+    assert _is_green(0, PASS, runner=DJANGO_RUNNER, target=target)
+
+
+@pytest.mark.parametrize("output", [
+    "Ran 0 tests in 0.001s\nOK\n", "Ran 1 test in 0.001s\nOK\n",
+    PASS.replace(" ... ok", " ... skipped 'disabled'").replace("OK", "OK (skipped=1)"),
+    PASS.replace(" ... ok", " ... FAIL").replace("OK", "FAILED (failures=1)"),
+    PASS + "Ran 0 tests in 0.01s\nOK\n", PASS.replace("Ran 1 test", "Ran 2 tests"),
+    PASS + "FAILED (errors=1)\n", "usage: runtests.py --help\n", PASS + PASS,
+])
+def test_django_rejects_missing_ambiguous_or_nonpassing_execution(output):
+    assert not _is_green(0, output, runner=DJANGO_RUNNER, target="admin_utils")
+
+
+def test_django_rejects_wrong_target_and_nonzero_exit():
+    assert not _is_green(0, PASS, runner=DJANGO_RUNNER, target="auth_tests")
+    assert not _is_green(1, PASS, runner=DJANGO_RUNNER, target="admin_utils")
+
+
+@pytest.mark.parametrize(
+    "target", ["--help", "admin_utils auth_tests", "../../other", "admin_utils; true", "/admin_utils"]
+)
+def test_django_command_rejects_flags_and_multiple_targets(target):
+    with pytest.raises(ValueError, match="Django target"):
+        django_command(DJANGO_RUNNER, target)
+
+
+async def test_native_source_runner_executes_without_override_or_pytest(tmp_path):
+    (tmp_path / "django").mkdir()
+    (tmp_path / "django/__init__.py").write_text("# source marker\n")
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "admin_utils.py").write_text(
+        "import unittest\nclass Example(unittest.TestCase):\n"
+        "    def test_one(self): self.assertEqual(2 + 2, 4)\n"
+    )
+    (tests / "runtests.py").write_text(
+        "import argparse, unittest, sys\n"
+        "p = argparse.ArgumentParser()\np.add_argument('--verbosity', type=int)\n"
+        "p.add_argument('--parallel')\np.add_argument('label')\na = p.parse_args()\n"
+        "suite = unittest.defaultTestLoader.loadTestsFromName(a.label)\n"
+        "result = unittest.TextTestRunner(verbosity=a.verbosity).run(suite)\n"
+        "sys.exit(not result.wasSuccessful())\n"
+    )
+    env = LocalEnvironment(workspace=str(tmp_path))
+    original = env.exec_cmd
+    commands = []
+
+    async def execute(command, timeout=120):
+        commands.append(command)
+        # Use the test interpreter without changing discovery's environment.
+        if command.startswith("python "):
+            command = repr(sys.executable) + command[len("python"):]
+        return await original(command, timeout=timeout)
+
+    env.exec_cmd = execute
+    tool = RunTestsTool(allow_runner_override=False, allow_extra_args=False)
+    try:
+        report = await tool.execute_with_runtime({"target": "admin_utils"}, runtime_for(env))
+        assert "Verdict: GREEN" in report
+        assert "passed=1" in report
+        assert tool.verified_targets == {"admin_utils"}
+        assert not any("pytest" in cmd for cmd in commands)
+        assert "python tests/runtests.py --verbosity 2 --parallel 1 admin_utils" in commands
+        (tests / "admin_utils.py").write_text(
+            "import unittest\nclass Example(unittest.TestCase):\n"
+            "    def test_one(self): self.fail('regression')\n"
+        )
+        failed = await tool.execute_with_runtime({"target": "admin_utils"}, runtime_for(env))
+        assert "Verdict: RED" in failed
+        assert "failed=1" in failed
+        assert not tool.verified_targets
+        invalid = await tool.execute_with_runtime({"target": "--help"}, runtime_for(env))
+        assert "Command: not executed" in invalid
+        assert "Verdict: RED" in invalid
+    finally:
+        await env.cleanup()


### PR DESCRIPTION
## Summary

A Docker command timeout can delete an owned container before its caller extracts the patch. If process-group cancellation fails, the old fallback removes the container and returns an ordinary timeout, leaving later work with neither a usable environment nor its filesystem.

Separate interruption from final cleanup. Successful command cancellation keeps the running container usable. Failed cancellation stops and revokes the owned environment while retaining its filesystem and backing workspace until explicit `cleanup()`. Remove automatic container deletion so `abort()` also preserves artifacts. Explicit cleanup retains the existing ownership checks and resource removal behavior. Attached containers remain caller-owned.

Add `run_tests` support for Django source repositories containing `tests/runtests.py` and `django/__init__.py`. Auto-detection works with runner overrides disabled and accepts dotted labels or relative test paths/selectors. Use verbose, serial execution and parse individual unittest results, the run count, and the terminal summary. GREEN requires a completed passing run with matching target evidence. Reject zero tests, skipped-only runs, failures, mismatched targets, truncated output, and ambiguous summaries.

## Validation

`uv run pytest -q` completed with **2631 passed**. `uv run ruff check .` and `git diff --check` passed.

Two targeted regressions fail against the original code and pass with the changes. Docker tests cover usable-container recovery, failed group cancellation, caller cancellation, retained backing storage, failed container stop, and explicit cleanup. The lifecycle tests use controlled Docker command responses and executable cancellation-script tests; a local Docker daemon was unavailable.

The Django integration fixture executes a real local shell and Python test runner, verifies a passing result, changes the test to fail, and verifies removal of the earlier passing evidence. An additional manual run against the official Django **5.2.6** source tree executed `utils_tests.test_ipv6` through `RunTestsTool` with both command overrides disabled. All **10 tests passed**, and the native parser reported GREEN.

## Scope

This PR bundles the requested OC container-lifecycle fix and Django runner support. OCE environment activation remains separate work. Existing evaluation runtimes and historical results stay on their current versions.
